### PR TITLE
Split project export resolution into the core

### DIFF
--- a/KRuntime.sln
+++ b/KRuntime.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.21708.0
+VisualStudioVersion = 14.0.21723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{189961D1-DFF4-406A-9D42-39B61221A73A}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Microsoft.Framework.Runtime.Interfaces/IMetadataRawReference.cs
+++ b/src/Microsoft.Framework.Runtime.Interfaces/IMetadataRawReference.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+namespace Microsoft.Framework.Runtime
+{
+    [AssemblyNeutral]
+    public interface IMetadataRawReference : IMetadataReference
+    {
+        byte[] Contents { get; }
+    }
+}

--- a/src/Microsoft.Framework.Runtime.Interfaces/Microsoft.Framework.Runtime.Interfaces.kproj
+++ b/src/Microsoft.Framework.Runtime.Interfaces/Microsoft.Framework.Runtime.Interfaces.kproj
@@ -33,6 +33,7 @@
     <Compile Include="ILibraryExportProvider.cs" />
     <Compile Include="ILibraryInformation.cs" />
     <Compile Include="ILibraryManager.cs" />
+    <Compile Include="IMetadataRawReference.cs" />
     <Compile Include="IMetadataFileReference.cs" />
     <Compile Include="IMetadataReference.cs" />
     <Compile Include="Infrastructure\CallContextServiceLocator.cs" />

--- a/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/AssemblyNeutralWorker.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/AssemblyNeutralWorker.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Framework.Runtime.Roslyn
     public class AssemblyNeutralWorker
     {
         private IList<TypeCompilationContext> _typeCompilationContexts = new List<TypeCompilationContext>();
-        private readonly IDictionary<string, EmbeddedMetadataReference> _existingReferences;
+        private readonly IDictionary<string, MetadataReference> _existingReferences;
 
         public AssemblyNeutralWorker(CSharpCompilation compilation, 
-                                     IDictionary<string, EmbeddedMetadataReference> existingReferences)
+                                     IDictionary<string, MetadataReference> existingReferences)
         {
             OriginalCompilation = compilation;
             _existingReferences = existingReferences;
@@ -103,10 +103,10 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
                 MetadataReference neutralReference = neutralTypeContext.Reference;
 
-                EmbeddedMetadataReference assemblyNeutralReference;
-                if (_existingReferences.TryGetValue(neutralTypeContext.AssemblyName, out assemblyNeutralReference))
+                MetadataReference existingReference;
+                if (_existingReferences.TryGetValue(neutralTypeContext.AssemblyName, out existingReference))
                 {
-                    neutralReference = assemblyNeutralReference.MetadataReference;
+                    neutralReference = existingReference;
                 }
 
                 Compilation = Compilation.AddReferences(neutralReference);

--- a/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/EmbeddedMetadataReference.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/EmbeddedMetadataReference.cs
@@ -1,12 +1,11 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Framework.Runtime.Roslyn
 {
-    public class EmbeddedMetadataReference : RoslynMetadataReference
+    public class EmbeddedMetadataReference : RoslynMetadataReference, IMetadataRawReference
     {
         public EmbeddedMetadataReference(TypeCompilationContext context)
             : base(context.AssemblyName, context.RealOrShallowReference())
@@ -18,12 +17,6 @@ namespace Microsoft.Framework.Runtime.Roslyn
                 context.OutputStream.CopyTo(ms);
                 Contents = ms.ToArray();
             }
-        }
-
-        public EmbeddedMetadataReference(string name, byte[] buffer)
-            : base(name, new MetadataImageReference(buffer))
-        {
-            Contents = buffer;
         }
 
         public byte[] Contents { get; private set; }

--- a/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/TypeCompilationContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/TypeCompilationContext.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
             }
         }
 
