### PR TITLE
"kpm restore --quiet" hides HTTP requests/cache information

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Framework.PackageManager
                     CommandOptionType.SingleValue);
                 var optNoCache = c.Option("--no-cache", "Do not use local cache", CommandOptionType.NoValue);
                 var optPackageFolder = c.Option("--packages", "Path to restore packages", CommandOptionType.SingleValue);
+                var optQuiet = c.Option("--quiet", "Do not show output such as HTTP request/cache information",
+                    CommandOptionType.NoValue);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(async () =>
@@ -72,6 +74,10 @@ namespace Microsoft.Framework.PackageManager
                         Information = this,
                         Verbose = optionVerbose.HasValue() ? (this as IReport) : new NullReport()
                     };
+
+                    // If "--verbose" and "--quiet" are specified together, "--verbose" wins
+                    command.Reports.Quiet = optQuiet.HasValue() ? command.Reports.Verbose : this;
+
                     command.RestoreDirectory = argRoot.Value;
                     command.Sources = optSource.Values;
                     command.FallbackSources = optFallbackSource.Values;
@@ -356,14 +362,14 @@ namespace Microsoft.Framework.PackageManager
             var assemblyInformationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return assemblyInformationalVersionAttribute.InformationalVersion;
         }
-    }
 
-    internal class NullReport : IReport
-    {
-        public void WriteLine(string message)
+        private class NullReport : IReport
         {
-            // Consume the write operation and do nothing
-            // Used when verbose option is not specified
+            public void WriteLine(string message)
+            {
+                // Consume the write operation and do nothing
+                // Used when verbose option is not specified
+            }
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Reports.cs
+++ b/src/Microsoft.Framework.PackageManager/Reports.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Framework.PackageManager
     {
         public IReport Information { get; set; }
         public IReport Verbose { get; set; }
+        public IReport Quiet { get; set; }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Framework.PackageManager
                         new RemoteWalkProvider(
                             new PackageFolder(
                                 source.Source,
-                                Reports.Information)));
+                                Reports.Quiet)));
                 }
                 else
                 {
@@ -431,7 +431,7 @@ namespace Microsoft.Framework.PackageManager
                                 source.UserName,
                                 source.Password,
                                 NoCache,
-                                Reports.Information)));
+                                Reports.Quiet)));
                 }
             }
         }


### PR DESCRIPTION
parent #577 

An interesting usage mentioned by @davidfowl  is `kpm --verbose restore --quiet`. For my implementation, in this case, `--verbose` wins and here is the reason:
If `--quiet` wins, `kpm restore` blocks without showing HTTP requests/cache information. So the user might not notice that he mistakenly specified `--verbose` and `--quiet` together because he might think that `kpm restore` is blocking for some silent operations.
If `--verbose` wins, we show a bunch of HTTP request/cache information instantly after the user hit Enter key. So the user can easily notice he specified `--verbose`. The basic idea is that we make the behavior obvious & quick enough to draw users' attention.

@Eilon , do you like the idea above? Or we can give an error saying `--verbose` and `--quiet` are mutually exclusive.
