### PR TITLE
Rename targetframework to runtimeframework

### DIFF
--- a/src/Microsoft.Framework.ApplicationHost/Program.cs
+++ b/src/Microsoft.Framework.ApplicationHost/Program.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Framework.ApplicationHost
             }
             if (string.Equals(key, "env:TargetFramework", StringComparison.OrdinalIgnoreCase))
             {
-                return _environment.TargetFramework.Identifier;
+                return _environment.RuntimeFramework.Identifier;
             }
             return Environment.GetEnvironmentVariable(key);
         }
@@ -132,7 +132,7 @@ namespace Microsoft.Framework.ApplicationHost
             defaultHostOptions.WatchFiles = options.HasOption("watch");
             defaultHostOptions.PackageDirectory = options.GetValue("packages");
 
-            defaultHostOptions.TargetFramework = _environment.TargetFramework;
+            defaultHostOptions.TargetFramework = _environment.RuntimeFramework;
             defaultHostOptions.ApplicationBaseDirectory = _environment.ApplicationBasePath;
 
             if (options.RemainingArgs.Count > 0)

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Framework.PackageManager
                         OutputDir = optionOut.Value,
                         ProjectDir = argProject.Value ?? System.IO.Directory.GetCurrentDirectory(),
                         AppFolder = optionAppFolder.Value,
-                        RuntimeTargetFramework = _environment.TargetFramework,
+                        RuntimeTargetFramework = _environment.RuntimeFramework,
                         ZipPackages = optionZipPackages.Value != null,
                         Overwrite = optionOverwrite.Value != null,
                         Runtimes = optionRuntime.Value != null ? optionRuntime.Value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) : new string[0],

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Framework.PackageManager
             {
                 contexts.Add(new RestoreContext
                 {
-                    FrameworkName = ApplicationEnvironment.TargetFramework,
+                    FrameworkName = ApplicationEnvironment.RuntimeFramework,
                     ProjectLibraryProviders = projectProviders,
                     LocalLibraryProviders = localProviders,
                     RemoteLibraryProviders = remoteProviders,

--- a/src/Microsoft.Framework.Project/Program.cs
+++ b/src/Microsoft.Framework.Project/Program.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Framework.Project
                     parser.ParseOptions(args.Skip(1).ToArray(), _buildOptions, out options);
 
                     var buildOptions = new BuildOptions();
-                    buildOptions.RuntimeTargetFramework = _environment.TargetFramework;
+                    buildOptions.RuntimeTargetFramework = _environment.RuntimeFramework;
                     buildOptions.OutputDir = options.GetValue("out");
                     buildOptions.ProjectDir = options.RemainingArgs.Count > 0 ? options.RemainingArgs[0] : Directory.GetCurrentDirectory();
                     buildOptions.CopyDependencies = options.HasOption("dependencies");

--- a/src/Microsoft.Framework.Runtime.Interfaces/IApplicationEnvironment.cs
+++ b/src/Microsoft.Framework.Runtime.Interfaces/IApplicationEnvironment.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Framework.Runtime
         string ApplicationName { get; }
         string Version { get; }
         string ApplicationBasePath { get; }
-        FrameworkName TargetFramework { get; }
+        FrameworkName RuntimeFramework { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime/ApplicationEnvironment.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationEnvironment.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Framework.Runtime
         }
 
 
-        public FrameworkName TargetFramework
+        public FrameworkName RuntimeFramework
         {
             get { return _targetFramework; }
         }

--- a/src/klr.host/ApplicationEnvironment.cs
+++ b/src/klr.host/ApplicationEnvironment.cs
@@ -15,7 +15,7 @@ namespace klr.host
             ApplicationName = assemblyName.Name;
             Version = assemblyName.Version.ToString();
             ApplicationBasePath = appBase;
-            TargetFramework = targetFramework;
+            RuntimeFramework = targetFramework;
         }
 
         public string ApplicationName
@@ -36,7 +36,7 @@ namespace klr.host
             private set;
         }
 
-        public FrameworkName TargetFramework
+        public FrameworkName RuntimeFramework
         {
             get;
             private set;


### PR DESCRIPTION
parent #149 

This is a breaking change and it will break at least Entropy, Testing, Mvc and Hosting. Breaking Testing means it will break all unit tests. I will fix all repositories ASAP once I push this change.
