### PR TITLE
"kpm restore" prints out the dependency graph after restore

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
+++ b/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
@@ -21,6 +21,7 @@
     <Compile Include="Building\BuildManager.cs" />
     <Compile Include="Building\BuildOptions.cs" />
     <Compile Include="Colors.cs" />
+    <Compile Include="ReportExtensions.cs" />
     <Compile Include="IReport.cs" />
     <Compile Include="NuGet\CommandLine\CommandLineMachineWideSettings.cs" />
     <Compile Include="NuGet\CommandLine\Common\CommandLineConstants.cs" />

--- a/src/Microsoft.Framework.PackageManager/ReportExtensions.cs
+++ b/src/Microsoft.Framework.PackageManager/ReportExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.PackageManager
+{
+    public static class ReportExtensions
+    {
+        public static void WriteLine(this IReport report)
+        {
+            report.WriteLine(string.Empty);
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -10,6 +10,7 @@ using System.IO.Compression;
 using System.IO.Packaging;
 #endif
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -310,7 +311,52 @@ namespace Microsoft.Framework.PackageManager
             }
 
             Report.WriteLine(string.Format("{0}, {1}ms elapsed", "Restore complete".Green().Bold(), sw.ElapsedMilliseconds));
+
+            // Print the dependency graph
+            if (success)
+            {
+                var graphNum = contexts.Count;
+                for (int i = 0; i < graphNum; i++)
+                {
+                    PrintDependencyGraph(graphs[i], contexts[i].FrameworkName);
+                }
+            }
+
             return success;
+        }
+
+        private void PrintDependencyGraph(GraphNode root, FrameworkName frameworkName)
+        {
+            // Box Drawing Unicode characters:
+            // http://www.unicode.org/charts/PDF/U2500.pdf
+            const char LIGHT_HORIZONTAL = '\u2500';
+            const char LIGHT_UP_AND_RIGHT = '\u2514';
+            const char LIGHT_VERTICAL_AND_RIGHT = '\u251C';
+
+            var frameworkSuffix = string.Format(" [{0}]", frameworkName.ToString());
+            Report.WriteLine(root.Item.Match.Library.ToString() + frameworkSuffix);
+
+            Func<GraphNode, bool> isValidDependency = d => 
+                (d != null && d.Library != null && d.Item != null && d.Item.Match != null);
+            var dependencies = root.Dependencies.Where(isValidDependency).ToList();
+            var dependencyNum = dependencies.Count;
+            for (int i = 0; i < dependencyNum; i++)
+            {
+                var branchChar = LIGHT_VERTICAL_AND_RIGHT;
+                if (i == dependencyNum - 1)
+                {
+                    branchChar = LIGHT_UP_AND_RIGHT;
+                }
+
+                var name = dependencies[i].Item.Match.Library.ToString();
+                var dependencyListStr = string.Join(", ", dependencies[i].Dependencies
+                    .Where(isValidDependency)
+                    .Select(d => d.Item.Match.Library.ToString()));
+                var format = string.IsNullOrEmpty(dependencyListStr) ? "{0}{1} {2}{3}" : "{0}{1} {2} ({3})";
+                Report.WriteLine(string.Format(format,
+                    branchChar, LIGHT_HORIZONTAL, name, dependencyListStr));
+            }
+            Report.WriteLine();
         }
 
         private static void ExtractPackage(string targetPath, FileStream stream)


### PR DESCRIPTION
parent #447 

npm is using archy (https://github.com/substack/node-archy/blob/master/index.js) to print the dependency graph and I mimic the logic in archy to implement this feature.

Note that we print dependency graph for each target framework. Here are the dependency graphs for `PackageManager` itself:

```
Microsoft.Framework.PackageManager 1.0.0-SNAPSHOT [.NETFramework,Version=v4.5]
├── Microsoft.Framework.CommandLineUtils 1.0.0-SNAPSHOT
├─┬ Microsoft.Framework.Runtime 1.0.0-SNAPSHOT
│ ├─┬ Microsoft.Bcl.Metadata 1.0.11-alpha
│ │ └── Microsoft.Bcl.Immutable 1.1.20-beta
│ └── Newtonsoft.Json 5.0.8
├── Microsoft.Framework.Runtime.Common 1.0.0-SNAPSHOT
├── Microsoft.Framework.Runtime.Interfaces 1.0.0-SNAPSHOT
└─┬ Microsoft.Framework.Runtime.Roslyn 1.0.0-SNAPSHOT
  └─┬ K.Roslyn 1.0.0-alpha3-10032
    ├─┬ Microsoft.CodeAnalysis.Common 0.7.4060502-beta
    │ ├── Microsoft.Bcl.Immutable 1.1.20-beta
    │ └── Microsoft.Bcl.Metadata 1.0.11-alpha
    └── Microsoft.CodeAnalysis.CSharp 0.7.4060502-beta

Microsoft.Framework.PackageManager 1.0.0-SNAPSHOT [K,Version=v1.0]
├── Microsoft.Framework.CommandLineUtils 1.0.0-SNAPSHOT
├─┬ Microsoft.Framework.Runtime 1.0.0-SNAPSHOT
│ ├─┬ Microsoft.Bcl.Metadata 1.0.11-alpha
│ │ └── Microsoft.Bcl.Immutable 1.1.20-beta
│ └── Newtonsoft.Json 5.0.8
├── Microsoft.Framework.Runtime.Common 1.0.0-SNAPSHOT
├── Microsoft.Framework.Runtime.Interfaces 1.0.0-SNAPSHOT
├─┬ Microsoft.Framework.Runtime.Roslyn 1.0.0-SNAPSHOT
│ ├─┬ K.Roslyn 1.0.0-alpha3-10032
│ │ ├─┬ Microsoft.CodeAnalysis.Common 0.7.4060502-beta
│ │ │ ├── Microsoft.Bcl.Immutable 1.1.20-beta
│ │ │ └── Microsoft.Bcl.Metadata 1.0.11-alpha
│ │ └── Microsoft.CodeAnalysis.CSharp 0.7.4060502-beta
│ ├── System.Resources.ResourceWriter 4.0.0.0
│ ├── System.Runtime.Handles 4.0.0.0
│ └── System.Text.Encoding 4.0.20.0
├── System.Collections 4.0.10.0
├── System.Collections.Concurrent 4.0.0.0
├── System.ComponentModel 4.0.0.0
├── System.Console 4.0.0.0
├── System.Diagnostics.Debug 4.0.10.0
├── System.Diagnostics.Tools 4.0.0.0
├─┬ System.Dynamic.Runtime 4.0.0.0
│ └── System.Linq.Expressions 4.0.0.0
├── System.Globalization 4.0.10.0
├─┬ System.IO 4.0.0.0
│ └── System.Text.Encoding 4.0.10.0
├─┬ System.IO.Compression 4.0.0.0
│ └── System.Text.Encoding 4.0.10.0
├─┬ System.IO.FileSystem 4.0.10.0
│ ├── System.IO.FileSystem.Primitives 4.0.10.0
│ ├── System.Runtime.Handles 4.0.0.0
│ └── System.Text.Encoding 4.0.10.0
├── System.IO.FileSystem.Watcher 4.0.0.0
├── System.Linq 4.0.0.0
├── System.ObjectModel 4.0.0.0
├─┬ System.Reflection 4.0.10.0
│ └── System.Reflection.Primitives 4.0.0.0
├── System.Reflection.Extensions 4.0.0.0
├── System.Reflection.TypeExtensions 4.0.0.0
├── System.Resources.ResourceManager 4.0.0.0
├── System.Runtime 4.0.20.0
├── System.Runtime.Extensions 4.0.10.0
├─┬ System.Runtime.InteropServices 4.0.20.0
│ ├── System.Reflection.Primitives 4.0.0.0
│ └── System.Runtime.Handles 4.0.0.0
├── System.Runtime.Loader 4.0.0.0
├── System.Runtime.Serialization.Primitives 4.0.0.0
├── System.Security.Cryptography.Encryption 4.0.0.0
├─┬ System.Security.Cryptography.Hashing.Algorithms 4.0.0.0
│ └── System.Security.Cryptography.Hashing 4.0.0.0
├── System.Text.RegularExpressions 4.0.0.0
├── System.Threading 4.0.0.0
├── System.Threading.Timer 4.0.0.0
├── System.Threading.Tasks 4.0.10.0
├── System.Threading.Thread 4.0.0.0
├─┬ System.Xml.ReaderWriter 4.0.10.0
│ └── System.Text.Encoding 4.0.10.0
├── System.Xml.XDocument 4.0.0.0
└── System.Xml.XmlSerializer 4.0.0.0
```
