### PR TITLE
Add $MONO_OPTIONS as the mono runtime arguments. It is common practice in mono

### DIFF
--- a/scripts/klr.sh
+++ b/scripts/klr.sh
@@ -9,7 +9,7 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 if [ -f "$DIR/mono" ]; then
-  "$DIR/mono" "$DIR/klr.mono.managed.dll" "$@"
+  "$DIR/mono" $MONO_OPTIONS "$DIR/klr.mono.managed.dll" "$@"
 else
-  mono "$DIR/klr.mono.managed.dll" "$@"
+  mono $MONO_OPTIONS "$DIR/klr.mono.managed.dll" "$@"
 fi


### PR DESCRIPTION
This would be useful when debugging, tracing profiling with mono runtime (for example, "MONO_OPTIONS=--debug k Kestrel" would give you source location within stack trace, if the debug symbols exist).
