### PR TITLE
Use mono or mono symlink if present

### DIFF
--- a/scripts/klr.sh
+++ b/scripts/klr.sh
@@ -8,5 +8,8 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-
-mono $DIR/klr.mono.managed.dll "$@"
+if [ -f "$DIR/mono" ]; then
+  "$DIR/mono" "$DIR/klr.mono.managed.dll" "$@"
+else
+  mono "$DIR/klr.mono.managed.dll" "$@"
+fi


### PR DESCRIPTION
This will help in cases where KRE is installed on a machine to use a
custom build of mono that doesn’t interfere with the standard mono
release. That works by going into the KRE folder and creating a symlink
to exactly the mono executable that should be used to host k commands.
