### PR TITLE
Reusing HttpClient when restoring packages

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/PackageFeed.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/PackageFeed.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
         private string _userName;
         private string _password;
         private IReport _report;
+        private HttpClient _httpClient;
 
         public PackageFeed(
             string baseUri,
@@ -42,6 +43,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
             _userName = userName;
             _password = password;
             _report = report;
+            _httpClient = new HttpClient();
         }
 
         Dictionary<string, Task<IEnumerable<PackageInfo>>> _cache = new Dictionary<string, Task<IEnumerable<PackageInfo>>>();
@@ -111,8 +113,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
                 request.Headers.Authorization = new AuthenticationHeaderValue("Basic", token);
             };
 
-            var client = new HttpClient();
-            return await client.SendAsync(request);
+            return await _httpClient.SendAsync(request);
         }
 
         public PackageInfo BuildModel(string id, XElement element)


### PR DESCRIPTION
Reusing HttpClient when restoring packages so that HTTPS handshakes are only performed once per host (respecting HTTP keep-alive)
