### PR TITLE
Updating Roslyn compilation to default to experimental LanguageVersion

### DIFF
--- a/src/Microsoft.Framework.Runtime.Roslyn/ProjectExtensions.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/ProjectExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
                                                 ignoreCase: true,
                                                 result: out languageVersion))
             {
-                languageVersion = LanguageVersion.CSharp6;
+                languageVersion = LanguageVersion.Experimental;
             }
 
             var settings = new CompilationSettings


### PR DESCRIPTION
This allows using new language features that have been marked as ["Done"](https://roslyn.codeplex.com/wikipage?title=Language%20Feature%20Status&referringTitle=Documentation) but aren't available as part of C# 6.0 (e.g. primary constructors, declaration expressions)
