### PR TITLE
Handle the case where version of an indirect dependency is missing

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/RemoteWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RemoteWalkProvider.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Framework.PackageManager
                 {
                     return dependencySet
                         .SelectMany(x => x.Dependencies)
-                        .Select(x => new Library { Name = x.Id, Version = x.VersionSpec.MinVersion })
+                        .Select(x => new Library { Name = x.Id,
+                            Version = x.VersionSpec != null ? x.VersionSpec.MinVersion : null })
                         .ToList();
                 }
             }


### PR DESCRIPTION
parent #255 

For now, if an indirect dependency's version is missing (e.g. the `Ninject` dependency of `Nancy.Bootstrappers.Ninject` mentioned in #255 ), we won't download nupkg for it. @davidfowl , do we want to warn users in this case? They won't be able to do `k run` because of missing indirect dependencies.
