### PR TITLE
"kpm pack" writes SHAs of packages into global.json

### DIFF
--- a/src/Microsoft.Framework.Runtime/GlobalSettings.cs
+++ b/src/Microsoft.Framework.Runtime/GlobalSettings.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Framework.Runtime
             return true;
         }
 
-        private static bool HasGlobalFile(string path)
+        public static bool HasGlobalFile(string path)
         {
             string projectPath = Path.Combine(path, GlobalFileName);
 


### PR DESCRIPTION
parent #399 

Assume the original `global.json` file is

``` json
{
  "sources": [
    "src"
  ]
}
```

An example of `global.json` file generated by `kpm pack` is

``` json
{
  "sources": [
    "src"
  ],
  "SHAs": {
    "Microsoft.Framework.ConfigurationModel.0.1-alpha-build-0233.nupkg": "wKeQHcfCxyFFbLzSvDipmsp51PqJ5n3vLr9QmNn3Nu5BdmzqO+Mr0OiG8j4U/M2tiDgNL3xLAECOuA3BJ5GFMQ==",
    "Nancy.0.23.0.nupkg": "Jd4MqtGriddM6eNHVZihaodsxaHQD3g6fDl9CQGySPEtOVWaV2o9e/pnkunfE8tyIVOHgAW2guNDHO4fzqDKVA==",
    "Ninject.3.2.2.0.nupkg": "vDyKaDZ1RgmPxD87u3om3La34r4RHBZfap3tCsJtUbSGkIWjQJ8La1s61BR/C0LgO1+3xGEC6UfI7D594MNl5Q=="
  }
}
```
