### PR TITLE
Fixed file watching for global.json scenarios

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Framework.DesignTimeHost
             }
 
             var projectDir = project.ProjectDirectory;
-            var rootDirectory = DefaultHost.ResolveRootDirectory(projectDir);
+            var rootDirectory = ProjectResolver.ResolveRootDirectory(projectDir);
             var projectResolver = new ProjectResolver(projectDir, rootDirectory);
 
             var referenceAssemblyDependencyResolver = new ReferenceAssemblyDependencyResolver();

--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Framework.PackageManager.Packing
         {
             public DependencyContext(string projectDir)
             {
-                var rootDirectory = DefaultHost.ResolveRootDirectory(projectDir);
+                var rootDirectory = ProjectResolver.ResolveRootDirectory(projectDir);
                 var projectResolver = new ProjectResolver(projectDir, rootDirectory);
 
                 var referenceAssemblyDependencyResolver = new ReferenceAssemblyDependencyResolver();

--- a/src/Microsoft.Framework.Project/BuildManager.cs
+++ b/src/Microsoft.Framework.Project/BuildManager.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Framework.Project
         private static RoslynArtifactsProducer PrepareArtifactsProducer(KProject project, FrameworkName targetFramework, out IDictionary<string, string> packagePaths)
         {
             var projectDir = project.ProjectDirectory;
-            var rootDirectory = DefaultHost.ResolveRootDirectory(projectDir);
+            var rootDirectory = ProjectResolver.ResolveRootDirectory(projectDir);
             var projectResolver = new ProjectResolver(projectDir, rootDirectory);
 
             var resxProvider = new ResxResourceProvider();
@@ -349,7 +349,7 @@ namespace Microsoft.Framework.Project
         private IRoslynCompiler PrepareCompiler(KProject project, FrameworkName targetFramework)
         {
             var projectDir = project.ProjectDirectory;
-            var rootDirectory = DefaultHost.ResolveRootDirectory(projectDir);
+            var rootDirectory = ProjectResolver.ResolveRootDirectory(projectDir);
             var projectResolver = new ProjectResolver(projectDir, rootDirectory);
 
             var referenceAssemblyDependencyResolver = new ReferenceAssemblyDependencyResolver();

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
             string path = project.ProjectDirectory;
 
+            _watcher.WatchProject(path);
+
             _watcher.WatchFile(project.ProjectFilePath);
 
             var targetFrameworkConfig = project.GetTargetFrameworkConfiguration(targetFramework);

--- a/src/Microsoft.Framework.Runtime/DefaultHost.cs
+++ b/src/Microsoft.Framework.Runtime/DefaultHost.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Framework.Runtime
             var dependencyProviders = new List<IDependencyProvider>();
             var loaders = new List<IAssemblyLoader>();
 
-            string rootDirectory = ResolveRootDirectory(_projectDir);
+            string rootDirectory = ProjectResolver.ResolveRootDirectory(_projectDir);
 
             if (options.WatchFiles)
             {
@@ -169,25 +169,6 @@ namespace Microsoft.Framework.Runtime
                                    libraryExporters.Concat(new[] { roslynLoader })));
         }
 
-        public static string ResolveRootDirectory(string projectDir)
-        {
-            var di = new DirectoryInfo(Path.GetDirectoryName(projectDir));
-
-            while (di.Parent != null)
-            {
-                if (di.EnumerateFiles("*." + GlobalSettings.GlobalFileName).Any() ||
-                    di.EnumerateFiles("*.sln").Any() ||
-                    di.EnumerateDirectories("packages").Any() ||
-                    di.EnumerateDirectories(".git").Any())
-                {
-                    return di.FullName;
-                }
-
-                di = di.Parent;
-            }
-
-            return Path.GetDirectoryName(projectDir);
-        }
 
         private static string Normalize(string projectDir)
         {

--- a/src/Microsoft.Framework.Runtime/FileSystem/FileWatcher.cs
+++ b/src/Microsoft.Framework.Runtime/FileSystem/FileWatcher.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Framework.Runtime.FileSystem
         private readonly HashSet<string> _files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, HashSet<string>> _directories = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly FileSystemWatcher _watcher;
+        private readonly List<FileSystemWatcher> _watchers = new List<FileSystemWatcher>();
 
         internal FileWatcher()
         {
@@ -22,14 +22,7 @@ namespace Microsoft.Framework.Runtime.FileSystem
 
         public FileWatcher(string path)
         {
-            _watcher = new FileSystemWatcher(path);
-            _watcher.IncludeSubdirectories = true;
-            _watcher.EnableRaisingEvents = true;
-
-            _watcher.Changed += OnWatcherChanged;
-            _watcher.Renamed += OnRenamed;
-            _watcher.Deleted += OnWatcherChanged;
-            _watcher.Created += OnWatcherChanged;
+            AddWatcher(path);
         }
 
         public event Action<string> OnChanged;
@@ -45,9 +38,40 @@ namespace Microsoft.Framework.Runtime.FileSystem
         {
             return _files.Add(path);
         }
+
+        public void WatchProject(string projectPath)
+        {
+            bool anyWatchers = false;
+
+            foreach (var watcher in _watchers)
+            {
+                // REVIEW: This needs to work x-platform, should this be case
+                // sensitive?
+                if (projectPath.StartsWith(watcher.Path, StringComparison.OrdinalIgnoreCase))
+                {
+                    anyWatchers = true;
+                }
+            }
+
+            // If any watchers already handle this path then noop
+            if (!anyWatchers)
+            {
+                // To reduce the number of watchers we have we add a watcher to the root
+                // of this project so that we'll be notified if anything we care
+                // about changes
+                var rootPath = ProjectResolver.ResolveRootDirectory(projectPath);
+                AddWatcher(rootPath);
+            }
+        }
+
         public void Dispose()
         {
-            _watcher.Dispose();
+            foreach (var w in _watchers)
+            {
+                w.Dispose();
+            }
+
+            _watchers.Clear();
         }
 
         public bool ReportChange(string newPath, WatcherChangeTypes changeType)
@@ -77,6 +101,20 @@ namespace Microsoft.Framework.Runtime.FileSystem
             }
 
             return false;
+        }
+
+        private void AddWatcher(string path)
+        {
+            var watcher = new FileSystemWatcher(path);
+            watcher.IncludeSubdirectories = true;
+            watcher.EnableRaisingEvents = true;
+
+            watcher.Changed += OnWatcherChanged;
+            watcher.Renamed += OnRenamed;
+            watcher.Deleted += OnWatcherChanged;
+            watcher.Created += OnWatcherChanged;
+
+            _watchers.Add(watcher);
         }
 
         private void OnRenamed(object sender, RenamedEventArgs e)
@@ -153,6 +191,11 @@ namespace Microsoft.Framework.Runtime.FileSystem
 
         public void Dispose()
         {
+        }
+
+        public void WatchProject(string path)
+        {
+
         }
     }
 }

