### PR TITLE
Fixed KRuntime to build on mono/Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,12 +19,12 @@ fi
 
 if test ! -e .nuget; then
     mkdir .nuget
-    cp $cachedir/nuget.exe .nuget/nuget.exe
+    cp $cachedir/nuget.exe .nuget/NuGet.exe
 fi
 
 if test ! -d packages/KoreBuild; then
-    mono .nuget/nuget.exe install KoreBuild -ExcludeVersion -o packages -nocache -pre
-    mono .nuget/nuget.exe install Sake -version 0.2 -o packages -ExcludeVersion
+    mono .nuget/NuGet.exe install KoreBuild -ExcludeVersion -o packages -nocache -pre
+    mono .nuget/NuGet.exe install Sake -version 0.2 -o packages -ExcludeVersion
 fi
 
 if ! type k > /dev/null 2>&1; then

--- a/makefile
+++ b/makefile
@@ -1,9 +1,0 @@
-CURDIR=`pwd`
-
-all: compile
-
-prepare-output:
-	mkdir -p artifacts/build/klr.mono.managed
-
-compile: prepare-output
-	mcs src/klr.mono.managed/EntryPoint.cs src/klr.hosting.shared/RuntimeBootstrapper.cs src/klr.hosting.shared/LoaderEngine.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineParser.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOptions.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOptionType.cs /target:exe /unsafe /out:artifacts/build/klr.mono.managed/klr.mono.managed.dll /r:"System;System.Core" /define:NET45

--- a/makefile.shade
+++ b/makefile.shade
@@ -58,23 +58,30 @@ var NEW_RUNTIME = '${Environment.GetEnvironmentVariable("NEW_RUNTIME") == "1"}'
   directory delete='${Path.Combine(BUILD_DIR2, "klr")}'
   copy sourceDir='${Path.Combine(ROOT, "src", "klr")}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, "klr")}' overwrite='${true}'
 
-#build-mono-entrypoint target='compile' if='!IsMono'
-    directory create='artifacts/build/klr.mono.managed'
-    
+#build-mono-entrypoint target='compile'
+   directory create='artifacts/build/klr.mono.managed' target='compile' 
+     
     @{
-        var cscPath = Path.Combine(Environment.GetEnvironmentVariable("WINDIR"), "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe");
-        Log.Info("Using csc path:" + cscPath);
-        Exec(cscPath, @"/target:exe /nologo /unsafe /out:artifacts\build\klr.mono.managed\klr.mono.managed.dll /define:NET45 src\klr.mono.managed\EntryPoint.cs src\klr.hosting.shared\RuntimeBootstrapper.cs src\klr.hosting.shared\LoaderEngine.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandArgument.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandLineApplication.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandOption.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandOptionType.cs");
-    }
-
+       if(IsMono)
+       {
+         Exec("mcs", @"/target:exe /nologo /unsafe /out:artifacts/build/klr.mono.managed/klr.mono.managed.dll /define:NET45 src/klr.mono.managed/EntryPoint.cs src/klr.hosting.shared/RuntimeBootstrapper.cs src/klr.hosting.shared/LoaderEngine.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandArgument.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineApplication.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOption.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOptionType.cs");
+       }
+       else     
+       {
+         var cscPath = Path.Combine(Environment.GetEnvironmentVariable("WINDIR"), "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe");
+         Log.Info("Using csc path:" + cscPath);
+         Exec(cscPath, @"/target:exe /nologo /unsafe /out:artifacts\build\klr.mono.managed\klr.mono.managed.dll /define:NET45 src\klr.mono.managed\EntryPoint.cs src\klr.hosting.shared\RuntimeBootstrapper.cs src\klr.hosting.shared\LoaderEngine.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandArgument.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandLineApplication.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandOption.cs src\Microsoft.Framework.CommandLineUtils\CommandLine\CommandOptionType.cs");
+       }
+     }
+	
 #copy-kvm target='compile'
     copy sourceDir='setup' outputDir='${ARTIFACTS_DIR}' include='*.cmd' overwrite='${true}'
     copy sourceDir='setup' outputDir='${ARTIFACTS_DIR}' include='*.ps1'
     copy sourceDir='setup' outputDir='${ARTIFACTS_DIR}' include='*.sh'
