### PR TITLE
Fix some faults in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 if test `uname` = Darwin; then
     cachedir=~/Library/Caches/KBuild
 else
-    if x$XDG_DATA_HOME = x; then
+    if test x$XDG_DATA_HOME = x; then
 	cachedir=$HOME/.local/share
     else
 	cachedir=$XDG_DATA_HOME;
@@ -14,7 +14,7 @@ mkdir -p $cachedir
 url=https://www.nuget.org/nuget.exe
 
 if test ! -f $cachedir/nuget.exe; then
-    wget -o $cachedir/nuget.exe $url 2>/dev/null || curl -o $cachedir/nuget.exe --location $url /dev/null
+    wget -O $cachedir/nuget.exe $url 2>/dev/null || curl -o $cachedir/nuget.exe --location $url 2>/dev/null
 fi
 
 if test ! -e .nuget; then


### PR DESCRIPTION
- build.sh now acquires nuget.exe properly in Linux environments
- Hide the curl command's stderr

Applying this commit, running ./build.sh on Linux should end up with the same error memtioned in #173.
