### PR TITLE
delete KVM temp folder after downloading and unpacking

### DIFF
--- a/setup/kvm.ps1
+++ b/setup/kvm.ps1
@@ -217,6 +217,7 @@ param(
     md $kreFolder -Force | Out-Null   
     Write-Host "Installing to $kreFolder"
     mv "$kreTempDownload\*" $kreFolder
+    del $kreTempDownload -Force
 }
 
 function Do-Kvm-Unpack {


### PR DESCRIPTION
Added del command for the temp folder. The other block of changes is because that one section had different line endings to the rest of the file. They are now all the same.
