### PR TITLE
Adding test adapter OM

### DIFF
--- a/src/Microsoft.Framework.TestAdapter/ITestDiscoverySink.cs
+++ b/src/Microsoft.Framework.TestAdapter/ITestDiscoverySink.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.TestAdapter
+{
+    public interface ITestDiscoverySink
+    {
+        void SendTest(Test test);
+    }
+}

--- a/src/Microsoft.Framework.TestAdapter/ITestExecutionSink.cs
+++ b/src/Microsoft.Framework.TestAdapter/ITestExecutionSink.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.TestAdapter
+{
+    public interface ITestExecutionSink
+    {
+        void RecordStart(Test test);
+
+        void RecordResult(TestResult testResult);
+    }
+}

--- a/src/Microsoft.Framework.TestAdapter/Microsoft.Framework.TestAdapter.kproj
+++ b/src/Microsoft.Framework.TestAdapter/Microsoft.Framework.TestAdapter.kproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>71c2f8aa-05e6-47db-9a1a-d2760cef7dc1</ProjectGuid>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(OutputType) == 'Console'">
+    <DebuggerFlavor>ConsoleDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(OutputType) == 'Web'">
+    <DebuggerFlavor>WebDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ITestDiscoverySink.cs" />
+    <Compile Include="ITestExecutionSink.cs" />
+    <Compile Include="Test.cs" />
+    <Compile Include="TestOutcome.cs" />
+    <Compile Include="TestResult.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Framework.TestAdapter/Test.cs
+++ b/src/Microsoft.Framework.TestAdapter/Test.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Framework.TestAdapter
+{
+    public class Test
+    {
+        public Test()
+        {
+            Properties = new Dictionary<string, object>(StringComparer.Ordinal);
+        }
+
+        public string CodeFilePath { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public string FullyQualifiedName { get; set; }
+
+        public Guid? Id { get; set; }
+
+        public int? LineNumber { get; set; }
+
+        public IDictionary<string, object> Properties { get; private set; }
+    }
+}

--- a/src/Microsoft.Framework.TestAdapter/TestOutcome.cs
+++ b/src/Microsoft.Framework.TestAdapter/TestOutcome.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.TestAdapter
+{
+    public enum TestOutcome
+    {
+        None,
+        Passed,
+        Failed,
+        Skipped,
+        NotFound
+    }
+}

--- a/src/Microsoft.Framework.TestAdapter/TestResult.cs
+++ b/src/Microsoft.Framework.TestAdapter/TestResult.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+    using System;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Framework.TestAdapter
+{
+    public sealed class TestResult
+    {
+        public TestResult(Test test)
+        {
+            if (test == null)
+            {
+                throw new ArgumentNullException("test");
+            }
+
+            Test = test;
+            Messages = new Collection<string>();
+        }
+
+        public Test Test { get; private set; }
+
+        public TestOutcome Outcome { get; set; }
+
+        public string ErrorMessage { get; set; }
+
+        public string ErrorStackTrace { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public Collection<string> Messages { get;  private set; }
+
+        public string ComputerName { get; set; }
+
+        public TimeSpan Duration { get; set; }
+
+        public DateTimeOffset StartTime { get; set; }
+
+        public DateTimeOffset EndTime { get; set; }
+    }
+}

--- a/src/Microsoft.Framework.TestAdapter/project.json
+++ b/src/Microsoft.Framework.TestAdapter/project.json
@@ -1,0 +1,13 @@
+﻿{
+    "dependencies": { },
+    "configurations": {
+        "net45": { },
+        "k10": {
+            "dependencies": {
+                "System.Collections": "4.0.0.0",
+                "System.Runtime": "4.0.20.0",
+                "System.Runtime.Extensions": "4.0.10.0"
+            }
+        }
+    }
+}


### PR DESCRIPTION
/cc @davidfowl 

Based loosely on `Microsoft.VisualStudio.TestPlatform.ObjectModel` and the extensibility exposed by VS's unit test system.

This change is part of enabling support for 'k test' reporting discovery/integration of tests to VS.
