### PR TITLE
Fixed how project references were being resolved

### DIFF
--- a/src/Microsoft.Net.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Net.DesignTimeHost/ApplicationContext.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Net.DesignTimeHost
                 // Unhandled errors
                 var error = new ErrorMessage
                 {
-                    Message = ex.Message
+                    Message = ex.ToString()
                 };
 
                 OnTransmit(new Message

--- a/src/Microsoft.Net.Runtime.Roslyn/CompilationContext.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/CompilationContext.cs
@@ -23,17 +23,14 @@ namespace Microsoft.Net.Runtime.Roslyn
         public IList<Diagnostic> Diagnostics { get; private set; }
 
         public IList<IMetadataReference> MetadataReferences { get; private set; }
-        public IList<CompilationContext> ProjectReferences { get; private set; }
 
         public CompilationContext(CSharpCompilation compilation,
                                   IList<IMetadataReference> metadataReferences,
-                                  IList<CompilationContext> projectReferences,
                                   IList<Diagnostic> diagnostics,
                                   Project project)
         {
             Compilation = compilation;
             MetadataReferences = metadataReferences;
-            ProjectReferences = projectReferences;
             Diagnostics = diagnostics;
             Project = project;
         }
@@ -45,9 +42,8 @@ namespace Microsoft.Net.Runtime.Roslyn
                 var metadataReferences = new List<IMetadataReference>();
                 var sourceReferences = new List<ISourceReference>();
 
-                // Compilation reference
-                var metadataReference = Compilation.ToMetadataReference(embedInteropTypes: Project.EmbedInteropTypes);
-                metadataReferences.Add(new RoslynMetadataReference(Project.Name, metadataReference));
+                // Project reference
+                metadataReferences.Add(new RoslynProjectReference(this));
 
                 // Other references
                 metadataReferences.AddRange(MetadataReferences);

--- a/src/Microsoft.Net.Runtime.Roslyn/Microsoft.Net.Runtime.Roslyn.kproj
+++ b/src/Microsoft.Net.Runtime.Roslyn/Microsoft.Net.Runtime.Roslyn.kproj
@@ -40,6 +40,7 @@
     <Compile Include="RoslynCompiler.cs" />
     <Compile Include="RoslynLibraryExport.cs" />
     <Compile Include="RoslynMetadataProvider.cs" />
+    <Compile Include="RoslynProjectReference.cs" />
     <Compile Include="RoslynMetadataReference.cs" />
     <Compile Include="RoslynProjectMetadata.cs" />
     <Compile Include="Services\IRoslynMetadataReference.cs" />

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynArtifactsProducer.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynArtifactsProducer.cs
@@ -112,7 +112,9 @@ namespace Microsoft.Net.Runtime.Roslyn
             var targetFramework = buildContext.TargetFramework;
             var dependencies = new List<PackageDependency>();
             var project = compilationContext.Project;
-            var projectReferenceByName = compilationContext.ProjectReferences.ToDictionary(p => p.Project.Name, p => p.Project);
+            var projectReferenceByName = compilationContext.MetadataReferences.OfType<RoslynProjectReference>()
+                                                                              .Select(r => r.CompliationContext)
+                                                                              .ToDictionary(p => p.Project.Name, p => p.Project);
             var frameworkAssemblies = new List<string>();
 
             var targetFrameworkConfig = project.GetTargetFrameworkConfiguration(targetFramework);

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynAssemblyLoader.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynAssemblyLoader.cs
@@ -93,9 +93,9 @@ namespace Microsoft.Net.Runtime.Roslyn
         {
             _compilationCache[context.Project.Name] = context;
 
-            foreach (var ctx in context.ProjectReferences)
+            foreach (var projectReference in context.MetadataReferences.OfType<RoslynProjectReference>())
             {
-                CacheCompilation(ctx);
+                CacheCompilation(projectReference.CompliationContext);
             }
         }
 

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynCompiler.cs
@@ -116,12 +116,10 @@ namespace Microsoft.Net.Runtime.Roslyn
             IList<SyntaxTree> trees = GetSyntaxTrees(project, compilationSettings, exports);
 
             IList<MetadataReference> exportedReferences;
-            IList<CompilationContext> projectReferences;
             IList<IMetadataReference> metadataReferences;
 
             ExtractReferences(exports,
                               out exportedReferences,
-                              out projectReferences,
                               out metadataReferences);
 
             var embeddedReferences = metadataReferences.OfType<EmbeddedMetadataReference>()
@@ -155,7 +153,6 @@ namespace Microsoft.Net.Runtime.Roslyn
 
             compilationContext = new CompilationContext(newCompilation,
                 metadataReferences,
-                projectReferences,
                 assemblyNeutralTypeDiagnostics,
                 project);
 
@@ -237,25 +234,14 @@ namespace Microsoft.Net.Runtime.Roslyn
 
         private void ExtractReferences(List<ILibraryExport> dependencyExports,
                                        out IList<MetadataReference> references,
-                                       out IList<CompilationContext> projectReferences,
                                        out IList<IMetadataReference> metadataReferences)
         {
             var used = new HashSet<string>();
             references = new List<MetadataReference>();
-            projectReferences = new List<CompilationContext>();
             metadataReferences = new List<IMetadataReference>();
 
             foreach (var export in dependencyExports)
             {
-                var roslynExport = export as RoslynLibraryExport;
-
-                // Roslyn exports have more information that we might want to flow to the 
-                // original compilation
-                if (roslynExport != null)
-                {
-                    projectReferences.Add(roslynExport.CompilationContext);
-                }
-
                 ExpandEmbeddedReferences(export.MetadataReferences);
 
                 foreach (var reference in export.MetadataReferences)
@@ -301,7 +287,7 @@ namespace Microsoft.Net.Runtime.Roslyn
                 return MetadataFileReferenceFactory.CreateReference(fileMetadataReference.Path);
             }
 
-            var roslynReference = metadataReference as RoslynMetadataReference;
+            var roslynReference = metadataReference as IRoslynMetadataReference;
 
             if (roslynReference != null)
             {

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectMetadata.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectMetadata.cs
@@ -30,8 +30,9 @@ namespace Microsoft.Net.Runtime.Roslyn
                                             .Select(r => r.Path)
                                             .ToList();
 
-            ProjectReferences = context.ProjectReferences.Select(p => p.Project.ProjectFilePath)
-                                                         .ToList();
+            ProjectReferences = context.MetadataReferences.OfType<RoslynProjectReference>()
+                                                          .Select(r => r.CompliationContext.Project.ProjectFilePath)
+                                                          .ToList();
 
             var formatter = new DiagnosticFormatter();
 

--- a/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectReference.cs
+++ b/src/Microsoft.Net.Runtime.Roslyn/RoslynProjectReference.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Net.Runtime.Roslyn
+{
+    public class RoslynProjectReference : IRoslynMetadataReference
+    {
+        public RoslynProjectReference(CompilationContext compilationContext)
+        {
+            CompliationContext = compilationContext;
+            MetadataReference = compilationContext.Compilation.ToMetadataReference(embedInteropTypes: compilationContext.Project.EmbedInteropTypes);
+            Name = compilationContext.Project.Name;
+        }
+
+        public CompilationContext CompliationContext { get; set; }
+
+        public MetadataReference MetadataReference
+        {
+            get;
+            private set;
+        }
+
+        public string Name
+        {
+            get;
+            private set;
+        }
+    }
+}


### PR DESCRIPTION
- Transitive project references weren't being exposed in the design time host. This
  was because we had a separate way of figuring out project references from the other references
  which was incorrect.
- Created a new reference type to preserve the compilation context for a project reference
