### PR TITLE
Allow no-throw behavior when command-line parser sees an unexpected option

### DIFF
--- a/src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -134,8 +134,8 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
 
                         if (option == null)
                         {
-                            command.ShowHint();
-                            throw new Exception(string.Format("TODO: Error: unrecognized flag '{0}'", arg));
+                            HandleUnexpectedArg(command, args, index, argTypeName: "option");
+                            break;
                         }
 
                         // If we find a help/version option, show information and stop parsing
@@ -179,8 +179,8 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
 
                         if (option == null)
                         {
-                            command.ShowHint();
-                            throw new Exception(string.Format("TODO: Error: unrecognized flag '{0}'", arg));
+                            HandleUnexpectedArg(command, args, index, argTypeName: "option");
+                            break;
                         }
 
                         // If we find a help/version option, show information and stop parsing
@@ -257,17 +257,8 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
                 }
                 if (!processed)
                 {
-                    if (command._throwOnUnexpectedArg)
-                    {
-                        command.ShowHint();
-                        throw new Exception(string.Format("TODO: Error: unexpected argument '{0}'", arg));
-                    }
-                    else
-                    {
-                        // All remaining arguments are stored for further use
-                        command.RemainingArguments.AddRange(new ArraySegment<string>(args, index, args.Length - index));
-                        break;
-                    }
+                    HandleUnexpectedArg(command, args, index, argTypeName: "argument");
+                    break;
                 }
             }
 
@@ -435,6 +426,20 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
                 maxLen = arg.Name.Length > maxLen ? arg.Name.Length : maxLen;
             }
             return maxLen;
+        }
+
+        private void HandleUnexpectedArg(CommandLineApplication command, string[] args, int index, string argTypeName)
+        {
+            if (command._throwOnUnexpectedArg)
+            {
+                command.ShowHint();
+                throw new Exception(string.Format("TODO: Error: unrecognized {0} '{1}'", argTypeName, args[index]));
+            }
+            else
+            {
+                // All remaining arguments are stored for further use
+                command.RemainingArguments.AddRange(new ArraySegment<string>(args, index, args.Length - index));
+            }
         }
     }
 }

--- a/test/Microsoft.Framework.CommandLineUtils.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Framework.CommandLineUtils.Tests/CommandLineApplicationTests.cs
@@ -166,5 +166,178 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
             Assert.Equal("one", first.Values[0]);
             Assert.Equal("two", second.Values[0]);
         }
