### PR TITLE
Re-enabling --packages flag which allows user to crossgen dependencies

### DIFF
--- a/src/Microsoft.Framework.Project/CrossGenManager.cs
+++ b/src/Microsoft.Framework.Project/CrossGenManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Microsoft.Framework.Runtime;
 
 namespace Microsoft.Framework.Project
 {
@@ -17,10 +18,21 @@ namespace Microsoft.Framework.Project
         public CrossgenManager(CrossgenOptions options)
         {
             _options = options;
-            _universe = BuildUniverse(options.RuntimePath, options.InputPaths);
+
+            var crossgenPaths = options.InputPaths;
+
+            if (options.Packages)
+            {
+                Console.WriteLine("Crossgen will include all package dependencies");
+                var packageRoot = NuGetDependencyResolver.ResolveRepositoryPath(Directory.GetCurrentDirectory());
+                var packageDirectories = Directory.EnumerateDirectories(packageRoot, "k10", SearchOption.AllDirectories);
+                crossgenPaths = crossgenPaths.Concat(packageDirectories);
+            }
+
+            _universe = BuildUniverse(options.RuntimePath, crossgenPaths);
         }
 
-        public bool GenerateNativeImages()
+        public CrossgenResult GenerateNativeImages()
         {
             // Generate a -> [closure]
             foreach (var assemblyInfo in _universe.Values)
@@ -32,15 +44,19 @@ namespace Microsoft.Framework.Project
                                                             .ToList();
             }
 
-            bool success = true;
+            var crossgenResult = new CrossgenResult();
 
             // Generate the native images in dependency order
             foreach (var assemblyInfo in Sort(_universe.Values))
             {
-                success = success && GenerateNativeImage(assemblyInfo);
+                GenerateNativeImage(assemblyInfo, crossgenResult);
+                if (crossgenResult.Failed)
+                {
+                    break;
+                }
             }
             
-            return success;
+            return crossgenResult;
         }
         
         private bool ExecuteCrossgen(string filename, string arguments, string assemblyName)
@@ -80,19 +96,27 @@ namespace Microsoft.Framework.Project
             return false;
         }
 
-        private bool GenerateNativeImage(AssemblyInformation assemblyInfo)
+        private void GenerateNativeImage(AssemblyInformation assemblyInfo, CrossgenResult result)
         {
             var retCrossgen = false;
-        
-            if (assemblyInfo.Closure.Any(a => !a.Generated))
-            {
-                Console.WriteLine("Skipping {0}. Because one or more dependencies failed to generate", assemblyInfo.Name);
-                return false;
-            }
 
             // Add the assembly itself to the closure
-            var closure = assemblyInfo.Closure.Select(d => d.NativeImagePath)
-                                      .Concat(new[] { assemblyInfo.AssemblyPath });
+            var closure = assemblyInfo.Closure
+                            .Where(a =>
+                            {
+                                if (a.Generated)
+                                {
+                                    return true;
+                                }
+                                else
+                                {
+                                    result.Warn();
+                                    Console.WriteLine(string.Format("WARNING: {0} depends on {1}. Dependency's native image failed to generate", assemblyInfo.Name, a.Name));
+                                    return false;
+                                }
+                            })
+                            .Select(d => d.NativeImagePath)
+                            .Concat(new[] { assemblyInfo.AssemblyPath });
 
             Console.WriteLine("Generating native images for {0}", assemblyInfo.Name);
 
@@ -127,7 +151,8 @@ namespace Microsoft.Framework.Project
             }
             else
             {
-                return false;
+                result.Fail();
+                return;
             }
 
             if (_options.Symbols)
@@ -165,7 +190,10 @@ namespace Microsoft.Framework.Project
                 retCrossgen = ExecuteCrossgen(_options.CrossgenPath, argsPdb, assemblyInfo.Name);
             }
 
-            return retCrossgen;
+            if (!retCrossgen)
+            {
+                result.Fail();
+            }
         }
 
         void OnErrorDataReceived(object sender, DataReceivedEventArgs e)

--- a/src/Microsoft.Framework.Project/CrossgenOptions.cs
+++ b/src/Microsoft.Framework.Project/CrossgenOptions.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Framework.Project
         public IEnumerable<string> InputPaths { get; set; }
         
         public bool Symbols { get; set; }
+
+        public bool Packages { get; set; }
     }
 }

