### PR TITLE
Make mono run as .NET 4.5.1

### DIFF
--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -71,6 +71,17 @@ namespace Microsoft.Framework.Runtime
 
         public ILibraryExport GetLibraryExport(string name, FrameworkName targetFramework, string configuration)
         {
+            // Did we even resolve this name, if not then do nothing
+            if (!_resolvedPaths.ContainsKey(name))
+            {
+                return null;
+            }
+
+            // We can't use resolved paths since it might be different to the target framework
+            // being passed in here. After we know this resolver is handling the 
+            // requested name, we can call back into the FrameworkResolver to figure out
+            //  the specific path for the target framework
+
             string path;
             if (FrameworkResolver.TryGetAssembly(name, targetFramework, out path))
             {

--- a/src/klr.host/Bootstrapper.cs
+++ b/src/klr.host/Bootstrapper.cs
@@ -56,7 +56,8 @@ namespace klr.host
             var framework = Environment.GetEnvironmentVariable("TARGET_FRAMEWORK") ?? Environment.GetEnvironmentVariable("KRE_FRAMEWORK");
             var configuration = Environment.GetEnvironmentVariable("TARGET_CONFIGURATION") ?? Environment.GetEnvironmentVariable("KRE_CONFIGURATION") ?? "Debug";
 
-            var targetFramework = FrameworkNameUtility.ParseFrameworkName(framework ?? (PlatformHelper.IsMono ? "net45" : "net451"));
+            // TODO: Support the highest installed version
+            var targetFramework = FrameworkNameUtility.ParseFrameworkName("net451");
 
             var applicationEnvironment = new ApplicationEnvironment(applicationBaseDirectory,
                                                                     targetFramework,


### PR DESCRIPTION
- Turns out mono's 4.5 profile (for the versions of mono we support)
  is actually compatible with .NET 4.5.1.
- Fix problem with compiling against reference assemblies
  that were not resolved via dependency resolution.
#511
#374

This should make @Praburaj happy :smile: 
