### PR TITLE
Separate pack exclusion from compile exclusion

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Framework.PackageManager.Packing
             root.Operations.Delete(TargetPath);
 
             // A set of excluded files/directories used as a filter when doing copy
-            var excludeSet = new HashSet<string>(project.ExcludeFiles, StringComparer.OrdinalIgnoreCase);
+            var excludeSet = new HashSet<string>(project.PackExcludeFiles, StringComparer.OrdinalIgnoreCase);
 
             root.Operations.Copy(project.ProjectDirectory, TargetPath, (isRoot, filePath) =>
             {

--- a/src/Microsoft.Framework.Runtime/Project.cs
+++ b/src/Microsoft.Framework.Runtime/Project.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Framework.Runtime
         internal static readonly string[] _defaultSourcePatterns = new[] { @"**\*.cs" };
         internal static readonly string[] _defaultExcludePatterns = new[] { @"obj\**\*", @"bin\**\*", @"**.csproj",
             @"**.kproj", @"**.user", @"**.vspscc", @"**.vssscc", @"**.pubxml" };
+        internal static readonly string[] _defaultPackExcludePatterns = new[] { @"obj\**\*", @"bin\**\*", @"**.csproj",
+            @"**.kproj", @"**.user", @"**.vspscc", @"**.vssscc", @"**.pubxml" };
         internal static readonly string[] _defaultPreprocessPatterns = new[] { @"compiler\preprocess\**\*.cs" };
         internal static readonly string[] _defaultSharedPatterns = new[] { @"compiler\shared\**\*.cs" };
         internal static readonly string[] _defaultResourcesPatterns = new[] { @"compiler\resources\**\*" };
@@ -67,6 +69,8 @@ namespace Microsoft.Framework.Runtime
 
         internal IEnumerable<string> ExcludePatterns { get; set; }
 
+        internal IEnumerable<string> PackExcludePatterns { get; set; }
+
         internal IEnumerable<string> PreprocessPatterns { get; set; }
 
         internal IEnumerable<string> SharedPatterns { get; set; }
@@ -98,17 +102,17 @@ namespace Microsoft.Framework.Runtime
             }
         }
 
-        public IEnumerable<string> ExcludeFiles
+        public IEnumerable<string> PackExcludeFiles
         {
             get
             {
                 string path = ProjectDirectory;
 
-                var sourceExcludeFiles = ExcludePatterns
+                var packExcludeFiles = PackExcludePatterns
                     .SelectMany(pattern => PathResolver.PerformWildcardSearch(path, pattern))
                     .ToArray();
 
-                return sourceExcludeFiles;
+                return packExcludeFiles;
             }
         }
 
@@ -151,7 +155,7 @@ namespace Microsoft.Framework.Runtime
                     .ToArray();
 
                 var excludePatterns = PreprocessPatterns.Concat(SharedPatterns).Concat(ResourcesPatterns)
-                    .Concat(ExcludePatterns).Concat(SourcePatterns)
+                    .Concat(PackExcludePatterns).Concat(SourcePatterns)
                     .Select(pattern => PathResolver.NormalizeWildcardForExcludedFiles(path, pattern))
                     .ToArray();
 
@@ -234,6 +238,7 @@ namespace Microsoft.Framework.Runtime
             // Source file patterns
             project.SourcePatterns = GetSourcePattern(rawProject, "code", _defaultSourcePatterns);
             project.ExcludePatterns = GetSourcePattern(rawProject, "exclude", _defaultExcludePatterns);
+            project.PackExcludePatterns = GetSourcePattern(rawProject, "pack-exclude", _defaultPackExcludePatterns);
             project.PreprocessPatterns = GetSourcePattern(rawProject, "preprocess", _defaultPreprocessPatterns);
             project.SharedPatterns = GetSourcePattern(rawProject, "shared", _defaultSharedPatterns);
             project.ResourcesPatterns = GetSourcePattern(rawProject, "resources", _defaultResourcesPatterns);

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Framework.Runtime.Tests
 {
     ""code"": ""*.cs;../*.cs"",
     ""exclude"": ""buggy/*.*"",
+    ""pack-exclude"": ""no_pack/*.*"",
     ""preprocess"": ""other/**/*.cs;*.cs;*.*"",
     ""shared"": ""shared/**/*.cs"",
     ""resources"": ""a.cs;foo.js""
@@ -146,6 +147,7 @@ namespace Microsoft.Framework.Runtime.Tests
 
             Assert.Equal(new[] { "*.cs", @"../*.cs" }, project.SourcePatterns);
             Assert.Equal(new[] { @"buggy/*.*" }, project.ExcludePatterns);
+            Assert.Equal(new[] { @"no_pack/*.*" }, project.PackExcludePatterns);
             Assert.Equal(new[] { @"other/**/*.cs", "*.cs", "*.*" }, project.PreprocessPatterns);
             Assert.Equal(new[] { @"shared/**/*.cs" }, project.SharedPatterns);
             Assert.Equal(new[] { "a.cs", @"foo.js" }, project.ResourcesPatterns);
@@ -158,6 +160,7 @@ namespace Microsoft.Framework.Runtime.Tests
 {
     ""code"": [""*.cs"", ""../*.cs""],
     ""exclude"": [""buggy/*.*""],
+    ""pack-exclude"": [""no_pack/*.*""],
     ""preprocess"": [""other/**/*.cs"", ""*.cs"", ""*.*""],
     ""shared"": [""shared/**/*.cs;../../shared/*.cs""],
     ""resources"": [""a.cs"", ""foo.js""]
@@ -167,6 +170,7 @@ namespace Microsoft.Framework.Runtime.Tests
 
             Assert.Equal(new[] { "*.cs", @"../*.cs" }, project.SourcePatterns);
             Assert.Equal(new[] { @"buggy/*.*" }, project.ExcludePatterns);
+            Assert.Equal(new[] { @"no_pack/*.*" }, project.PackExcludePatterns);
             Assert.Equal(new[] { @"other/**/*.cs", "*.cs", "*.*" }, project.PreprocessPatterns);
             Assert.Equal(new[] { @"shared/**/*.cs", @"../../shared/*.cs" }, project.SharedPatterns);
             Assert.Equal(new[] { "a.cs", @"foo.js" }, project.ResourcesPatterns);
@@ -183,6 +187,7 @@ namespace Microsoft.Framework.Runtime.Tests
 
             Assert.Equal(Project._defaultSourcePatterns, project.SourcePatterns);
             Assert.Equal(Project._defaultExcludePatterns, project.ExcludePatterns);
+            Assert.Equal(Project._defaultPackExcludePatterns, project.PackExcludePatterns);
             Assert.Equal(Project._defaultPreprocessPatterns, project.PreprocessPatterns);
             Assert.Equal(Project._defaultSharedPatterns, project.SharedPatterns);
             Assert.Equal(Project._defaultResourcesPatterns, project.ResourcesPatterns);


### PR DESCRIPTION
parent #469 

Now in `project.json`, we have `code-exclude` pattern and `pack-exclude` pattern. They have the same default values:

``` c#
new[] { @"obj\**\*", @"bin\**\*", @"**.csproj", @"**.kproj", @"**.user", @"**.vspscc", @"**.vssscc", @"**.pubxml" }; 
```
