### PR TITLE
Add environment variable to set application base on mono

### DIFF
--- a/src/klr.host/Bootstrapper.cs
+++ b/src/klr.host/Bootstrapper.cs
@@ -45,10 +45,19 @@ namespace klr.host
             }
 
 #if NET45
-            // REVIEW: Need a way to set the application base on mono
-            string applicationBaseDirectory = PlatformHelper.IsMono ?
-                                              Directory.GetCurrentDirectory() :
-                                              AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
+            string applicationBaseDirectory;
+            if (PlatformHelper.IsMono)
+            {
+                applicationBaseDirectory = Environment.GetEnvironmentVariable("KRE_APPBASE");
+                if (string.IsNullOrEmpty(applicationBaseDirectory))
+                {
+                    applicationBaseDirectory = Directory.GetCurrentDirectory();
+                }
+            }
+            else
+            {
+                applicationBaseDirectory = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
+            }
 #else
             string applicationBaseDirectory = ApplicationContext.BaseDirectory;
 #endif

--- a/src/klr/klr.cpp
+++ b/src/klr/klr.cpp
@@ -42,6 +42,15 @@ int CallFirmwareProcessMain(int argc, wchar_t* argv[])
     data.argc = argc - 1;
     data.argv = const_cast<LPCWSTR*>(&argv[1]);
 
+    // Get application base from KRE_APPBASE environment variable
+    // Note: this value can be overriden by --appbase option
+    TCHAR szAppBase[MAX_PATH];
+    DWORD dwAppBase = GetEnvironmentVariableW(L"KRE_APPBASE", szAppBase, MAX_PATH);
+    if (dwAppBase != 0)
+    {
+        data.applicationBase = szAppBase;
+    }
+
     auto stringsEqual = [](const wchar_t*  const a, const wchar_t*  const b) -> bool
     {
         return ::_wcsicmp(a, b) == 0;


### PR DESCRIPTION
parent #580 

You can specify application base with environment variable `K_MONO_APPBASE` on mono.
