### PR TITLE
"kpm pack" identifies source files outside of project root and packs them

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
@@ -69,6 +69,35 @@ namespace Microsoft.Framework.PackageManager.Packing
 
                 return true;
             });
+
+            // We can reference source files outside of project root with "code" property in project.json,
+            // e.g. { "code" : "..\\ExternalProject\\**.cs" }
+            // So we find out external source files and copy them separately
+            var rootDirectory = ProjectResolver.ResolveRootDirectory(project.ProjectDirectory);
+            foreach (var sourceFile in project.SourceFiles)
+            {
+                // This source file is in project root directory. So it was already copied.
+                if (PathUtility.IsChildOfDirectory(dir: project.ProjectDirectory, candidate: sourceFile))
+                {
+                    continue;
+                }
+
+                // This source file is in solution root but out of project root,
+                // it is an external source file that we should copy here
+                if (PathUtility.IsChildOfDirectory(dir: rootDirectory, candidate: sourceFile))
+                {
+                    // Keep the relativeness between external source files and project root,
+                    var relativeSourcePath = PathUtility.GetRelativePath(project.ProjectFilePath, sourceFile);
+                    var relativeParentDir = Path.GetDirectoryName(relativeSourcePath);
+                    Directory.CreateDirectory(Path.Combine(TargetPath, relativeParentDir));
+                    File.Copy(sourceFile, Path.Combine(TargetPath, relativeSourcePath));
+                }
+                else
+                {
+                    Console.WriteLine(
+                        string.Format("TODO: Warning: the referenced source file '{0}' is not in solution root and it is not packed to output.", sourceFile));
+                }
+            }
         }
 
         public void EmitNupkg(PackRoot root)
@@ -265,6 +294,5 @@ root.Configuration));
             var index2 = (relativePath + Path.AltDirectorySeparatorChar).IndexOf(Path.AltDirectorySeparatorChar);
             return relativePath.Substring(0, Math.Min(index1, index2));
         }
-
     }
 }

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/PathUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/PathUtility.cs
@@ -8,18 +8,20 @@ namespace NuGet
 {
     public static class PathUtility
     {
-        public static bool IsSubdirectory(string basePath, string path)
+        public static bool IsChildOfDirectory(string dir, string candidate)
         {
-            if (basePath == null)
+            if (dir == null)
             {
-                throw new ArgumentNullException("basePath");
+                throw new ArgumentNullException("dir");
             }
-            if (path == null)
+            if (candidate == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException("candidate");
             }
-            basePath = basePath.TrimEnd(Path.DirectorySeparatorChar);
-            return path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase);
+            dir = Path.GetFullPath(dir);
+            dir = EnsureTrailingSlash(dir);
+            candidate = Path.GetFullPath(candidate);
+            return candidate.StartsWith(dir, StringComparison.OrdinalIgnoreCase);
         }
 
         public static string EnsureTrailingSlash(string path)

--- a/test/Microsoft.Framework.Runtime.Tests/PathUtilityFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/PathUtilityFacts.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using NuGet;
+using Xunit;
+
+namespace Microsoft.Framework.Runtime.Tests
+{
+    public class PathUtilityFacts
+    {
+        [Fact]
+        public void IsChildOfDirectoryWorksWithRelativePath()
+        {
+            var baseDir = @"..\BaseDir\";
+            var childPath = @"..\BaseDir\ChildFile";
+            var nonChildPath = @"..\AnotherBaseDir\NonChildFile";
+
+            Assert.True(PathUtility.IsChildOfDirectory(baseDir, childPath));
+            Assert.False(PathUtility.IsChildOfDirectory(baseDir, nonChildPath));
+        }
+
+        [Fact]
+        public void IsChildOfDirectoryWorksWithAbsolutePath()
+        {
+            var baseDir = @"C:\Test\BaseDir\";
+            var childPath = @"C:\Test\BaseDir\ChildFile";
+            var nonChildPath = @"C:\Test\AnotherBaseDir\NonChildFile";
+
+            Assert.True(PathUtility.IsChildOfDirectory(baseDir, childPath));
+            Assert.False(PathUtility.IsChildOfDirectory(baseDir, nonChildPath));
+        }
+
+        [Fact]
+        public void IsChildOfDirectoryWorksOnBaseDirWithoutTrailingPathSeparator()
+        {
+            var baseDir = @"..\foo";
+            var childPath = @"..\foo\ChildFile";
+            var nonChildPath = @"..\food\NonChildFile";
+
+            Assert.True(PathUtility.IsChildOfDirectory(baseDir, childPath));
+            Assert.False(PathUtility.IsChildOfDirectory(baseDir, nonChildPath));
+        }
+    }
+}


### PR DESCRIPTION
parent #570 

The original implementation only packs source files inside project root dir. In this PR, if a source file is out of project root dir but in the solution dir, we pack it as well.
