### PR TITLE
Allow kvm alias to set one alias to the version of another alias

### DIFF
--- a/setup/kvm.ps1
+++ b/setup/kvm.ps1
@@ -68,8 +68,9 @@ kvm alias
 kvm alias <alias>
   display value of named alias
 
-kvm alias <alias> <semver> [-x86][-x64] [-svr50][-svrc50]
-  set alias to specific version
+kvm alias <alias> <semver>|<alias> [-x86][-x64] [-svr50][-svrc50]
+  <alias>            The name of the alias to set 
+  <semver>|<alias>   The KRE version to set the alias to. Alternatively use the version of the specified alias
 
 "@ | Write-Host
 }
@@ -472,7 +473,7 @@ param(
   [string] $name,
   [string] $value
 )
-    $kreFullName = "KRE-" + (Requested-Platform "svr50") + "-" + (Requested-Architecture "x86") + "." + $value
+    $kreFullName = Requested-VersionOrAlias $value
 
     Write-Host "Setting alias '$name' to '$kreFullName'"
     md ($userKrePath + "\alias\") -Force | Out-Null

--- a/setup/kvm.sh
+++ b/setup/kvm.sh
@@ -189,7 +189,7 @@ kvm()
             echo "kvm use <semver>|<alias>|none [-p -persistent]"
             echo "<semver>|<alias>  add KRE bin to path of current command line   "
             echo "none              remove KRE bin from path of current command line"
-            echo "-p -persistent   set selected version as default"
+            echo "-p -persistent    set selected version as default"
             echo ""
             echo "kvm list"
             echo "list KRE versions installed "
@@ -201,7 +201,8 @@ kvm()
             echo "display value of named alias"
             echo ""
             echo "kvm alias <alias> <semver>"
-            echo "set alias to specific version"
+            echo "<alias>            The name of the alias to set"
+            echo "<semver>|<alias>   The KRE version to set the alias to. Alternatively use the version of the specified alias"
             echo ""
             echo ""
         ;;
@@ -336,10 +337,9 @@ kvm()
                 return
             fi
 
-            local semver="$3"
-            local kreFullName="KRE-$(_kvm_requested_platform mono45)-$(_kvm_requested_architecture x86).$semver"
+            local kreFullName=$(_kvm_requested_version_or_alias "$3")
 
-            [[ ! -d "$KRE_USER_PACKAGES/$kreFullName" ]] && echo "$semver is not an installed KRE version." && return 1
+            [[ ! -d "$KRE_USER_PACKAGES/$kreFullName" ]] && echo "$kreFullName is not an installed KRE version." && return 1
 
             echo "Setting alias '$name' to '$kreFullName'"
 


### PR DESCRIPTION
Modified the command 'kvm alias foo bar' to allow alias 'foo' to be set to the verison of alias 'bar' when bar is an existing alias.

This is required to support the change alias functionality discussed in #320.
