### PR TITLE
Reacting to Roslyn changes

### DIFF
--- a/src/Microsoft.Framework.Runtime.Roslyn/ProjectExtensions.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/ProjectExtensions.cs
@@ -68,7 +68,6 @@ namespace Microsoft.Framework.Runtime.Roslyn
             var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
 
             string platformValue = compilerOptions.Platform;
-            string debugSymbolsValue = compilerOptions.DebugSymbols;
             bool allowUnsafe = compilerOptions.AllowUnsafe ?? false;
             bool optimize = compilerOptions.Optimize ?? false;
             bool warningsAsErrors = compilerOptions.WarningsAsErrors ?? false;
@@ -81,21 +80,12 @@ namespace Microsoft.Framework.Runtime.Roslyn
                 platform = Platform.AnyCpu;
             }
 
-            DebugInformationKind debugInformationKind;
-            if (!Enum.TryParse<DebugInformationKind>(debugSymbolsValue,
-                                                     ignoreCase: true,
-                                                     result: out debugInformationKind))
-            {
-                debugInformationKind = DebugInformationKind.Full;
-            }
-
             ReportDiagnostic warningOption = warningsAsErrors ? ReportDiagnostic.Error : ReportDiagnostic.Default;
 
             return options.WithAllowUnsafe(allowUnsafe)
                           .WithPlatform(platform)
                           .WithGeneralDiagnosticOption(warningOption)
-                          .WithOptimizations(optimize)
-                          .WithDebugInformationKind(debugInformationKind);
+                          .WithOptimizationLevel(optimize ? OptimizationLevel.Release : OptimizationLevel.Debug);
         }
     }
 }

--- a/src/Microsoft.Framework.Runtime/CompilerOptions.cs
+++ b/src/Microsoft.Framework.Runtime/CompilerOptions.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Framework.Runtime
 
         public string LanguageVersion { get; set; }
 
-        public string DebugSymbols { get; set; }
-
         public string Platform { get; set; }
 
         public bool? AllowUnsafe { get; set; }
@@ -44,11 +42,6 @@ namespace Microsoft.Framework.Runtime
                 if (option.LanguageVersion != null)
                 {
                     result.LanguageVersion = option.LanguageVersion;
-                }
-
-                if (option.DebugSymbols != null)
-                {
-                    result.DebugSymbols = option.DebugSymbols;
                 }
 
                 if (option.Platform != null)

--- a/src/Microsoft.Framework.Runtime/Project.cs
+++ b/src/Microsoft.Framework.Runtime/Project.cs
@@ -404,14 +404,12 @@ namespace Microsoft.Framework.Runtime
             // Add default configurations
             _configurations["Debug"] = new CompilerOptions
             {
-                DebugSymbols = "full",
                 Defines = new[] { "DEBUG", "TRACE" },
                 Optimize = false
             };
 
             _configurations["Release"] = new CompilerOptions
             {
-                DebugSymbols = "pdbOnly",
                 Defines = new[] { "RELEASE", "TRACE" },
                 Optimize = true
             };
@@ -582,7 +580,6 @@ namespace Microsoft.Framework.Runtime
                 Platform = GetValue<string>(rawOptions, "platform"),
                 WarningsAsErrors = GetValue<bool?>(rawOptions, "warningsAsErrors"),
                 Optimize = GetValue<bool?>(rawOptions, "optimize"),
-                DebugSymbols = GetValue<string>(rawOptions, "debugSymbols"),
             };
 
             return options;


### PR DESCRIPTION
`DebugInformationKind` was removed from Roslyn and it looks like setting `OptimizationLevel` is equivalent. 
