### PR TITLE
Add "kpm add" command

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Commands/AddCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/AddCommand.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Framework.Runtime;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class AddCommand
+    {
+        public string Name;
+        public string Version;
+        public string ProjectDir;
+        public IReport Report;
+
+        public bool ExecuteCommand()
+        {
+            if (string.IsNullOrEmpty(Name))
+            {
+                Report.WriteLine("Name of dependency to add is required.");
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(Version))
+            {
+                Report.WriteLine("Version of dependency to add is required.");
+                return false;
+            }
+
+            ProjectDir = ProjectDir ?? Directory.GetCurrentDirectory();
+
+            Project project;
+            if (!Project.TryGetProject(ProjectDir, out project))
+            {
+                Report.WriteLine("Unable to locate {0}.", Project.ProjectFileName);
+                return false;
+            }
+
+            var root = JObject.Parse(File.ReadAllText(project.ProjectFilePath));
+            if (root["dependencies"] == null)
+            {
+                root["dependencies"] = new JObject();
+            }
+
+            root["dependencies"][Name] = Version;
+
+            File.WriteAllText(project.ProjectFilePath, root.ToString());
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
+++ b/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
@@ -23,6 +23,7 @@
     <Compile Include="Building\BuildOptions.cs" />
     <Compile Include="Building\ProjectBuilder.cs" />
     <Compile Include="Colors.cs" />
+    <Compile Include="Commands\AddCommand.cs" />
     <Compile Include="ReportExtensions.cs" />
     <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="IReport.cs" />

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -219,6 +219,29 @@ namespace Microsoft.Framework.PackageManager
                 });
             });
 
+            app.Command("add", c =>
+            {
+                c.Description = "Add a dependency into dependencies section of project.json";
+
+                var argName = c.Argument("[name]", "Name of the dependency to add");
+                var argVersion = c.Argument("[version]", "Version of the dependency to add");
+                var argProject = c.Argument("[project]", "Path to project, default is current directory");
+                c.HelpOption("-?|-h|--help");
+
+                c.OnExecute(() =>
+                {
+                    var command = new AddCommand();
+                    command.Report = this;
+                    command.Name = argName.Value;
+                    command.Version = argVersion.Value;
+                    command.ProjectDir = argProject.Value;
+
+                    var success = command.ExecuteCommand();
+
+                    return success ? 0 : 1;
+                });
+            });
+
             return app.Execute(args);
         }
 

--- a/src/Microsoft.Framework.PackageManager/ReportExtensions.cs
+++ b/src/Microsoft.Framework.PackageManager/ReportExtensions.cs
@@ -9,5 +9,10 @@ namespace Microsoft.Framework.PackageManager
         {
             report.WriteLine(string.Empty);
         }
+
+        public static void WriteLine(this IReport report, string format, params object[] args)
+        {
+            report.WriteLine(string.Format(format, args));
+        }
     }
 }


### PR DESCRIPTION
parent #201 

Added command `kpm add [name] [version] [project]`. The `[project]` argument is optional and default value is current dir.
You can do `kpm add Newtonsoft.Json 5.0.2` to add `"Newtonsoft.Json": "5.0.2"` into `"dependencies"` section of project.json under current dir. If a `Newtonsoft.Json` dependency already exist in the `"dependencies"` section, the version information is overwritten.