--- a/src/Microsoft.Framework.Runtime/FileSystem/IFileWatcher.cs
+++ b/src/Microsoft.Framework.Runtime/FileSystem/IFileWatcher.cs
@@ -11,5 +11,7 @@ namespace Microsoft.Framework.Runtime.FileSystem
         void WatchDirectory(string path, string extension);
 
         bool WatchFile(string path);
+
+        void WatchProject(string path);
     }
 }

--- a/src/Microsoft.Framework.Runtime/ProjectResolver.cs
+++ b/src/Microsoft.Framework.Runtime/ProjectResolver.cs
@@ -53,5 +53,25 @@ namespace Microsoft.Framework.Runtime
 
             return paths;
         }
+
+        public static string ResolveRootDirectory(string projectPath)
+        {
+            var di = new DirectoryInfo(Path.GetDirectoryName(projectPath));
+
+            while (di.Parent != null)
+            {
+                if (di.EnumerateFiles("*." + GlobalSettings.GlobalFileName).Any() ||
+                    di.EnumerateFiles("*.sln").Any() ||
+                    di.EnumerateDirectories("packages").Any() ||
+                    di.EnumerateDirectories(".git").Any())
+                {
+                    return di.FullName;
+                }
+
+                di = di.Parent;
+            }
+
+            return Path.GetDirectoryName(projectPath);
+        }
     }
 }


### PR DESCRIPTION
- Today, if global.json brings in projects that live outside of the original
  solution root, it won't pick up changes dynamically. We added a WatchProject
  call to the file watcher which will setup a new file watcher at the solution
  root of that project.
- This means that project changes will be picked up.
