### PR TITLE
Don't use the resolved items in GetLibraryExport.

### DIFF
--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Framework.Runtime
         public ILibraryExport GetLibraryExport(string name, FrameworkName targetFramework, string configuration)
         {
             string path;
-            if (_resolvedPaths.TryGetValue(name, out path))
+            if (FrameworkResolver.TryGetAssembly(name, targetFramework, out path))
             {
                 return new LibraryExport(name, path);
             }

--- a/src/Microsoft.Framework.Runtime/ExportProviders/ProjectExportProvider.cs
+++ b/src/Microsoft.Framework.Runtime/ExportProviders/ProjectExportProvider.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Framework.Runtime
                                        out IList<IMetadataReference> metadataReferences,
                                        out IList<ISourceReference> sourceReferences)
         {
-            var used = new HashSet<string>();
-            metadataReferences = new List<IMetadataReference>();
+            var references = new Dictionary<string, IMetadataReference>(StringComparer.OrdinalIgnoreCase);
+
             sourceReferences = new List<ISourceReference>();
 
             foreach (var export in dependencyExports)
@@ -116,19 +116,19 @@ namespace Microsoft.Framework.Runtime
                               libraryExportProvider,
                               targetFramework,
                               configuration,
-                              metadataReferences,
-                              sourceReferences,
-                              used);
+                              references,
+                              sourceReferences);
             }
+
+            metadataReferences = references.Values.ToList();
         }
 
         private void ProcessExport(ILibraryExport export,
                                    ILibraryExportProvider libraryExportProvider,
                                    FrameworkName targetFramework,
                                    string configuration,
-                                   IList<IMetadataReference> metadataReferences,
-                                   IList<ISourceReference> sourceReferences,
-                                   HashSet<string> used)
+                                   IDictionary<string, IMetadataReference> metadataReferences,
+                                   IList<ISourceReference> sourceReferences)
         {
             ExpandEmbeddedReferences(export.MetadataReferences);
 
@@ -148,18 +148,12 @@ namespace Microsoft.Framework.Runtime
                                       targetFramework,
                                       configuration,
                                       metadataReferences,
-                                      sourceReferences,
-                                      used);
+                                      sourceReferences);
                     }
                 }
                 else
                 {
-                    if (!used.Add(reference.Name))
-                    {
-                        continue;
-                    }
-
-                    metadataReferences.Add(reference);
+                    metadataReferences[reference.Name] = reference;
                 }
             }
 


### PR DESCRIPTION
This should unblock #288. There's still work that needs to be done with respect to the NuGetDependencyResolver returning the wrong compilation exports.
- Overwrite references with the more recent target framework
#288
