### PR TITLE
Make NullReport a public class

### DIFF
--- a/src/Microsoft.Framework.PackageManager/NullReport.cs
+++ b/src/Microsoft.Framework.PackageManager/NullReport.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class NullReport : IReport
+    {
+        public void WriteLine(string message)
+        {
+            // Consume the write operation and do nothing
+            // Used when verbose option is not specified
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -369,14 +369,5 @@ namespace Microsoft.Framework.PackageManager
             var assemblyInformationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return assemblyInformationalVersionAttribute.InformationalVersion;
         }
-
-        private class NullReport : IReport
-        {
-            public void WriteLine(string message)
-            {
-                // Consume the write operation and do nothing
-                // Used when verbose option is not specified
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR is a response to @davidfowl 's previous feedback at
https://github.com/aspnet/KRuntime/commit/ae336d911251223b876d84fa7e85f9ae26a0e1f1#commitcomment-7264560

Making `NullReport` public is better than making it private because scaffolding wants to reuse `NullReport`.
