### PR TITLE
Cached assembly neutral interfaces that come from assemblies

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
@@ -485,9 +485,8 @@ namespace Microsoft.Framework.DesignTimeHost
                                                                     appPath,
                                                                     packagesDirectory: null,
                                                                     configuration: configuration,
-                                                                    targetFramework: targetFramework);
-
-            applicationHostContext.AddService(typeof(ICache), _cache);
+                                                                    targetFramework: targetFramework,
+                                                                    cache: _cache);
 
             Project project = applicationHostContext.Project;
 

--- a/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
@@ -29,9 +29,8 @@ namespace Microsoft.Framework.PackageManager
                 projectDirectory: project.ProjectDirectory,
                 packagesDirectory: null,
                 configuration: configuration,
-                targetFramework: targetFramework);
-
-            _applicationHostContext.AddService(typeof(ICache), cache);
+                targetFramework: targetFramework,
+                cache: cache);
         }
 
         public void Initialize()

--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Framework.PackageManager.Packing
                     projectDirectory: projectDirectory,
                     packagesDirectory: null,
                     configuration: configuration,
-                    targetFramework: targetFramework);
+                    targetFramework: targetFramework,
+                    cache: new Cache());
 
                 ProjectResolver = applicationHostContext.ProjectResolver;
                 NuGetDependencyResolver = applicationHostContext.NuGetDependencyProvider;

--- a/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Framework.Runtime
                                       string projectDirectory,
                                       string packagesDirectory,
                                       string configuration,
-                                      FrameworkName targetFramework)
+                                      FrameworkName targetFramework,
+                                      ICache cache)
         {
             ProjectDirectory = projectDirectory;
             RootDirectory = Runtime.ProjectResolver.ResolveRootDirectory(ProjectDirectory);
@@ -56,8 +57,8 @@ namespace Microsoft.Framework.Runtime
 
             _serviceProvider.Add(typeof(NuGetDependencyResolver), NuGetDependencyProvider);
             _serviceProvider.Add(typeof(ProjectReferenceDependencyProvider), ProjectDepencyProvider);
-            _serviceProvider.Add(typeof(ILibraryManager), new LibraryManager(targetFramework, configuration, DependencyWalker, compositeDependencyExporter));
-            _serviceProvider.Add(typeof(ICache), new Cache());
+            _serviceProvider.Add(typeof(ILibraryManager), new LibraryManager(targetFramework, configuration, DependencyWalker, compositeDependencyExporter, cache));
+            _serviceProvider.Add(typeof(ICache), cache);
         }
 
         public void AddService(Type type, object instance)

--- a/src/Microsoft.Framework.Runtime/DefaultHost.cs
+++ b/src/Microsoft.Framework.Runtime/DefaultHost.cs
@@ -131,7 +131,8 @@ namespace Microsoft.Framework.Runtime
                 _projectDirectory,
                 options.PackageDirectory,
                 options.Configuration,
-                _targetFramework);
+                _targetFramework,
+                new Cache());
 
             Trace.TraceInformation("[{0}]: Project path: {1}", GetType().Name, _projectDirectory);
             Trace.TraceInformation("[{0}]: Project root: {1}", GetType().Name, _applicationHostContext.RootDirectory);

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryManager.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryManager.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Framework.Runtime
         private readonly FrameworkName _targetFramework;
         private readonly string _configuration;
         private readonly ILibraryExportProvider _libraryExportProvider;
+        private readonly ICache _cache;
         private readonly Func<IEnumerable<ILibraryInformation>> _libraryInfoThunk;
         private readonly object _initializeLock = new object();
         private Dictionary<string, IEnumerable<ILibraryInformation>> _inverse;
@@ -22,23 +23,27 @@ namespace Microsoft.Framework.Runtime
         public LibraryManager(FrameworkName targetFramework,
                               string configuration,
                               DependencyWalker dependencyWalker,
-                              ILibraryExportProvider libraryExportProvider)
+                              ILibraryExportProvider libraryExportProvider,
+                              ICache cache)
             : this(targetFramework,
                    configuration,
                    GetLibraryInfoThunk(dependencyWalker),
-                   libraryExportProvider)
+                   libraryExportProvider,
+                   cache)
         {
         }
 
         public LibraryManager(FrameworkName targetFramework,
                               string configuration,
                               Func<IEnumerable<ILibraryInformation>> libraryInfoThunk,
-                              ILibraryExportProvider libraryExportProvider)
+                              ILibraryExportProvider libraryExportProvider,
+                              ICache cache)
         {
             _targetFramework = targetFramework;
             _configuration = configuration;
             _libraryInfoThunk = libraryInfoThunk;
             _libraryExportProvider = libraryExportProvider;
+            _cache = cache;
         }
 
         private Dictionary<string, ILibraryInformation> LibraryLookup
@@ -89,6 +94,7 @@ namespace Microsoft.Framework.Runtime
         public ILibraryExport GetAllExports(string name)
         {
             return ProjectExportProviderHelper.GetExportsRecursive(
+                _cache,
                 this,
                 _libraryExportProvider,
                 name,

--- a/src/Microsoft.Framework.Runtime/ExportProviders/ProjectLibraryExportProvider.cs
+++ b/src/Microsoft.Framework.Runtime/ExportProviders/ProjectLibraryExportProvider.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Framework.Runtime
 
                     // Get the exports for the project dependencies
                     var projectExport = new Lazy<ILibraryExport>(() => ProjectExportProviderHelper.GetExportsRecursive(
+                        cache,
                         libraryManager,
                         exportProvider,
                         project.Name,

--- a/test/Microsoft.Framework.Runtime.Tests/LibraryManagerFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/LibraryManagerFacts.cs
@@ -57,7 +57,19 @@ namespace Microsoft.Framework.Runtime.Tests
                 new LibraryInformation("MyApp", new[] { "DI", "Hosting", "Mvc", "HttpAbstractions" })
 
             };
-            return new LibraryManager(frameworkName, "Debug", () => libraryInfo, new CompositeLibraryExportProvider(Enumerable.Empty<ILibraryExportProvider>()));
+            return new LibraryManager(frameworkName, 
+                                      "Debug", 
+                                      () => libraryInfo, 
+                                      new CompositeLibraryExportProvider(Enumerable.Empty<ILibraryExportProvider>()),
+                                      new EmptyCache());
+        }
+
+        private class EmptyCache : ICache
+        {
+            public object Get(object key, Func<CacheContext, object> factory)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
- This helps because the ANIs were changing for each compilation.
  Now the design time host wont' send anything back to VS if nothing changed
  (at least for ANIs coming from disk).
#534