-    update-file updateFile='${ARTIFACTS_DIR}\kvm.ps1' @{
+    update-file updateFile='${ARTIFACTS_DIR}\kvm.ps1' if='!IsMono' @{
         updateText = updateText.Replace("{{BUILD_NUMBER}}", Environment.GetEnvironmentVariable("BUILD_NUMBER"));
     }
-    update-file updateFile='${ARTIFACTS_DIR}\kvm.sh' @{
+    update-file updateFile='${ARTIFACTS_DIR}\kvm.sh' if='!IsMono' @{
         updateText = updateText.Replace("{{BUILD_NUMBER}}", Environment.GetEnvironmentVariable("BUILD_NUMBER"));
     }
 
@@ -241,37 +248,50 @@ var NEW_RUNTIME = '${Environment.GetEnvironmentVariable("NEW_RUNTIME") == "1"}'
             File.WriteAllText(targetShFile, script);
         }
     }
+     
+#copy-bits-windows
+     @{
+         if(!IsMono)
+         {   
+             // KRE-svr50-x86
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr", "bin", "Win32", Configuration, "net45", "*.exe")).Single(), SVR50_x86_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "Win32", Configuration, "*.dll")).Single(), SVR50_x86_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "Win32", Configuration, "*.pdb")).Single(), SVR50_x86_BIN, true);
+             File.Copy(Files.Include(Path.Combine(ROOT, "src", "klr.net45.managed", "*.config")).Single(), SVR50_x86_BIN, true);
 
-    -// KRE-svr50-x86
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr", "bin", "Win32", Configuration, "net45")}' outputDir='${SVR50_x86_BIN}' include='*.exe' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.net45", "bin", "Win32", Configuration)}' outputDir='${SVR50_x86_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.net45", "bin", "Win32", Configuration)}' outputDir='${SVR50_x86_BIN}' include='*.pdb' overwrite='${true}'
-    copy sourceDir='${Path.Combine(ROOT, "src", "klr.net45.managed")}' outputDir='${SVR50_x86_BIN}' include='*.config' overwrite='${true}'
+             // KRE-svr50-x64
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr", "bin", "x64", Configuration, "net45", "*.exe")).Single(), SVR50_x86_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "x64", Configuration, "*.dll")).Single(), SVR50_x64_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "x64", Configuration, "*.pdb")).Single(), SVR50_x64_BIN, true);
+             File.Copy(Files.Include(Path.Combine(ROOT, "src", "klr.net45.managed", "*.config")).Single(), SVR50_x64_BIN, true);             
 
-    -// KRE-svr50-x64
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr", "bin", "x64", Configuration, "net45")}' outputDir='${SVR50_x64_BIN}' include='*.exe' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.net45", "bin", "x64", Configuration)}' outputDir='${SVR50_x64_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.net45", "bin", "x64", Configuration)}' outputDir='${SVR50_x64_BIN}' include='*.pdb' overwrite='${true}'
-    copy sourceDir='${Path.Combine(ROOT, "src", "klr.net45.managed")}' outputDir='${SVR50_x64_BIN}' include='*.config' overwrite='${true}'
+             // KRE-svrc50-x86
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr", "bin", "Win32", Configuration, "k10", "*.exe")).Single(), SVRC50_x86_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "Win32", Configuration, "*.dll")).Single(), SVRC50_x86_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "Win32", Configuration, "*.pdb")).Single(), SVRC50_x86_BIN, true); 
+       
+             // KRE-svrc50-x64
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr", "bin", "x64", Configuration, "k10", "*.exe")).Single(), SVRC50_x64_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "x64", Configuration, "*.dll")).Single(), SVRC50_x64_BIN, true);
+             File.Copy(Files.Include(Path.Combine(BUILD_DIR2, "klr.net45", "bin", "x64", Configuration, "*.pdb")).Single(), SVRC50_x64_BIN, true);
+			 
+             foreach(var outputDir in new[]{ SVR50_x86_BIN, SVR50_x64_BIN, SVRC50_x86_BIN, SVRC50_x64_BIN })                    
+             {
+                 foreach(var file in Files.Include(Path.Combine(SCRIPTS_DIR, "*.cmd")))
+                 {
+                     File.Copy(file, outputDir, true);
+                 }
+             }          
+         }
+     }
 
