### PR TITLE
Add "kpm install" command

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Commands/AddCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/AddCommand.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using Microsoft.Framework.Runtime;
 using Newtonsoft.Json.Linq;
+using NuGet;
 
 namespace Microsoft.Framework.PackageManager
 {
@@ -29,6 +29,9 @@ namespace Microsoft.Framework.PackageManager
                 return false;
             }
 
+            // Only for version validation
+            SemanticVersion.Parse(Version);
+
             ProjectDir = ProjectDir ?? Directory.GetCurrentDirectory();
 
             Project project;
@@ -47,6 +50,8 @@ namespace Microsoft.Framework.PackageManager
             root["dependencies"][Name] = Version;
 
             File.WriteAllText(project.ProjectFilePath, root.ToString());
+
+            Report.WriteLine("{0}.{1} was added to {2}.", Name, Version, Project.ProjectFileName);
 
             return true;
         }

--- a/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Framework.Runtime;
+using Microsoft.Framework.PackageManager.Restore.NuGet;
+using NuGet;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class InstallCommand
+    {
+        private readonly AddCommand _addCommand;
+        private readonly RestoreCommand _restoreCommand;
+
+        public InstallCommand(AddCommand addCmd, RestoreCommand restoreCmd)
+        {
+            _addCommand = addCmd;
+            _restoreCommand = restoreCmd;
+        }
+
+        public IReport Report { get; set; }
+
+        public async Task<bool> ExecuteCommand()
+        {
+            if (string.IsNullOrEmpty(_addCommand.Name))
+            {
+                Report.WriteLine("Name of dependency to install is required.");
+                return false;
+            }
+
+            SemanticVersion version = null;
+            if (!string.IsNullOrEmpty(_addCommand.Version))
+            {
+                version = SemanticVersion.Parse(_addCommand.Version);
+            }
+
+            // Create source provider from solution settings
+            _addCommand.ProjectDir = _addCommand.ProjectDir ?? Directory.GetCurrentDirectory();
+            var rootDir = ProjectResolver.ResolveRootDirectory(_addCommand.ProjectDir);
+            var fileSystem = new PhysicalFileSystem(Directory.GetCurrentDirectory());
+            var settings = SettingsUtils.ReadSettings(solutionDir: rootDir,
+                nugetConfigFile: null,
+                fileSystem: fileSystem,
+                machineWideSettings: new CommandLineMachineWideSettings());
+            var sourceProvider = PackageSourceBuilder.CreateSourceProvider(settings);
+
+            var effectiveSources = PackageSourceUtils.GetEffectivePackageSources(sourceProvider,
+                _restoreCommand.Sources, _restoreCommand.FallbackSources);
+
+            var packageFeeds = new List<IPackageFeed>();
+            foreach (var source in effectiveSources)
+            {
+                if (new Uri(source.Source).IsFile)
+                {
+                    packageFeeds.Add(new PackageFolder(source.Source, Report));
+                }
+                else
+                {
+                    packageFeeds.Add(new PackageFeed(
+                        source.Source, source.UserName, source.Password, _restoreCommand.NoCache, Report));
+                }
+            }
+
+            PackageInfo result = null;
+            if (version == null)
+            {
+                result = await FindLatestVersion(packageFeeds, _addCommand.Name);
+            }
+            else
+            {
+                result = await FindBestMatch(packageFeeds, _addCommand.Name, version);
+            }
+
+            if (result == null)
+            {
+                Report.WriteLine("Unable to locate {0} >= {1}", _addCommand.Name, _addCommand.Version);
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(_addCommand.Version))
+            {
+                _addCommand.Version = result.Version.ToString();
+            }
+
+            return _addCommand.ExecuteCommand() && (await _restoreCommand.ExecuteCommand());
+        }
+
+        private static async Task<PackageInfo> FindLatestVersion(IEnumerable<IPackageFeed> packageFeeds, string packageName)
+        {
+            var tasks = new List<Task<IEnumerable<PackageInfo>>>();
+            foreach (var feed in packageFeeds)
+            {
+                tasks.Add(feed.FindPackagesByIdAsync(packageName));
+            }
+            var results = (await Task.WhenAll(tasks)).SelectMany(x => x);
+            return GetMaxVersion(results);
+        }
+
+        private static PackageInfo GetMaxVersion(IEnumerable<PackageInfo> packageInfos)
+        {
+            var max = packageInfos.FirstOrDefault();
+            foreach (var packageInfo in packageInfos)
+            {
+                max = max.Version > packageInfo.Version ? max : packageInfo;
+            }
+            return max;
+        }
+
+        private static async Task<PackageInfo> FindBestMatch(IEnumerable<IPackageFeed> packageFeeds, string packageName,
+            SemanticVersion idealVersion)
+        {
+            var tasks = new List<Task<IEnumerable<PackageInfo>>>();
+            foreach (var feed in packageFeeds)
+            {
+                tasks.Add(feed.FindPackagesByIdAsync(packageName));
+            }
+            var results = (await Task.WhenAll(tasks)).SelectMany(x => x);
+
+            var bestResult = results.FirstOrDefault();
+            foreach (var result in results)
+            {
+                if (VersionUtility.ShouldUseConsidering(
+                    current: bestResult.Version,
+                    considering: result.Version,
+                    ideal: idealVersion))
+                {
+                    bestResult = result;
+                }
+            }
+            return bestResult;
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -48,59 +48,92 @@ namespace Microsoft.Framework.PackageManager
         protected internal ISettings Settings { get; set; }
         protected internal IPackageSourceProvider SourceProvider { get; set; }
 
-        public bool ExecuteCommand()
+        public async Task<bool> ExecuteCommand()
         {
-            var sw = new Stopwatch();
-            sw.Start();
-
-            var restoreDirectory = RestoreDirectory ?? Directory.GetCurrentDirectory();
-
-            var rootDirectory = ProjectResolver.ResolveRootDirectory(restoreDirectory);
-            ReadSettings(rootDirectory);
-
-            string packagesDirectory = PackageFolder;
-
-            if (string.IsNullOrEmpty(PackageFolder))
+            try
             {
-                packagesDirectory = NuGetDependencyResolver.ResolveRepositoryPath(rootDirectory);
-            }
+                var sw = Stopwatch.StartNew();
 
-            var packagesFolderFileSystem = CreateFileSystem(packagesDirectory);
-            var pathResolver = new DefaultPackagePathResolver(packagesFolderFileSystem, useSideBySidePaths: true);
-            var localRepository = new LocalPackageRepository(pathResolver, packagesFolderFileSystem);
-
-            int restoreCount = 0;
-            int successCount = 0;
-
-            if (string.IsNullOrEmpty(GlobalJsonFile))
-            {
-                var projectJsonFiles = Directory.GetFiles(restoreDirectory, "project.json", SearchOption.AllDirectories);
-                foreach (var projectJsonPath in projectJsonFiles)
+                // If the root argument is a project.json file
+                if (string.Equals(
+                    Project.ProjectFileName,
+                    Path.GetFileName(RestoreDirectory),
+                    StringComparison.OrdinalIgnoreCase))
                 {
-                    restoreCount += 1;
-                    var success = RestoreForProject(localRepository, projectJsonPath, rootDirectory, packagesDirectory).Result;
-                    if (success)
+                    RestoreDirectory = Path.GetDirectoryName(Path.GetFullPath(RestoreDirectory));
+                }
+                // If the root argument is a global.json file
+                else if (string.Equals(
+                    GlobalSettings.GlobalFileName,
+                    Path.GetFileName(RestoreDirectory),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    GlobalJsonFile = RestoreDirectory;
+                    RestoreDirectory = Path.GetDirectoryName(Path.GetFullPath(RestoreDirectory));
+                }
+                else if (!Directory.Exists(RestoreDirectory) && !string.IsNullOrEmpty(RestoreDirectory))
+                {
+                    throw new InvalidOperationException("The given root is invalid.");
+                }
+
+                var restoreDirectory = RestoreDirectory ?? Directory.GetCurrentDirectory();
+
+                var rootDirectory = ProjectResolver.ResolveRootDirectory(restoreDirectory);
+                ReadSettings(rootDirectory);
+
+                string packagesDirectory = PackageFolder;
+
+                if (string.IsNullOrEmpty(PackageFolder))
+                {
+                    packagesDirectory = NuGetDependencyResolver.ResolveRepositoryPath(rootDirectory);
+                }
+
+                var packagesFolderFileSystem = CreateFileSystem(packagesDirectory);
+                var pathResolver = new DefaultPackagePathResolver(packagesFolderFileSystem, useSideBySidePaths: true);
+                var localRepository = new LocalPackageRepository(pathResolver, packagesFolderFileSystem);
+
+                int restoreCount = 0;
+                int successCount = 0;
+
+                if (string.IsNullOrEmpty(GlobalJsonFile))
+                {
+                    var projectJsonFiles = Directory.GetFiles(restoreDirectory, "project.json", SearchOption.AllDirectories);
+                    foreach (var projectJsonPath in projectJsonFiles)
                     {
-                        successCount += 1;
+                        restoreCount += 1;
+                        var success = await RestoreForProject(localRepository, projectJsonPath, rootDirectory, packagesDirectory);
+                        if (success)
+                        {
+                            successCount += 1;
+                        }
                     }
                 }
-            }
-            else
-            {
-                restoreCount = 1;
-                var success = RestoreFromGlobalJson(localRepository, rootDirectory, packagesDirectory).Result;
-                if (success)
+                else
                 {
-                    successCount = 1;
+                    restoreCount = 1;
+                    var success = await RestoreFromGlobalJson(localRepository, rootDirectory, packagesDirectory);
+                    if (success)
+                    {
+                        successCount = 1;
+                    }
                 }
-            }
 
-            if (restoreCount > 1)
+                if (restoreCount > 1)
+                {
+                    Reports.Information.WriteLine(string.Format("Total time {0}ms", sw.ElapsedMilliseconds));
+                }
+
+                return restoreCount == successCount;
+            }
+            catch (Exception ex)
             {
-                Reports.Information.WriteLine(string.Format("Total time {0}ms", sw.ElapsedMilliseconds));
+                Reports.Information.WriteLine("----------");
+                Reports.Information.WriteLine(ex.ToString());
+                Reports.Information.WriteLine("----------");
+                Reports.Information.WriteLine("Restore failed");
+                Reports.Information.WriteLine(ex.Message);
+                return false;
             }
-
-            return restoreCount == successCount;
         }
 
         private async Task<bool> RestoreForProject(LocalPackageRepository localRepository, string projectJsonPath, string rootDirectory, string packagesDirectory)
@@ -467,21 +500,7 @@ namespace Microsoft.Framework.PackageManager
 
         private void ReadSettings(string solutionDirectory)
         {
-            // Read the solution-level settings
-            var solutionSettingsFile = Path.Combine(
-                solutionDirectory,
-                NuGetConstants.NuGetSolutionSettingsFolder);
-            var fileSystem = CreateFileSystem(solutionSettingsFile);
-
-            if (NuGetConfigFile != null)
-            {
-                NuGetConfigFile = FileSystem.GetFullPath(NuGetConfigFile);
-            }
-
-            Settings = NuGet.Settings.LoadDefaultSettings(
-                fileSystem: fileSystem,
-                configFileName: NuGetConfigFile,
-                machineWideSettings: MachineWideSettings);
+            Settings = SettingsUtils.ReadSettings(solutionDirectory, NuGetConfigFile, FileSystem, MachineWideSettings);
 
             // Recreate the source provider and credential provider
             SourceProvider = PackageSourceBuilder.CreateSourceProvider(Settings);

--- a/src/Microsoft.Framework.PackageManager/Utils/SettingsUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/SettingsUtils.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public static class SettingsUtils
+    {
+        public static ISettings ReadSettings(string solutionDir, string nugetConfigFile, IFileSystem fileSystem,
+            IMachineWideSettings machineWideSettings)
+        {
+            // Read the solution-level settings
+            var solutionSettingsFile = Path.Combine(solutionDir, NuGetConstants.NuGetSolutionSettingsFolder);
+            var fullPath = fileSystem.GetFullPath(solutionSettingsFile);
+            var solutionSettingsFileSystem = new PhysicalFileSystem(fullPath);
+
+            if (nugetConfigFile != null)
+            {
+                nugetConfigFile = fileSystem.GetFullPath(nugetConfigFile);
+            }
+
+            var settings = Settings.LoadDefaultSettings(
+                fileSystem: solutionSettingsFileSystem,
+                configFileName: nugetConfigFile,
+                machineWideSettings: machineWideSettings);
+
+            return settings;
+        }
+    }
+}


### PR DESCRIPTION
- "kpm install" accepts all arguments & options that "kpm restore" and "kpm
  add" accept
- Refactor "kpm restore" command to make it easier to be invoked by "kpm
  install"
- Add utility method to read solution settings

parent #201 

Here is the usage of "kpm install":

```
Usage: kpm install [arguments] [options]

Arguments:
  [name]     Name of the dependency to add
  [version]  Version of the dependency to add, default is the latest version.
  [project]  Path to project, default is current directory

Options:
  -s|--source <FEED>          A list of packages sources to use for this command
  -f|--fallbacksource <FEED>  A list of packages sources to use as a fallback
  -p|--proxy <ADDRESS>        The HTTP proxy to use when retrieving packages
  --no-cache                  Do not use local cache
  --packages                  Path to restore packages
  -?|-h|--help                Show help information
```
