### PR TITLE
[Unix] Use exec before calling into a child process

### DIFF
--- a/scripts/k-build.sh
+++ b/scripts/k-build.sh
@@ -9,4 +9,4 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 
-klr $DIR/lib/Microsoft.Framework.Project/Microsoft.Framework.Project.dll "$@"
+exec klr $DIR/lib/Microsoft.Framework.Project/Microsoft.Framework.Project.dll "$@"

--- a/scripts/k.sh
+++ b/scripts/k.sh
@@ -9,7 +9,7 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 if [ -f "$DIR/k-$1" ]; then
-    k-$1 "$@"
+    exec k-$1 "$@"
 else
-    klr Microsoft.Framework.ApplicationHost "$@"  
+    exec klr Microsoft.Framework.ApplicationHost "$@"  
 fi

--- a/scripts/klr.sh
+++ b/scripts/klr.sh
@@ -9,4 +9,4 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 
-mono $DIR/klr.mono.managed.dll "$@"
+exec mono $DIR/klr.mono.managed.dll "$@"

--- a/scripts/kpm.sh
+++ b/scripts/kpm.sh
@@ -9,4 +9,4 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 
-klr $DIR/lib/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.dll "$@"
+exec klr $DIR/lib/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.dll "$@"


### PR DESCRIPTION
This uses the Unix idiom to use the shell's exec command to have the
child process take over the address space of the calling process.
This means that there are fewer processes running on the system.
