### PR TITLE
Clean up command line parsing

### DIFF
--- a/src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -285,10 +285,9 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
         // Show short hint that reminds users to use help option
         public void ShowHint()
         {
-            var andCmdStr = Commands.Any() ? " and commands" : string.Empty;
             if (HelpOptions.Any())
             {
-                Console.WriteLine(string.Format("Try --{0} for options{1}", HelpOptions.First().LongName, andCmdStr));
+                Console.WriteLine(string.Format("Specify --{0} for a list of available options and commands.", HelpOptions.First().LongName));
             }
         }
 

--- a/src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOption.cs
+++ b/src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOption.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
 
         private bool IsEnglishLetter(char c)
         {
-            return (c > 'a' && c < 'z') || (c > 'A' && c < 'Z');
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
         }
     }
 }

--- a/src/Microsoft.Framework.Project/Program.cs
+++ b/src/Microsoft.Framework.Project/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Framework.Project
 
                 var optionFramework = c.Option("--framework <TARGET_FRAMEWORK>", "Target framework", CommandOptionType.MultipleValue);
                 var optionOut = c.Option("--out <OUTPUT_DIR>", "Output directory", CommandOptionType.SingleValue);
-                var optionCheckt = c.Option("--check", "Check diagnostics", CommandOptionType.NoValue);
+                var optionCheck = c.Option("--check", "Check diagnostics", CommandOptionType.NoValue);
                 var optionDependencies = c.Option("--dependencies", "Copy dependencies", CommandOptionType.NoValue);
                 var optionNative = c.Option("--native", "Generate native images", CommandOptionType.NoValue);
                 var optionCrossgenPath = c.Option("--crossgenPath <PATH>", "Crossgen path", CommandOptionType.SingleValue);
@@ -58,7 +58,7 @@ namespace Microsoft.Framework.Project
                     buildOptions.GenerateNativeImages = optionNative.HasValue();
                     buildOptions.RuntimePath = optionRuntimePath.Value();
                     buildOptions.CrossgenPath = optionCrossgenPath.Value();
-                    buildOptions.CheckDiagnostics = optionCheckt.HasValue();
+                    buildOptions.CheckDiagnostics = optionCheck.HasValue();
 
                     var projectManager = new BuildManager(buildOptions);
 
@@ -85,8 +85,8 @@ namespace Microsoft.Framework.Project
                 {
                     var crossgenOptions = new CrossgenOptions();
                     crossgenOptions.InputPaths = optionIn.Values;
-                    crossgenOptions.RuntimePath = optionOut.Value();
-                    crossgenOptions.CrossgenPath = optionOut.Value();
+                    crossgenOptions.RuntimePath = optionRuntimePath.Value();
+                    crossgenOptions.CrossgenPath = optionExePath.Value();
                     crossgenOptions.Symbols = optionSymbols.HasValue();
 
                     var gen = new CrossgenManager(crossgenOptions);


### PR DESCRIPTION
(Some fixes based on feedbacks in #264 )
- Fix small bugs & typos in Microsoft.Framework.Project command line parsing
- Rephrase options/commands hint