-        public EmitResult Generate(IDictionary<string, EmbeddedMetadataReference> existingReferences)
+        public EmitResult Generate(IDictionary<string, MetadataReference> existingReferences)
         {
             Compilation = CSharpCompilation.Create(
                 assemblyName: AssemblyName,

--- a/src/Microsoft.Framework.Runtime.Roslyn/CompilationContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/CompilationContext.cs
@@ -63,15 +63,15 @@ namespace Microsoft.Framework.Runtime.Roslyn
             return _roslynLibraryExport;
         }
 
-        public IEnumerable<EmbeddedMetadataReference> GetRequiredEmbeddedReferences()
+        public IEnumerable<IMetadataRawReference> GetRequiredEmbeddedReferences()
         {
-            var assemblyNeutralTypes = MetadataReferences.OfType<EmbeddedMetadataReference>()
+            var assemblyNeutralTypes = MetadataReferences.OfType<IMetadataRawReference>()
                                                          .ToDictionary(r => r.Name);
 
             // No assembly neutral types so do nothing
             if (assemblyNeutralTypes.Count == 0)
             {
-                return Enumerable.Empty<EmbeddedMetadataReference>();
+                return Enumerable.Empty<IMetadataRawReference>();
             }
 
             Trace.TraceInformation("Assembly Neutral References {0}", assemblyNeutralTypes.Count);
@@ -101,7 +101,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
             return embeddedTypes;
         }
 
-        private HashSet<string> GetUsedReferences(Dictionary<string, EmbeddedMetadataReference> assemblies)
+        private HashSet<string> GetUsedReferences(Dictionary<string, IMetadataRawReference> assemblies)
         {
             var results = new HashSet<string>();
 
@@ -143,7 +143,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
                 foreach (var reference in GetReferences(buffer))
                 {
-                    EmbeddedMetadataReference embeddedReference;
+                    IMetadataRawReference embeddedReference;
                     if (assemblies.TryGetValue(reference, out embeddedReference))
                     {
                         stack.Push(Tuple.Create(reference, embeddedReference.Contents));

--- a/src/Microsoft.Framework.Runtime.Roslyn/Microsoft.Framework.Runtime.Roslyn.kproj
+++ b/src/Microsoft.Framework.Runtime.Roslyn/Microsoft.Framework.Runtime.Roslyn.kproj
@@ -31,7 +31,6 @@
     <Compile Include="IResourceProvider.cs" />
     <Compile Include="IRoslynCompiler.cs" />
     <Compile Include="MetadataFileReferenceFactory.cs" />
-    <Compile Include="PEReaderExtensions.cs" />
     <Compile Include="ProjectExtensions.cs" />
     <Compile Include="ResourceExtensions.cs" />
     <Compile Include="ResxResourceProvider.cs" />

--- a/src/Microsoft.Framework.Runtime.Roslyn/ResourceExtensions.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/ResourceExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
 {
     internal static class ResourceExtensions
     {
-        public static void AddEmbeddedReferences(this IList<ResourceDescription> resources, IEnumerable<EmbeddedMetadataReference> references)
+        public static void AddRawReferences(this IList<ResourceDescription> resources, IEnumerable<IMetadataRawReference> references)
         {
             foreach (var reference in references)
             {

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynArtifactsProducer.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynArtifactsProducer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
             var resources = _resourceProvider.GetResources(project);
 
-            resources.AddEmbeddedReferences(compilationContext.GetRequiredEmbeddedReferences());
+            resources.AddRawReferences(compilationContext.GetRequiredEmbeddedReferences());
 
             diagnostics.AddRange(compilationContext.Diagnostics);
 

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynAssemblyLoader.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynAssemblyLoader.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
             var resources = _resourceProvider.GetResources(project);
 
-            resources.AddEmbeddedReferences(compilationContext.GetRequiredEmbeddedReferences());
+            resources.AddRawReferences(compilationContext.GetRequiredEmbeddedReferences());
 
             return CompileInMemory(name, compilationContext, resources);
         }

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynProjectMetadata.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynProjectMetadata.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Framework.Runtime.Roslyn
             SourceFiles = context.Compilation
                                  .SyntaxTrees
                                  .Select(t => t.FilePath)
-                                 .Where(p => !String.IsNullOrEmpty(p)) // REVIEW: Raw sources?
+                                 .Where(p => !string.IsNullOrEmpty(p)) // REVIEW: Raw sources?
                                  .ToList();
 
-            RawReferences = context.MetadataReferences.OfType<EmbeddedMetadataReference>().Select(r =>
+            RawReferences = context.MetadataReferences.OfType<IMetadataRawReference>().Select(r =>
             {
                 return new
                 {

--- a/src/Microsoft.Framework.Runtime.Roslyn/project.json
+++ b/src/Microsoft.Framework.Runtime.Roslyn/project.json
@@ -4,8 +4,7 @@
     "dependencies": {
         "K.Roslyn" : "0.1-alpha-*",
         "Microsoft.Framework.Runtime" :  "",
-        "Microsoft.Framework.Runtime.Interfaces" : "",
-        "Newtonsoft.Json" : "5.0.8"
+        "Microsoft.Framework.Runtime.Interfaces" : ""
     },
     "configurations" : {
         "net45" : {

--- a/src/Microsoft.Framework.Runtime/ExportProviders/PEReaderExtensions.cs
+++ b/src/Microsoft.Framework.Runtime/ExportProviders/PEReaderExtensions.cs
@@ -8,13 +8,13 @@ using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
-namespace Microsoft.Framework.Runtime.Roslyn
+namespace Microsoft.Framework.Runtime
 {
     internal static class PEReaderExtensions
     {
-        public static IList<EmbeddedMetadataReference> GetEmbeddedReferences(this PEReader reader)
+        public static IList<IMetadataRawReference> GetEmbeddedReferences(this PEReader reader)
         {
-            var items = new List<EmbeddedMetadataReference>();
+            var items = new List<IMetadataRawReference>();
 
             var mdReader = reader.GetMetadataReader();
             foreach (var resourceHandle in mdReader.ManifestResources)
@@ -30,7 +30,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
                     // Remove .dll
                     var nameWithoutDll = resourceName.Substring(0, resourceName.Length - 4);
 
-                    items.Add(new EmbeddedMetadataReference(nameWithoutDll, buffer));
+                    items.Add(new RawMetadataReference(nameWithoutDll, buffer));
                 }
             }
 

--- a/src/Microsoft.Framework.Runtime/ExportProviders/ProjectExportProvider.cs
+++ b/src/Microsoft.Framework.Runtime/ExportProviders/ProjectExportProvider.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Versioning;
+using NuGet;
+
+namespace Microsoft.Framework.Runtime
+{
+    public class ProjectExportProvider
+    {
+        private readonly IProjectResolver _projectResolver;
+
+        public ProjectExportProvider(IProjectResolver projectResolver)
+        {
+            _projectResolver = projectResolver;
+        }
+
+        public ILibraryExport GetProjectExport(ILibraryExportProvider libraryExportProvider, string name, FrameworkName targetFramework)
+        {
+            Project project;
+            // Can't find a project file with the name so bail
+            if (!_projectResolver.TryResolveProject(name, out project))
+            {
+                return null;
+            }
+
+            var targetFrameworkConfig = project.GetTargetFrameworkConfiguration(targetFramework);
+
+            // Update the target framework for compilation
+            targetFramework = targetFrameworkConfig.FrameworkName ?? targetFramework;
+
+            Trace.TraceInformation("[{0}]: Found project '{1}' framework={2}", GetType().Name, project.Name, targetFramework);
+
+            var exports = new List<ILibraryExport>();
+
+            var dependencies = project.Dependencies.Concat(targetFrameworkConfig.Dependencies)
+                                                   .Select(d => d.Name)
+                                                   .ToList();
+
+            if (VersionUtility.IsDesktop(targetFramework))
+            {
+                // mscorlib is ok
+                dependencies.Add("mscorlib");
+
+                // TODO: Remove these references
+                dependencies.Add("System");
+                dependencies.Add("System.Core");
+                dependencies.Add("Microsoft.CSharp");
+            }
+
+            var dependencyStopWatch = Stopwatch.StartNew();
+            Trace.TraceInformation("[{0}]: Resolving exports for '{1}'", GetType().Name, project.Name);
+
+            if (dependencies.Count > 0)
+            {
+                foreach (var dependency in dependencies)
+                {
+                    var libraryExport = libraryExportProvider.GetLibraryExport(dependency, targetFramework);
+
+                    if (libraryExport == null)
+                    {
+                        // TODO: Failed to resolve dependency so do something useful
+                        Trace.TraceInformation("[{0}]: Failed to resolve dependency '{1}'", GetType().Name, dependency);
+                    }
+                    else
+                    {
+                        exports.Add(libraryExport);
+                    }
+                }
+            }
+
+            IList<IMetadataReference> resolvedReferences;
+            IList<ISourceReference> resolvedSources;
+
+            ExtractReferences(exports,
+                              libraryExportProvider,
+                              targetFramework, 
+                              out resolvedReferences, 
+                              out resolvedSources);
+
+            dependencyStopWatch.Stop();
+            Trace.TraceInformation("[{0}]: Resolved {1} exports for '{2}' in {3}ms", 
+                                  GetType().Name, 
+                                  resolvedReferences.Count, 
+                                  project.Name, 
+                                  dependencyStopWatch.ElapsedMilliseconds);
+
+            return new LibraryExport(resolvedReferences, resolvedSources);
+        }
+
+        private void ExtractReferences(List<ILibraryExport> dependencyExports,
+                                       ILibraryExportProvider libraryExportProvider,
+                                       FrameworkName targetFramework,
+                                       out IList<IMetadataReference> metadataReferences,
+                                       out IList<ISourceReference> sourceReferences)
+        {
+            var used = new HashSet<string>();
+            metadataReferences = new List<IMetadataReference>();
+            sourceReferences = new List<ISourceReference>();
+
+            foreach (var export in dependencyExports)
+            {
+                ProcessExport(export,
+                              libraryExportProvider,
+                              targetFramework,
+                              metadataReferences,
+                              sourceReferences,
+                              used);
+            }
+        }
+
+        private void ProcessExport(ILibraryExport export,
+                                   ILibraryExportProvider libraryExportProvider,
+                                   FrameworkName targetFramework,
+                                   IList<IMetadataReference> metadataReferences,
+                                   IList<ISourceReference> sourceReferences,
+                                   HashSet<string> used)
+        {
+            ExpandEmbeddedReferences(export.MetadataReferences);
+
+            foreach (var reference in export.MetadataReferences)
+            {
+                var unresolvedReference = reference as UnresolvedMetadataReference;
+
+                if (unresolvedReference != null)
+                {
+                    // Try to resolve the unresolved references
+                    var compilationExport = libraryExportProvider.GetLibraryExport(unresolvedReference.Name, targetFramework);
+
+                    if (compilationExport != null)
+                    {
+                        ProcessExport(compilationExport,
+                                      libraryExportProvider,
+                                      targetFramework,
+                                      metadataReferences,
+                                      sourceReferences,
+                                      used);
+                    }
+                }
+                else
+                {
+                    if (!used.Add(reference.Name))
+                    {
+                        continue;
+                    }
+
+                    metadataReferences.Add(reference);
+                }
+            }
+
+            foreach (var sourceReference in export.SourceReferences)
+            {
+                sourceReferences.Add(sourceReference);
+            }
+        }
+
+        private void ExpandEmbeddedReferences(IList<IMetadataReference> references)
+        {
+            var otherReferences = new List<IMetadataReference>();
+
+            foreach (var reference in references)
+            {
+                var fileReference = reference as IMetadataFileReference;
+
+                if (fileReference != null)
+                {
+                    using (var fileStream = File.OpenRead(fileReference.Path))
+                    using (var reader = new PEReader(fileStream))
+                    {
+                        otherReferences.AddRange(reader.GetEmbeddedReferences());
+                    }
+                }
+            }
+
+            references.AddRange(otherReferences);
+        }
+
+    }
+}

--- a/src/Microsoft.Framework.Runtime/ExportProviders/RawMetadataReference.cs
+++ b/src/Microsoft.Framework.Runtime/ExportProviders/RawMetadataReference.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.Framework.Runtime
+{
+    public class RawMetadataReference : IMetadataRawReference
+    {
+        public RawMetadataReference(string name, byte[] buffer)
+        {
+            Name = name;
+            Contents = buffer;
+        }
+
+        public string Name { get; private set; }
+
+        public byte[] Contents { get; private set; }
+    }
+}

--- a/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.kproj
+++ b/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.kproj
@@ -44,6 +44,9 @@
     <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="ExportProviders\CompositeLibraryExportProvider.cs" />
     <Compile Include="ExportProviders\LibraryExport.cs" />
+    <Compile Include="ExportProviders\PEReaderExtensions.cs" />
+    <Compile Include="ExportProviders\ProjectExportProvider.cs" />
+    <Compile Include="ExportProviders\RawMetadataReference.cs" />
     <Compile Include="ExportProviders\UnresolvedMetadataReference.cs" />
     <Compile Include="ExportProviders\MetadataFileReference.cs" />
     <Compile Include="ExportProviders\SourceFileReference.cs" />

--- a/src/Microsoft.Framework.Runtime/project.json
+++ b/src/Microsoft.Framework.Runtime/project.json
@@ -1,7 +1,8 @@
 {
     "version": "0.1-alpha-*",
-    "compilationOptions" : { "define" : ["LOADER", "TRACE"] },
+    "compilationOptions" : { "define" : ["LOADER", "TRACE"], "allowUnsafe": true },
     "dependencies": {
+        "Microsoft.Bcl.Metadata": "1.0.11-alpha",
         "Microsoft.Framework.Runtime.Common" : "",
         "Microsoft.Framework.Runtime.Interfaces" : "",
         "Newtonsoft.Json": "5.0.8"
@@ -10,6 +11,7 @@
         "net45" : {
             "dependencies": {
                 "System.Collections" : "",
+                "System.IO": "",
                 "System.IO.Compression" : "",
                 "System.IO.Compression.FileSystem" : "",
                 "System.Runtime" : "",

--- a/test/Microsoft.Framework.Runtime.Roslyn.Tests/AssemblyNeutralFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Roslyn.Tests/AssemblyNeutralFacts.cs
@@ -197,7 +197,7 @@ namespace Something
                 syntaxTrees: fileContents.Select(text => CSharpSyntaxTree.ParseText(text)));
 
             var worker = new AssemblyNeutralWorker(compilation,
-                new Dictionary<string, EmbeddedMetadataReference>());
+                new Dictionary<string, MetadataReference>());
             worker.FindTypeCompilations(compilation.GlobalNamespace);
             worker.OrderTypeCompilations();
             return worker;


### PR DESCRIPTION
- Made ProjectExportProvider which is an uber ILibraryExportProvider that
  returns an ILibraryExport for the entire project based on the
  specified target framework.
- Added IMetadataRawReference which reflects assembly metadata as a byte[]
- Made EmbeddedMetadataReference implement IMetadataRawReference
- Simplified roslyn compiler logic by using the new ProjectExportProvider as
  part of the compilation process.
- Improve tracing in ProjectExportProvider
- Pass the ILibraryExportProvider to GetProjectExport
