### PR TITLE
Changed IAssemblyLoaderEngine.LoadBytes to LoadStream

### DIFF
--- a/src/Microsoft.Framework.Runtime.Interfaces/IAssemblyLoaderEngine.cs
+++ b/src/Microsoft.Framework.Runtime.Interfaces/IAssemblyLoaderEngine.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Reflection;
 
 namespace Microsoft.Framework.Runtime
@@ -9,6 +10,6 @@ namespace Microsoft.Framework.Runtime
     public interface IAssemblyLoaderEngine
     {
         Assembly LoadFile(string path);
-        Assembly LoadBytes(byte[] assemblyBytes, byte[] pdbBytes);
+        Assembly LoadStream(Stream assemblyStream, Stream pdbStream);
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynAssemblyLoader.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynAssemblyLoader.cs
@@ -138,19 +138,22 @@ namespace Microsoft.Framework.Runtime.Roslyn
                     return ReportCompilationError(errors);
                 }
 
-                var assemblyBytes = assemblyStream.ToArray();
-
                 Assembly assembly = null;
+
+                // Rewind the stream
+                assemblyStream.Seek(0, SeekOrigin.Begin);
 
                 if (PlatformHelper.IsMono)
                 {
-                    // Pdb generation doesn't work on mono today
-                    assembly = _loaderEngine.LoadBytes(assemblyBytes, pdbBytes: null);
+                    // Pdbs aren't supported on mono
+                    assembly = _loaderEngine.LoadStream(assemblyStream, pdbStream: null);
                 }
                 else
                 {
-                    var pdbBytes = pdbStream.ToArray();
-                    assembly = _loaderEngine.LoadBytes(assemblyBytes, pdbBytes);
+                    // Rewind the pdb stream
+                    pdbStream.Seek(0, SeekOrigin.Begin);
+
+                    assembly = _loaderEngine.LoadStream(assemblyStream, pdbStream);
                 }
 
                 return new AssemblyLoadResult(assembly);

--- a/src/klr.host/DefaultLoaderEngine.cs
+++ b/src/klr.host/DefaultLoaderEngine.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Reflection;
 using Microsoft.Framework.Runtime;
 
@@ -10,7 +11,7 @@ namespace klr.host
     public class DefaultLoaderEngine : IAssemblyLoaderEngine
     {
         private readonly Func<string, Assembly> _loadFile;
-        private readonly Func<byte[], byte[], Assembly> _loadBytes;
+        private readonly Func<Stream, Stream, Assembly> _loadStream;
 
         public DefaultLoaderEngine(object loaderImpl)
         {
@@ -21,10 +22,10 @@ namespace klr.host
 
             var typeInfo = loaderImpl.GetType().GetTypeInfo();
             var loaderFileMethod = typeInfo.GetDeclaredMethod("LoadFile");
-            var loadBytesMethod = typeInfo.GetDeclaredMethod("LoadBytes");
+            var loadStreamMethod = typeInfo.GetDeclaredMethod("LoadStream");
 
             _loadFile = (Func<string, Assembly>)loaderFileMethod.CreateDelegate(typeof(Func<string, Assembly>), loaderImpl);
-            _loadBytes = (Func<byte[], byte[], Assembly>)loadBytesMethod.CreateDelegate(typeof(Func<byte[], byte[], Assembly>), loaderImpl);
+            _loadStream = (Func<Stream, Stream, Assembly>)loadStreamMethod.CreateDelegate(typeof(Func<Stream, Stream, Assembly>), loaderImpl);
         }
 
         public Assembly LoadFile(string path)
@@ -32,9 +33,9 @@ namespace klr.host
             return _loadFile(path);
         }
 
-        public Assembly LoadBytes(byte[] assemblyBytes, byte[] pdbBytes)
+        public Assembly LoadStream(Stream assemblyStream, Stream pdbStream)
         {
-            return _loadBytes(assemblyBytes, pdbBytes);
+            return _loadStream(assemblyStream, pdbStream);
         }
     }
 }

--- a/src/klr.hosting.shared/DelegateAssemblyLoadContext.cs
+++ b/src/klr.hosting.shared/DelegateAssemblyLoadContext.cs
@@ -36,14 +36,14 @@ namespace klr.hosting
             return LoadFromAssemblyPath(path);
         }
 
-        public Assembly LoadBytes(byte[] assemblyBytes, byte[] pdbBytes)
+        public Assembly LoadStream(Stream assemblyStream, Stream pdbStream)
         {
-            if (pdbBytes == null)
+            if (pdbStream == null)
             {
-                return LoadFromStream(new MemoryStream(assemblyBytes));
+                return LoadFromStream(assemblyStream);
             }
 
-            return LoadFromStream(new MemoryStream(assemblyBytes), new MemoryStream(pdbBytes));
+            return LoadFromStream(assemblyStream, pdbStream);
         }
 
         private string GetNativeImagePath(string ilPath)

--- a/src/klr.hosting.shared/LoaderEngine.cs
+++ b/src/klr.hosting.shared/LoaderEngine.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #if NET45
+using System.IO;
 using System.Reflection;
 
 namespace klr.hosting
@@ -13,9 +14,34 @@ namespace klr.hosting
             return Assembly.LoadFile(path);
         }
 
-        public Assembly LoadBytes(byte[] assemblyBytes, byte[] pdbBytes)
+        public Assembly LoadStream(Stream assemblyStream, Stream pdbStream)
         {
+            byte[] assemblyBytes = GetStreamAsByteArray(assemblyStream);
+            byte[] pdbBytes = null;
+
+            if (pdbStream != null)
+            {
+                pdbBytes = GetStreamAsByteArray(pdbStream);
+            }
+
             return Assembly.Load(assemblyBytes, pdbBytes);
+        }
+
+        private byte[] GetStreamAsByteArray(Stream stream)
+        {
+            // Fast path assuming the stream is a memory stream
+            var ms = stream as MemoryStream;
+            if (ms != null)
+            {
+                return ms.ToArray();
+            }
+
+            // Otherwise copy the bytes
+            using (ms = new MemoryStream())
+            {
+                stream.CopyTo(ms);
+                return ms.ToArray();
+            }
         }
     }
 }


### PR DESCRIPTION
- Optimized for CoreCLR scenarios
- Desktop CLR will convert to byte[]
#65