+
+        [Fact]
+        public void ThrowsExceptionOnUnexpectedArgumentByDefault()
+        {
+            var unexpectedArg = "UnexpectedArg";
+            var app = new CommandLineApplication();
+
+            app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            });
+
+            var exception = Assert.Throws<Exception>(() => app.Execute("test", unexpectedArg));
+            Assert.Equal(string.Format("TODO: Error: unrecognized {0} '{1}'", "argument", unexpectedArg),
+                exception.Message);
+        }
+
+        [Fact]
+        public void AllowNoThrowBehaviorOnUnexpectedArgument()
+        {
+            var unexpectedArg = "UnexpectedArg";
+            var app = new CommandLineApplication();
+
+            var testCmd = app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            },
+            addHelpCommand: false,
+            throwOnUnexpectedArg: false);
+
+            Assert.DoesNotThrow(() => app.Execute("test", unexpectedArg));
+            Assert.Equal(1, testCmd.RemainingArguments.Count);
+            Assert.Equal(unexpectedArg, testCmd.RemainingArguments[0]);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnUnexpectedLongOptionByDefault()
+        {
+            var unexpectedOption = "--UnexpectedOption";
+            var app = new CommandLineApplication();
+
+            app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            });
+
+            var exception = Assert.Throws<Exception>(() => app.Execute("test", unexpectedOption));
+            Assert.Equal(string.Format("TODO: Error: unrecognized {0} '{1}'", "option", unexpectedOption),
+                exception.Message);
+        }
+
+        [Fact]
+        public void AllowNoThrowBehaviorOnUnexpectedLongOption()
+        {
+            var unexpectedOption = "--UnexpectedOption";
+            var app = new CommandLineApplication();
+
+            var testCmd = app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            },
+            addHelpCommand: false,
+            throwOnUnexpectedArg: false);
+
+            Assert.DoesNotThrow(() => app.Execute("test", unexpectedOption));
+            Assert.Equal(1, testCmd.RemainingArguments.Count);
+            Assert.Equal(unexpectedOption, testCmd.RemainingArguments[0]);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnUnexpectedShortOptionByDefault()
+        {
+            var unexpectedOption = "-uexp";
+            var app = new CommandLineApplication();
+
+            app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            });
+
+            var exception = Assert.Throws<Exception>(() => app.Execute("test", unexpectedOption));
+            Assert.Equal(string.Format("TODO: Error: unrecognized {0} '{1}'", "option", unexpectedOption),
+                exception.Message);
+        }
+
+        [Fact]
+        public void AllowNoThrowBehaviorOnUnexpectedShortOption()
+        {
+            var unexpectedOption = "-uexp";
+            var app = new CommandLineApplication();
+
+            var testCmd = app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            },
+            addHelpCommand: false,
+            throwOnUnexpectedArg: false);
+
+            Assert.DoesNotThrow(() => app.Execute("test", unexpectedOption));
+            Assert.Equal(1, testCmd.RemainingArguments.Count);
+            Assert.Equal(unexpectedOption, testCmd.RemainingArguments[0]);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnUnexpectedSymbolOptionByDefault()
+        {
+            var unexpectedOption = "-?";
+            var app = new CommandLineApplication();
+
+            app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            });
+
+            var exception = Assert.Throws<Exception>(() => app.Execute("test", unexpectedOption));
+            Assert.Equal(string.Format("TODO: Error: unrecognized {0} '{1}'", "option", unexpectedOption),
+                exception.Message);
+        }
+
+        [Fact]
+        public void AllowNoThrowBehaviorOnUnexpectedSymbolOption()
+        {
+            var unexpectedOption = "-?";
+            var app = new CommandLineApplication();
+
+            var testCmd = app.Command("test", c =>
+            {
+                c.OnExecute(() => 0);
+            },
+            addHelpCommand: false,
+            throwOnUnexpectedArg: false);
+
+            Assert.DoesNotThrow(() => app.Execute("test", unexpectedOption));
+            Assert.Equal(1, testCmd.RemainingArguments.Count);
+            Assert.Equal(unexpectedOption, testCmd.RemainingArguments[0]);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnUnexpectedOptionBeforeValidSubcommandByDefault()
+        {
+            var unexpectedOption = "--unexpected";
+            CommandLineApplication subCmd = null;
+            var app = new CommandLineApplication();
+
+            app.Command("k", c =>
+            {
+                subCmd = c.Command("run", _=> { });
+                c.OnExecute(() => 0);
+            });
+
+            var exception = Assert.Throws<Exception>(() => app.Execute("k", unexpectedOption, "run"));
+            Assert.Equal(string.Format("TODO: Error: unrecognized {0} '{1}'", "option", unexpectedOption),
+                exception.Message);
+        }
+
+        [Fact]
+        public void AllowNoThrowBehaviorOnUnexpectedOptionAfterSubcommand()
+        {
+            var unexpectedOption = "--unexpected";
+            CommandLineApplication subCmd = null;
+            var app = new CommandLineApplication();
+
+            var testCmd = app.Command("k", c =>
+            {
+                subCmd = c.Command("run", _ => { }, addHelpCommand: false, throwOnUnexpectedArg: false);
+                c.OnExecute(() => 0);
+            });
+
+            Assert.DoesNotThrow(() => app.Execute("k", "run", unexpectedOption));
+            Assert.Equal(0, testCmd.RemainingArguments.Count);
+            Assert.Equal(1, subCmd.RemainingArguments.Count);
+            Assert.Equal(unexpectedOption, subCmd.RemainingArguments[0]);
+        }
     }
 }


### PR DESCRIPTION
parent #520 
