### PR TITLE
"kpm pack" nupkg the project dependencies

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Framework.PackageManager.Packing
                 Overwrite = _options.Overwrite,
                 ZipPackages = _options.ZipPackages,
                 AppFolder = _options.AppFolder ?? project.Name,
+                NoSource = _options.NoSource
             };
 
             foreach (var runtime in _options.Runtimes)

--- a/src/Microsoft.Framework.PackageManager/Packing/PackOptions.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackOptions.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Framework.PackageManager.Packing
 
         public bool Overwrite { get; set; }
 
+        public bool NoSource { get; set; }
+
         public IEnumerable<string> Runtimes { get; set; }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Framework.PackageManager.Packing
         public string AppFolder { get; set; }
         public bool Overwrite { get; set; }
         public bool ZipPackages { get; set; }
+        public bool NoSource { get; set; }
 
         public IList<PackRuntime> Runtimes { get; set; }
         public IList<PackProject> Projects { get; private set; }
@@ -50,7 +51,24 @@ namespace Microsoft.Framework.PackageManager.Packing
 
             foreach (var deploymentProject in Projects)
             {
-                deploymentProject.Emit(this);
+                // TODO: temporarily we always emit sources for main project to make sure "k run"
+                // can find entry point of the program. Later we should make main project
+                // a nukpg too.
+                if (deploymentProject == mainProject)
+                {
+                    deploymentProject.EmitSource(this);
+                }
+                else
+                {
+                    if (NoSource)
+                    {
+                        deploymentProject.EmitNupkg(this);
+                    }
+                    else
+                    {
+                        deploymentProject.EmitSource(this);
+                    }
+                }
             }
 
             foreach (var deploymentRuntime in Runtimes)

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -111,6 +111,8 @@ namespace Microsoft.Framework.PackageManager
                     CommandOptionType.NoValue);
                 var optionOverwrite = c.Option("--overwrite", "Remove existing files in target folders",
                     CommandOptionType.NoValue);
+                var optionNoSource = c.Option("--no-source", "Don't include sources of project dependencies",
+                    CommandOptionType.NoValue);
                 var optionRuntime = c.Option("--runtime <KRE>", "Names or paths to KRE files to include",
                     CommandOptionType.MultipleValue);
                 var optionAppFolder = c.Option("--appfolder <NAME>",
@@ -133,6 +135,7 @@ namespace Microsoft.Framework.PackageManager
                         RuntimeTargetFramework = _environment.TargetFramework,
                         ZipPackages = optionZipPackages.HasValue(),
                         Overwrite = optionOverwrite.HasValue(),
+                        NoSource = optionNoSource.HasValue(),
                         Runtimes = optionRuntime.HasValue() ?
                             string.Join(";", optionRuntime.Values).
                                 Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) :


### PR DESCRIPTION
parent #80 

@loudej mentioned in #80 that "source packages should be built innermost-first from a dependency standpoint". However, I find we can successfully build all project dependencies without considering the order. So in my current implementation, I just build project dependencies in an arbitrary order and copy the output nupkgs to final destination. @loudej , please let me know if you have any concern regarding this implementation.