--- a/src/Microsoft.Framework.Project/CrossgenResult.cs
+++ b/src/Microsoft.Framework.Project/CrossgenResult.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace Microsoft.Framework.Project
+{
+    /// <summary>
+    /// Crossgen can either pass, fail or with warning
+    /// Note that crossgen failure means a fatal error and the crossgen image may be not present or unusable
+    /// warning means the crossgen image may be incomplete
+    /// </summary>
+    public class CrossgenResult
+    {
+        public bool Failed
+        {
+            get;
+            private set;
+        }
+
+        public bool HasWarning
+        {
+            get;
+            private set;
+        }
+
+        public CrossgenResult()
+        {
+            Failed = false;
+            HasWarning = false;
+        }
+
+        public void Fail()
+        {
+            Failed = true;
+        }
+
+        public void Warn()
+        {
+            HasWarning = true;
+        }
+    }
+}

--- a/src/Microsoft.Framework.Project/Microsoft.Framework.Project.kproj
+++ b/src/Microsoft.Framework.Project/Microsoft.Framework.Project.kproj
@@ -24,6 +24,7 @@
     <Compile Include="AssemblyInformation.cs" />
     <Compile Include="CrossGenManager.cs" />
     <Compile Include="CrossgenOptions.cs" />
+    <Compile Include="CrossgenResult.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/Microsoft.Framework.Project/Program.cs
+++ b/src/Microsoft.Framework.Project/Program.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IO;
+using System;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Common.CommandLine;
 
@@ -38,6 +38,7 @@ namespace Microsoft.Framework.Project
                 var optionExePath = c.Option("--exePath", "Exe path", CommandOptionType.SingleValue);
                 var optionRuntimePath = c.Option("--runtimePath <PATH>", "Runtime path", CommandOptionType.SingleValue);
                 var optionSymbols = c.Option("--symbols", "Use symbols", CommandOptionType.NoValue);
+                var optionCrossgenPackages = c.Option("--packages", "Crossgen all dependencies", CommandOptionType.NoValue);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(() =>
@@ -47,14 +48,25 @@ namespace Microsoft.Framework.Project
                     crossgenOptions.RuntimePath = optionRuntimePath.Value();
                     crossgenOptions.CrossgenPath = optionExePath.Value();
                     crossgenOptions.Symbols = optionSymbols.HasValue();
+                    crossgenOptions.Packages = optionCrossgenPackages.HasValue();
 
                     var gen = new CrossgenManager(crossgenOptions);
-                    if (!gen.GenerateNativeImages())
+                    var crossgenResult = gen.GenerateNativeImages();
+                    if (crossgenResult.Failed)
                     {
+                        Console.WriteLine("Crossgen FAILED.");
                         return -1;
                     }
-
-                    return 0;
+                    else if (crossgenResult.HasWarning)
+                    {
+                        Console.WriteLine("Crossgen completed with warnings. Some native images may be suboptimal");
+                        return -2;
+                    }
+                    else
+                    {
+                        Console.WriteLine("Crossgen successful");
+                        return 0;
+                    }
                 });
             });
 

--- a/src/Microsoft.Framework.Runtime/NuGet/Packages/LocalPackage.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Packages/LocalPackage.cs
@@ -11,7 +11,12 @@ namespace NuGet
 {
     public abstract class LocalPackage : IPackage
     {
-        private const string ResourceAssemblyExtension = ".resources.dll";
+        private static readonly string[] ExcludedExtensions =
+        {
+            ".resources.dll",     // ResourceAssembly
+            ".ni.dll"             // NativeImage
+        };
+
         private IList<IPackageAssemblyReference> _assemblyReferences;
 
         protected LocalPackage()
@@ -263,8 +268,8 @@ namespace NuGet
                 return true;
             }
 
-            // Assembly reference must have a .dll|.exe|.winmd extension and is not a resource assembly;
-            return !filePath.EndsWith(ResourceAssemblyExtension, StringComparison.OrdinalIgnoreCase) &&
+            // Assembly reference must have a .dll|.exe|.winmd extension and is not a resource assembly or ni images;
+            return !ExcludedExtensions.Any(ext => filePath.EndsWith(ext, StringComparison.OrdinalIgnoreCase)) &&
                 Constants.AssemblyReferencesExtensions.Contains(Path.GetExtension(filePath), StringComparer.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
- Re-enabling --packages flag which allows user to crossgen dependencies
- In rare case where there is circular dependency between packages, crossgen would not terminate with error but try its best to continue and treats it circular dependent as missing dependency
- LocalPackage class should also ignore native images
