### PR TITLE
Optimized accessing reference assemblies

### DIFF
--- a/src/Microsoft.Framework.Runtime/FrameworkReferenceResolver.cs
+++ b/src/Microsoft.Framework.Runtime/FrameworkReferenceResolver.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Framework.Runtime
             var frameworkInfo = new FrameworkInformation();
             frameworkInfo.Path = directory.FullName;
 
-            // The redist list conains the list of assemblies for this target framework
+            // The redist list contains the list of assemblies for this target framework
             string redistList = Path.Combine(directory.FullName, "RedistList", "FrameworkList.xml");
 
             if (File.Exists(redistList))


### PR DESCRIPTION
- Lazily resolve a target framework at a time as well as the assemblies
  within those target frameworks.
- This helps to reduce the amount of IO that happens when compiling.
