### PR TITLE
Fix handling of empty item in source file pattern list

### DIFF
--- a/src/Microsoft.Framework.Runtime/Project.cs
+++ b/src/Microsoft.Framework.Runtime/Project.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Framework.Runtime
 
                 var includePatterns = SourcePattern.Split(new[] { ';' });
                 var includeFiles = includePatterns
+                    .Where(pattern => !string.IsNullOrEmpty(pattern))
                     .SelectMany(pattern => PathResolver.PerformWildcardSearch(path, pattern))
                     .ToArray();
 


### PR DESCRIPTION
parent #181 
This is a post-alpha fix. It will be checked in later at a proper time.
