### PR TITLE
Change kvm alias message to "updating" when overwriting an alias

### DIFF
--- a/setup/kvm.ps1
+++ b/setup/kvm.ps1
@@ -473,10 +473,12 @@ param(
   [string] $value
 )
     $kreFullName = "KRE-" + (Requested-Platform "svr50") + "-" + (Requested-Architecture "x86") + "." + $value
-
-    Write-Host "Setting alias '$name' to '$kreFullName'"
+    
+    $aliasFilePath=$userKrePath + "\alias\" + $name + ".txt"
+    $action=if (Test-Path $aliasFilePath) { "Updating"} else { "Setting" }
+    Write-Host "$action alias '$name' to '$kreFullName'"
     md ($userKrePath + "\alias\") -Force | Out-Null
-    $kreFullName | Out-File ($userKrePath + "\alias\" + $name + ".txt") ascii
+    $kreFullName | Out-File ($aliasFilePath) ascii
 }
 
 function Locate-KreBinFromFullName() {

--- a/setup/kvm.sh
+++ b/setup/kvm.sh
@@ -339,7 +339,9 @@ kvm()
 
             [[ ! -d "$KRE_USER_PACKAGES/$kreFullName" ]] && echo "$semver is not an installed KRE version." && return 1
 
-            echo "Setting alias '$name' to '$kreFullName'"
+            local action="Setting"
+            [[ -e "$KRE_USER_HOME/alias/$name.alias" ]] && action="Updating"
+            echo "$action alias '$name' to '$kreFullName'"
 
             echo "$kreFullName" > "$KRE_USER_HOME/alias/$name.alias"
         ;;


### PR DESCRIPTION
Modified alias command in kvm.sh to print the verb 'Updating' rather than 'Setting' when overwriting an alias
Modified alias command in kvm.ps1 to print the verb 'Updating' rather than 'Setting' when overwriting an alias

Fixes #340
