### PR TITLE
RoslynAssemblyLoader loads assembly multiple times when concurrently invoked

### DIFF
--- a/src/klr.hosting.shared/project.json
+++ b/src/klr.hosting.shared/project.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "System.ApplicationContext": "4.0.0.0",
                 "System.Collections": "4.0.10.0",
+                "System.Collections.Concurrent": "4.0.0.0",
                 "System.ComponentModel": "4.0.0.0",
                 "System.Console": "4.0.0.0",
                 "System.Diagnostics.Debug": "4.0.10.0",
@@ -24,6 +25,7 @@
                 "System.Runtime.InteropServices": "4.0.20.0",
                 "System.Runtime.Loader": "4.0.0.0",
                 "System.Text.RegularExpressions": "4.0.0.0",
+                "System.Threading": "4.0.0.0",
                 "System.Threading.Tasks": "4.0.10.0",
                 "System.Threading.ThreadPool": "4.0.10.0"
             }


### PR DESCRIPTION
The call to CompileInMemory produces a new assembly for the assembly name
every time it is invoked. Consequently when it'sinvoked concurrently, we
end up with two assemblies that represent two instances of the same
source.
