### PR TITLE
Don't read the nuspec until the very last minute

### DIFF
--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -51,6 +51,12 @@ namespace Microsoft.Framework.Runtime
 
         public LibraryDescription GetDescription(string name, SemanticVersion version, FrameworkName targetFramework)
         {
+            // Null versions aren't supported
+            if (version == null)
+            {
+                return null;
+            }
+
             var package = FindCandidate(name, version);
 
             if (package != null)
@@ -365,26 +371,25 @@ namespace Microsoft.Framework.Runtime
 
         public IPackage FindCandidate(string name, SemanticVersion version)
         {
-            if (version == null)
-            {
-                return _repository.FindPackagesById(name).FirstOrDefault();
-            }
+            PackageInfo bestMatch = null;
 
-            var packages = _repository.FindPackagesById(name);
-            IPackage bestMatch = null;
-
-            foreach (var package in packages)
+            foreach (var packageInfo in _repository.FindPackagesById(name))
             {
                 if (VersionUtility.ShouldUseConsidering(
                     current: bestMatch != null ? bestMatch.Version : null,
-                    considering: package.Version,
+                    considering: packageInfo.Version,
                     ideal: version))
                 {
-                    bestMatch = package;
+                    bestMatch = packageInfo;
                 }
             }
 
-            return bestMatch;
+            if (bestMatch == null)
+            {
+                return null;
+            }
+
+            return bestMatch.Package;
         }
 
         public static string ResolveRepositoryPath(string rootDirectory)

--- a/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.kproj
+++ b/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.kproj
@@ -112,6 +112,7 @@
     <Compile Include="NuGet\Packages\OptimizedOpcZipPackage.cs" />
     <Compile Include="NuGet\Packages\OptimizedZipPackage.cs" />
     <Compile Include="NuGet\Packages\PackageDependency.cs" />
+    <Compile Include="NuGet\Packages\PackageInfo.cs" />
     <Compile Include="NuGet\Packages\UnzippedPackage.cs" />
     <Compile Include="NuGet\Packages\ZipPackage.cs" />
     <Compile Include="NuGet\Packages\ZipPackageAssemblyReference.cs" />

--- a/src/Microsoft.Framework.Runtime/NuGet/Packages/PackageInfo.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Packages/PackageInfo.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+
+namespace NuGet
+{
+    public class PackageInfo
+    {
+        private readonly IFileSystem _repositoryRoot;
+        private readonly string _versionDir;
+        private IPackage _package;
+
+        public PackageInfo(IFileSystem repositoryRoot, string packageId, SemanticVersion version, string versionDir)
+        {
+            _repositoryRoot = repositoryRoot;
+            Id = packageId;
+            Version = version;
+            _versionDir = versionDir;
+        }
+
+        public string Id { get; private set; }
+
+        public SemanticVersion Version { get; private set; }
+
+        public IPackage Package
+        {
+            get
+            {
+                if (_package == null)
+                {
+                    var nuspecPath = Path.Combine(_versionDir, string.Format("{0}.nuspec", Id));
+                    _package = new UnzippedPackage(_repositoryRoot, nuspecPath);
+                }
+
+                return _package;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added package info which stores the package id and version and nuspec directory.
  This is used for version resolution so we don't need to evaluate the nuspecs
  for all versions of a package up front.
- FindCandidate now resolves the correct package info then returns the appropriate
  IPackage after it is resolved.
- Skip null versions

/cc @jhawk42 @lodejard 
