### PR TITLE
Don't resolve the framework references while resolving dependencies

### DIFF
--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -99,15 +99,10 @@ namespace Microsoft.Framework.Runtime
             {
                 foreach (var assemblyReference in frameworkAssemblies)
                 {
-                    string path;
-                    if (_frameworkReferenceResolver.TryGetAssembly(assemblyReference.AssemblyName, targetFramework, out path))
+                    yield return new Library
                     {
-                        yield return new Library
-                        {
-                            Name = assemblyReference.AssemblyName,
-                            Version = VersionUtility.GetAssemblyVersion(path)
-                        };
-                    }
+                        Name = assemblyReference.AssemblyName
+                    };
                 }
             }
         }


### PR DESCRIPTION
- This allows other resolvers to handle them. On machines where there
  are no reference assemblies installed the GacDependencyResolver is used.
  We don't need the version here because the GacDependencyResolver or
  ReferenceAssemblyDependencyResolver will figure that out.
#391
