### PR TITLE
Add empty static file folder as a workaround

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
@@ -48,6 +48,14 @@ namespace Microsoft.Framework.PackageManager.Packing
 
             var mainProject = Projects.Single(project => project.Name == _project.Name);
 
+            // TODO: this folder is needed by WebDeply team
+            // we create an empty one as a temp workaround.
+            // Later we should extract all static files from main project
+            // and put them into this folder.
+            var staticFileRootName = AppFolder ?? mainProject.Name;
+            var staticFileRootPath = Path.Combine(OutputPath, staticFileRootName);
+            Directory.CreateDirectory(staticFileRootPath);
+
             foreach (var deploymentPackage in Packages)
             {
                 deploymentPackage.Emit(this);


### PR DESCRIPTION
parent #422 

@davidfowl , simply moving all output into `approot` is not enough. WebDeploy team is doing `kpm pack --appfolder wwwroot ...` and expecting a `wwwroot` folder siting in the same folder as `approot`.
