### PR TITLE
Fix missing method exception System.Net.Sockets.Socket..ctor in Mono

### DIFF
--- a/src/Microsoft.Framework.Runtime/DefaultHost.cs
+++ b/src/Microsoft.Framework.Runtime/DefaultHost.cs
@@ -168,7 +168,8 @@ namespace Microsoft.Framework.Runtime
 
             if (options.CompilationServerPort.HasValue)
             {
-                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+                socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, 0);
                 socket.Connect(new IPEndPoint(IPAddress.Loopback, options.CompilationServerPort.Value));
 
                 var networkStream = new NetworkStream(socket);


### PR DESCRIPTION
Mono has no default constructor for Socket class introduced in .NET 4.5
and KRuntime fails with:
`Missing method System.Net.Sockets.Socket::.ctor(SocketType,ProtocolType)
in assembly
  /usr/local/Cellar/kmono/3.6.1-10002/lib/mono/gac/System/4.0.0.0__b77a5c561934e089/System.dll,
referenced in assembly
  /Users/mattroberts/.kre/packages/KRE-mono45-x86.1.0.0-alpha4-10274/bin/Microsoft.Framework.Runtime.dll
Method not found: 'System.Net.Sockets.Socket..ctor'.`

Fixed with change of constructor call to existing on + setting of
DualMode property

And seems not just me struggling with that! http://stackoverflow.com/questions/25312521/trying-to-get-aspnet-vnext-working-on-a-mac-missing-method-errors