-    -// KRE-svrc50-x86
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr", "bin", "Win32", Configuration, "k10")}' outputDir='${SVRC50_x86_BIN}' include='*.exe' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.core45", "bin", "Win32", Configuration)}' outputDir='${SVRC50_x86_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.core45", "bin", "Win32", Configuration)}' outputDir='${SVRC50_x86_BIN}' include='*.pdb' overwrite='${true}'
-
-    -// KRE-svrc50-x64
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr", "bin", "x64", Configuration, "k10")}' outputDir='${SVRC50_x64_BIN}' include='*.exe' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.core45", "bin", "x64", Configuration)}' outputDir='${SVRC50_x64_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "klr.core45", "bin", "x64", Configuration)}' outputDir='${SVRC50_x64_BIN}' include='*.pdb' overwrite='${true}'
-
-    copy sourceDir='${SCRIPTS_DIR}' include='*.cmd' overwrite='${true}' each='var outputDir in new[]{ SVR50_x86_BIN, SVR50_x64_BIN, SVRC50_x86_BIN, SVRC50_x64_BIN }'
 
     @{
         var hostK10 = Path.Combine(BUILD_DIR2, "*", "k10", "**.*");
         var hostnet45 = Path.Combine(BUILD_DIR2, "*", "net45", "**.*");
-        var libPackages = new[] { "Microsoft.Framework.Project",
-                                  "Microsoft.Framework.PackageManager", 
-                                  "Microsoft.Framework.DesignTimeHost" };
+        var libPackages = new[] {   "Microsoft.Framework.Project",
+                                    "Microsoft.Framework.PackageManager", 
+                                    "Microsoft.Framework.DesignTimeHost" };
 
         var sharedSourceAssemblies = new [] { 
             Path.Combine(BUILD_DIR2, "klr.hosting.shared/**/*.*"), 
@@ -436,9 +456,9 @@ var NEW_RUNTIME = '${Environment.GetEnvironmentVariable("NEW_RUNTIME") == "1"}'
     }
 
 #copy-coreclr
-    nuget-install package='CoreCLR' outputDir='packages' extra='-pre -nocache' once='CoreCLR'
+    nuget-install package='CoreCLR' outputDir='packages' extra='-pre -nocache' once='CoreCLR' if='!IsMono'
 
-    var CoreCLR_DIR='${""}'
+    var CoreCLR_DIR='${""}' 
     @{
         Func<string, long> getVersion = version => {
         var dash = version.LastIndexOf('-');
@@ -457,24 +477,48 @@ var NEW_RUNTIME = '${Environment.GetEnvironmentVariable("NEW_RUNTIME") == "1"}'
             return Int64.MaxValue;
         };
 
-        string packagesDir = Path.Combine(Directory.GetCurrentDirectory(), "packages");
-        CoreCLR_DIR = Directory.EnumerateDirectories(packagesDir, "CoreCLR*")
-                                .OrderByDescending(getVersion)
-                                .First();
+        if(!IsMono)
+        {
+            string packagesDir = Path.Combine(Directory.GetCurrentDirectory(), "packages");
+            CoreCLR_DIR = Directory.EnumerateDirectories(packagesDir, "CoreCLR*")
+                                   .OrderByDescending(getVersion)
+                                   .First();
                                       
-        Log.Info("Using " + CoreCLR_DIR);
+            Log.Info("Using " + CoreCLR_DIR);
+        }
     }
     
     -// Copy to target
-    copy sourceDir='${Path.Combine(CoreCLR_DIR, "Runtime")}' outputDir='${Path.Combine(CORECLR_TARGET_PATH, "Runtime")}' overwrite='${true}'
+    copy sourceDir='${Path.Combine(CoreCLR_DIR, "Runtime")}' outputDir='${Path.Combine(CORECLR_TARGET_PATH, "Runtime")}' overwrite='${true}' if='!IsMono'
     
     -// Copy the CoreCLR to the k10 builds
-    copy sourceDir='${Path.Combine(CORECLR_TARGET_PATH, "Runtime", "x86")}' outputDir='${SVRC50_x86_BIN}'
-    copy sourceDir='${Path.Combine(CORECLR_TARGET_PATH, "Runtime", "amd64")}' outputDir='${SVRC50_x64_BIN}'
+    copy sourceDir='${Path.Combine(CORECLR_TARGET_PATH, "Runtime", "x86")}' outputDir='${SVRC50_x86_BIN}' if='!IsMono' 
+    copy sourceDir='${Path.Combine(CORECLR_TARGET_PATH, "Runtime", "amd64")}' outputDir='${SVRC50_x64_BIN}' if='!IsMono'
 
 #nuget-pack-runtime
-    copy sourceDir='${NUSPEC_ROOT}' outputDir='${BUILD_DIR2}' include='*.nuspec' overwrite='${true}'
-    nuget-pack packageVersion='${FULL_VERSION}' outputDir='${BUILD_DIR2}' extra='-NoPackageAnalysis' each='var nuspecFile in Files.Include(Path.Combine(BUILD_DIR2, "*.nuspec"))'
+    -//var nuspecs = KRE-mono45-x86
+    @{
+        var allPackages = Path.Combine(BUILD_DIR2, "**", "*.nupkg");
+        var excludePackages = Path.Combine(BUILD_DIR2, "**", "Microsoft.Framework.Runtime.Interfaces*.nupkg");
+        var excludePackages2 = Path.Combine(BUILD_DIR2, "**", "Microsoft.Framework.PackageManager*.nupkg");
+        foreach(var packageFile in Files.Include(allPackages).Exclude(excludePackages).Exclude(excludePackages2))
+        {
+            File.Delete(packageFile);
+        }
+
+    }
+       
+   @{
+        if(IsMono)
+        {
+            NUSPEC_ROOT = Path.Combine(ROOT, "nuspec", "Linux");
+        }
+    }
+	
+    copy sourceDir='${NUSPEC_ROOT}' outputDir='${BUILD_DIR2}' include='*.nuspec' overwrite='${true}' 
+    nuget-pack packageVersion='${FULL_VERSION}' outputDir='${BUILD_DIR2}' extra='-NoPackageAnalysis' each='var nuspecFile in Files.Include(Path.Combine(BUILD_DIR2, "*.nuspec"))' 
+
+
 
 #install-runtime target='install'
   var matchVersion=''

--- a/nuspec/Linux/KRE-mono45-x86.nuspec
+++ b/nuspec/Linux/KRE-mono45-x86.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+    <metadata>
+        <id>KRE-mono45-x86</id>
+        <version>0.0.1-pre</version>
+        <authors>Microsoft</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>The K Runtime Environment for Mono on OSX and Linux</description>
+    </metadata>
+    <files>
+        <file src="KRE-mono45-x86/bin/**" exclude="**\*.pdb;**\*.xml" target="bin" />
+    </files>
+</package>

--- a/src/Microsoft.Framework.DesignTimeHost/Program.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Program.cs
@@ -46,8 +46,9 @@ namespace Microsoft.Framework.DesignTimeHost
 
         private async Task OpenChannel(int port, string hostId)
         {
-            var listenSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            listenSocket.Bind(new IPEndPoint(IPAddress.Loopback, port));
+            var ipEndPoint = new IPEndPoint(IPAddress.Loopback, port);
+            var listenSocket = new Socket(ipEndPoint.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            listenSocket.Bind(ipEndPoint);
             listenSocket.Listen(10);
 
             Console.WriteLine("Listening on port {0}", port);


### PR DESCRIPTION
A Lot of changes were required to the build script, but most of the changes are just addition of if='IsMono' and if='!IsMono'. Highlights of some changes,I have to add Linux directory to the nuspec folder, because the current .nuspec files have file paths that follow windows file system structure. so i rewrite nuspec package for mono-kre and placed it  in the nuspec\Linux folder and direct build script to build nuget package from that if we are on Linux/mono and use the windows versions if we are on windows. Their is only one change in the source code which was a trivial one. I am here to answer any query about the changes i have a reason for every change.Personally tested it on both windows and Linux.
