### PR TITLE
fix build.sh on XDG_DATA_HOME, copy nuget.exe and use wget -O

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ mkdir -p $cachedir
 url=https://www.nuget.org/nuget.exe
 
 if test ! -f $cachedir/nuget.exe; then
-    wget -o $cachedir/nuget.exe $url 2>/dev/null || curl -o $cachedir/nuget.exe --location $url /dev/null
+    wget -O $cachedir/nuget.exe $url 2>/dev/null || curl -o $cachedir/nuget.exe --location $url /dev/null
 fi
 
 if test ! -e .nuget; then


### PR DESCRIPTION
Related to #193. The whole explanation is there: https://github.com/aspnet/KRuntime/pull/193#issuecomment-43680415

The correct way to verify the variable XDG_DATA_HOME is using -z.
To copy a file on bash you need to specify the filename also, not the
folder only.
Added execute permission to build.sh.
Fixed wget parameter `-o`, which should had been `-O` (uppercase).
