### PR TITLE
Converted EmbeddedMetadataReference.OutputStream to byte[]

### DIFF
--- a/src/Microsoft.Net.Runtime.Roslyn/AssemblyNeutral/EmbeddedMetadataReference.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/AssemblyNeutral/EmbeddedMetadataReference.cs
@@ -8,15 +8,21 @@ namespace Microsoft.Net.Runtime.Roslyn
         public EmbeddedMetadataReference(TypeCompilationContext context)
             : base(context.AssemblyName, context.RealOrShallowReference())
         {
-            OutputStream = context.OutputStream;
+            using (var ms = new MemoryStream((int)context.OutputStream.Length))
+            {
+                // This stream is always seekable
+                context.OutputStream.Position = 0;
+                context.OutputStream.CopyTo(ms);
+                Contents = ms.ToArray();
+            }
         }
 
-        public EmbeddedMetadataReference(string name, Stream stream)
-            : base(name, new MetadataImageReference(stream))
+        public EmbeddedMetadataReference(string name, byte[] buffer)
+            : base(name, new MetadataImageReference(buffer))
         {
-            OutputStream = stream;
+            Contents = buffer;
         }
 
-        public Stream OutputStream { get; private set; }
+        public byte[] Contents { get; private set; }
     }
 }

--- a/src/Microsoft.Net.Runtime.Roslyn/PEReaderExtensions.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/PEReaderExtensions.cs
@@ -7,7 +7,7 @@ using System.Reflection.PortableExecutable;
 
 namespace Microsoft.Net.Runtime.Roslyn
 {
-    public static class PEReaderExtensions
+    internal static class PEReaderExtensions
     {
         public static IList<EmbeddedMetadataReference> GetEmbeddedReferences(this PEReader reader)
         {
@@ -22,20 +22,19 @@ namespace Microsoft.Net.Runtime.Roslyn
                 // Embedded interface
                 if (resourceName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                 {
-                    var ms = reader.GetEmbeddedResourceStream(resource);
-                    ms.Seek(0, SeekOrigin.Begin);
+                    var buffer = GetEmbeddedResourceContents(reader, resource);
 
                     // Remove .dll
                     var nameWithoutDll = resourceName.Substring(0, resourceName.Length - 4);
 
-                    items.Add(new EmbeddedMetadataReference(nameWithoutDll, ms));
+                    items.Add(new EmbeddedMetadataReference(nameWithoutDll, buffer));
                 }
             }
 
             return items;
         }
 
-        private static unsafe MemoryStream GetEmbeddedResourceStream(this PEReader peReader, ManifestResource resource)
+        private static unsafe byte[] GetEmbeddedResourceContents(PEReader peReader, ManifestResource resource)
         {
             if (!resource.Implementation.IsNil)
             {
@@ -80,7 +79,7 @@ namespace Microsoft.Net.Runtime.Roslyn
                     buffer[i] = *(resourceStart + i);
                 }
 
-                return new MemoryStream(buffer);
+                return buffer;
             }
         }
     }

--- a/src/Microsoft.Net.Runtime.Roslyn/ResourceExtensions.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/ResourceExtensions.cs
@@ -12,13 +12,9 @@ namespace Microsoft.Net.Runtime.Roslyn
             {
                 resources.Add(new ResourceDescription(reference.Name + ".dll", () =>
                 {
-                    var ms = new MemoryStream();
-                    reference.OutputStream.Position = 0;
-                    reference.OutputStream.CopyTo(ms);
-                    ms.Position = 0;
-                    return ms;
-
-                }, isPublic: true));
+                    return new MemoryStream(reference.Contents);
+                }, 
+                isPublic: true));
             }
         }
     }

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectMetadata.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectMetadata.cs
@@ -18,14 +18,10 @@ namespace Microsoft.Net.Runtime.Roslyn
 
             RawReferences = context.GetRequiredEmbeddedReferences().Select(r =>
             {
-                var ms = new MemoryStream();
-                r.OutputStream.Position = 0;
-                r.OutputStream.CopyTo(ms);
-
                 return new
                 {
                     Name = r.Name,
-                    Bytes = ms.ToArray()
+                    Bytes = r.Contents
                 };
             })
             .ToDictionary(a => a.Name, a => a.Bytes);


### PR DESCRIPTION
- This solves issues with having to rewind the stream
  when trying to reuse it.
- It also fixes problems where concurrent compilations can cause
  problems because one might be reading the stream that is being
  copied to another stream. Using byte[] solves this all around
- There still needs to be a follow up change to lock so concurrent compilations
  don't happen but it's fine for now.
- This will fix WebFx's test runs (they are failing right now because of the stream
  issue)
