### PR TITLE
Add path and type to ILibraryInformation.

### DIFF
--- a/src/Microsoft.Net.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Net.DesignTimeHost/ApplicationContext.cs
@@ -358,22 +358,10 @@ namespace Microsoft.Net.DesignTimeHost
 
             Func<LibraryDescription, ReferenceDescription> referenceFactory = library =>
             {
-                var type = ReferenceDescriptionType.Unresolved;
-
-                string path = null;
-
-                Project thisProject;
-                if (projectResolver.TryResolveProject(library.Identity.Name, out thisProject))
-                {
-                    path = thisProject.ProjectFilePath;
-                    type = ReferenceDescriptionType.Project;
-                }
-                else if (nugetDependencyResolver.PackagePaths.TryGetValue(library.Identity.Name, out path))
-                {
-                    type = ReferenceDescriptionType.Package;
-                }
-                else if (VersionUtility.IsDesktop(targetFramework) && 
-                         globalAssemblyCache.Contains(library.Identity.Name))
+                var type = library.Type ?? ReferenceDescriptionType.Unresolved;
+ 
+                if (VersionUtility.IsDesktop(targetFramework) && 
+                    globalAssemblyCache.Contains(library.Identity.Name))
                 {
                     // Special case GAC references
                     type = ReferenceDescriptionType.GAC;
@@ -383,8 +371,8 @@ namespace Microsoft.Net.DesignTimeHost
                 {
                     Name = library.Identity.Name,
                     Version = library.Identity.Version == null ? null : library.Identity.Version.ToString(),
-                    Type = type.ToString(),
-                    Path = path,
+                    Type = type,
+                    Path = library.Path,
                     Dependencies = library.Dependencies.Select(lib => new ReferenceItem
                     {
                         Name = lib.Name,

--- a/src/Microsoft.Net.DesignTimeHost/Models/OutgoingMessages/ReferenceDescriptionType.cs
+++ b/src/Microsoft.Net.DesignTimeHost/Models/OutgoingMessages/ReferenceDescriptionType.cs
@@ -1,11 +1,11 @@
 ﻿
 namespace Microsoft.Net.DesignTimeHost.Models.OutgoingMessages
 {
-    public enum ReferenceDescriptionType
+    public static class ReferenceDescriptionType
     {
-        Unresolved,
-        Project,
-        Package,
-        GAC
+        public static readonly string Unresolved = "Unresolved";
+        public static readonly string Project = "Project";
+        public static readonly string Package = "Package";
+        public static readonly string GAC = "GAC";
     }
 }

--- a/src/Microsoft.Net.Runtime.Interfaces/ILibraryInformation.cs
+++ b/src/Microsoft.Net.Runtime.Interfaces/ILibraryInformation.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Net.Runtime
     {
         string Name { get; }
 
+        string Path { get; }
+
+        string Type { get; }
+
         IEnumerable<string> Dependencies { get; }
     }
 }

--- a/src/Microsoft.Net.Runtime/DependencyManagement/LibraryDescription.cs
+++ b/src/Microsoft.Net.Runtime/DependencyManagement/LibraryDescription.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Net.Runtime
     public class LibraryDescription
     {
         public Library Identity { get; set; }
+        public string Path { get; set; }
+        public string Type { get; set; }
         public IEnumerable<Library> Dependencies { get; set; }
     }
 }

--- a/src/Microsoft.Net.Runtime/DependencyManagement/LibraryInformation.cs
+++ b/src/Microsoft.Net.Runtime/DependencyManagement/LibraryInformation.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Net.Runtime
         public LibraryInformation(LibraryDescription description)
         {
             Name = description.Identity.Name;
+            Path = description.Path;
+            Type = description.Type;
             Dependencies = description.Dependencies.Select(d => d.Name);
         }
 
@@ -18,6 +20,18 @@ namespace Microsoft.Net.Runtime
         }
 
         public string Name
+        {
+            get;
+            private set;
+        }
+
+        public string Path
+        {
+            get;
+            private set;
+        }
+
+        public string Type
         {
             get;
             private set;

--- a/src/Microsoft.Net.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
+++ b/src/Microsoft.Net.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
@@ -43,6 +43,18 @@ namespace Microsoft.Net.Runtime
 
         public virtual void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework)
         {
+            // PERF: It sucks that we have to do this twice. We should be able to round trip
+            // the information from GetDescription
+            foreach (var d in dependencies)
+            {
+                Project project;
+                if (_projectResolver.TryResolveProject(d.Identity.Name, out project))
+                {
+                    d.Path = project.ProjectFilePath;
+                    d.Type = "Project";
+                }
+            }
+
             Dependencies = dependencies;
         }
     }

--- a/src/Microsoft.Net.Runtime/Loader/NuGet/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Net.Runtime/Loader/NuGet/NuGetDependencyResolver.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Net.Runtime.Loader.NuGet
         private readonly Dictionary<string, string> _paths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, LibraryDescription> _dependencies = new Dictionary<string, LibraryDescription>(StringComparer.OrdinalIgnoreCase);
         private readonly IDictionary<string, IList<string>> _sharedSources = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
-        private readonly IDictionary<string, string> _packagePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public NuGetDependencyResolver(string projectPath)
             : this(projectPath, null)
@@ -38,14 +37,6 @@ namespace Microsoft.Net.Runtime.Loader.NuGet
             get
             {
                 return _paths;
-            }
-        }
-
-        public IDictionary<string, string> PackagePaths
-        {
-            get
-            {
-                return _packagePaths;
             }
         }
 
@@ -107,7 +98,8 @@ namespace Microsoft.Net.Runtime.Loader.NuGet
                     continue;
                 }
 
-                _packagePaths[dependency.Identity.Name] = _repository.PathResolver.GetInstallPath(package);
+                dependency.Type = "Package";
+                dependency.Path = _repository.PathResolver.GetInstallPath(package);
 
                 // Try to find a contract folder for this package and store that
                 // for compilation


### PR DESCRIPTION
- This will help libraries discover paths to other libraries and the
  types of libraries available in the dependency closure.
- Helios needs this to find the package with the native binary.
