### PR TITLE
Use new logic to fetch default author

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
@@ -137,7 +137,16 @@ namespace Microsoft.Framework.PackageManager
 
             if (builder.Authors.Count == 0)
             {
-                builder.Authors.Add("K");
+                // TODO: K_AUTHOR is a temporary name
+                var defaultAuthor = Environment.GetEnvironmentVariable("K_AUTHOR");
+                if (string.IsNullOrEmpty(defaultAuthor))
+                {
+                    builder.Authors.Add(project.Name);
+                }
+                else
+                {
+                    builder.Authors.Add(defaultAuthor);
+                }
             }
 
             builder.Description = project.Description ?? project.Name;


### PR DESCRIPTION
- If author is not specified in project.json and there is a non-empty env var named "K_AUTHOR", we use its value
- If author is not specified in any possible source, we leave it blank

parent #208 
Tested by opening up the generated NUPKG and checking .nuspec file
