### PR TITLE
Make "--verbose" option work for "kpm restore"

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
+++ b/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
@@ -57,6 +57,7 @@
     <Compile Include="Packing\PackRoot.cs" />
     <Compile Include="Packing\PackRuntime.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="Reports.cs" />
     <Compile Include="Restore\EmptyFrameworkResolver.cs" />
     <Compile Include="Restore\GraphModel\GraphItem.cs" />
     <Compile Include="Restore\GraphModel\GraphNode.cs" />
@@ -73,6 +74,7 @@
     <Compile Include="Restore\LocalWalkProvider.cs" />
     <Compile Include="Restore\RestoreCommand.cs" />
     <Compile Include="Restore\RestoreOperations.cs" />
+    <Compile Include="Scripts\ScriptExecutor.cs" />
     <Compile Include="Shims\ListExtensions.cs" />
     <Compile Include="Shims\ProtectedData.cs" />
   </ItemGroup>

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Framework.PackageManager
                     try
                     {
                         var command = new RestoreCommand(_environment);
-                        command.Report = this;
+                        command.Reports = new Reports()
+                        {
+                            Information = this,
+                            Verbose = optionVerbose.HasValue() ? (this as IReport) : new NullReport()
+                        };
 
                         // If the root argument is a directory
                         if (Directory.Exists(argRoot.Value))
@@ -348,6 +352,15 @@ namespace Microsoft.Framework.PackageManager
             var assembly = typeof(Program).GetTypeInfo().Assembly;
             var assemblyInformationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return assemblyInformationalVersionAttribute.InformationalVersion;
+        }
+    }
+
+    internal class NullReport : IReport
+    {
+        public void WriteLine(string message)
+        {
+            // Consume the write operation and do nothing
+            // Used when verbose option is not specified
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Reports.cs
+++ b/src/Microsoft.Framework.PackageManager/Reports.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class Reports
+    {
+        public IReport Information { get; set; }
+        public IReport Verbose { get; set; }
+    }
+}


### PR DESCRIPTION
parent #492 

I found `kpm` itself already has a `--verbose|-v` option (although it's not used). So I am reusing that global option here. It means that you should specify verbose output with `kpm --verbose restore` instead of `kpm restore --verbose`.

In this implementation, `kpm restore` (without `--verbose`) only output:
1. Attempting to resolve dependency {NAME} >= {VERSION}
2. Installing {Name} {VERSION}
3. Errors/Warnings

If you specify `--verbose` option, it outputs detailed http requests and dependency graph in addition to information above.
