### PR TITLE
Cache invalidation is hard

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost/ProcessingQueue.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/ProcessingQueue.cs
@@ -53,8 +53,7 @@ namespace Microsoft.Framework.DesignTimeHost
             {
                 try
                 {
-                    Trace.TraceInformation("[ProcessingQueue]: Send({0})", message.MessageType);
-
+                    Trace.TraceInformation("[ProcessingQueue]: Send({0})", message);
                     _writer.Write(JsonConvert.SerializeObject(message));
 
                     return true;

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
@@ -153,7 +153,10 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
         private SyntaxTree CreateSyntaxTree(string sourcePath, CSharpParseOptions parseOptions)
         {
-            return _cache.Get<SyntaxTree>(sourcePath, ctx =>
+            // The cache key needs to take the parseOptions into account
+            var cacheKey = sourcePath + string.Join(",", parseOptions.PreprocessorSymbolNames) + parseOptions.LanguageVersion;
+
+            return _cache.Get<SyntaxTree>(cacheKey, ctx =>
             {
                 ctx.Monitor(new FileWriteTimeCacheDependency(sourcePath));
 


### PR DESCRIPTION
- Fixed the cache key for syntax trees
- Re-enabled the design time host JSON output tracing (it's super useful)
