### PR TITLE
Fixed project references when name is specified in project.json

### DIFF
--- a/src/Microsoft.Net.Runtime/Project.cs
+++ b/src/Microsoft.Net.Runtime/Project.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Net.Runtime
 
             string projectPath = null;
 
-            if (Path.GetFileName(path) == ProjectFileName)
+            if (String.Equals(Path.GetFileName(path), ProjectFileName, StringComparison.OrdinalIgnoreCase))
             {
                 projectPath = path;
                 path = Path.GetDirectoryName(path);


### PR DESCRIPTION
- In special cases where the project name is specified in a json file
  and it differs from the folder name, we should be able to find those project
  references.
