### PR TITLE
Initial implementation of new loader hook in core clr.

### DIFF
--- a/src/klr.core45.managed/DelegateAssemblyLoadContext.cs
+++ b/src/klr.core45.managed/DelegateAssemblyLoadContext.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Hosting.Loader;
+
+namespace klr.core45.managed
+{
+    public class DelegateAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly Func<AssemblyName, Assembly> _callback;
+
+        public DelegateAssemblyLoadContext(Func<AssemblyName, Assembly> callback)
+        {
+            _callback = callback;
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            return _callback(assemblyName);
+        }
+    }
+}


### PR DESCRIPTION
- klr host is given a loader hook registration delegate
- The delegate is normalized between net45 and coreclr.
- Renamed Main to Execute on DomainManager assembly in coreclr.
#7
