### PR TITLE
Fixed issues with assembly neutral interfaces

### DIFF
--- a/src/Microsoft.Net.Runtime.Roslyn/ResourceExtensions.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/ResourceExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Net.Runtime.Roslyn
+{
+    internal static class ResourceExtensions
+    {
+        public static void AddEmbeddedReferences(this IList<ResourceDescription> resources, IEnumerable<EmbeddedMetadataReference> references)
+        {
+            foreach (var reference in references)
+            {
+                resources.Add(new ResourceDescription(reference.Name + ".dll", () =>
+                {
+                    var ms = new MemoryStream();
+                    reference.OutputStream.Position = 0;
+                    reference.OutputStream.CopyTo(ms);
+                    ms.Position = 0;
+                    return ms;
+
+                }, isPublic: true));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynArtifactsProducer.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynArtifactsProducer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Net.Runtime.Roslyn
 
             var resources = _resourceProvider.GetResources(project);
 
-            compilationContext.PopulateAssemblyNeutralResources(resources);
+            resources.AddEmbeddedReferences(compilationContext.GetRequiredEmbeddedReferences());
 
             diagnostics.AddRange(compilationContext.Diagnostics);
 

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynAssemblyLoader.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynAssemblyLoader.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Net.Runtime.Roslyn
 
             var resources = _resourceProvider.GetResources(project);
 
-            compilationContext.PopulateAssemblyNeutralResources(resources);
+            resources.AddEmbeddedReferences(compilationContext.GetRequiredEmbeddedReferences());
 
             return CompileInMemory(name, compilationContext, resources);
         }

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectMetadata.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectMetadata.cs
@@ -16,9 +16,10 @@ namespace Microsoft.Net.Runtime.Roslyn
                                  .Where(p => !String.IsNullOrEmpty(p)) // REVIEW: Raw sources?
                                  .ToList();
 
-            RawReferences = context.MetadataReferences.OfType<EmbeddedMetadataReference>().Select(r =>
+            RawReferences = context.GetRequiredEmbeddedReferences().Select(r =>
             {
                 var ms = new MemoryStream();
+                r.OutputStream.Position = 0;
                 r.OutputStream.CopyTo(ms);
 
                 return new


### PR DESCRIPTION
- Added GetRequiredEmbeddedReferences method to CompilationContext
- Call the new method from the RoslynProjectMetadata for tooling
