### PR TITLE
"kpm pack" shows warnings when dependencies are missing

### DIFF
--- a/src/Microsoft.Framework.Runtime/DefaultHost.cs
+++ b/src/Microsoft.Framework.Runtime/DefaultHost.cs
@@ -62,29 +62,9 @@ namespace Microsoft.Framework.Runtime
             // If there's any unresolved dependencies then complain
             if (_applicationHostContext.UnresolvedDependencyProvider.UnresolvedDependencies.Any())
             {
-                var sb = new StringBuilder();
-
-                // TODO: Localize messages
-
-                sb.AppendLine("Failed to resolve the following dependencies:");
-
-                foreach (var d in _applicationHostContext.UnresolvedDependencyProvider.UnresolvedDependencies.OrderBy(d => d.Identity.Name))
-                {
-                    sb.AppendLine("   " + d.Identity.ToString());
-                }
-
-                sb.AppendLine();
-                sb.AppendLine("Searched Locations:");
-
-                foreach (var path in _applicationHostContext.UnresolvedDependencyProvider.GetAttemptedPaths(_targetFramework))
-                {
-                    sb.AppendLine("  " + path);
-                }
-
-                sb.AppendLine();
-                sb.AppendLine("Try running 'kpm restore'.");
-
-                throw new InvalidOperationException(sb.ToString());
+                var exceptionMsg = _applicationHostContext.UnresolvedDependencyProvider.GetMissingDependenciesWarning(
+                    _targetFramework);
+                throw new InvalidOperationException(exceptionMsg);
             }
 
             return Assembly.Load(new AssemblyName(applicationName));

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
+using System.Text;
 using NuGet;
 
 namespace Microsoft.Framework.Runtime
@@ -38,6 +39,34 @@ namespace Microsoft.Framework.Runtime
         {
             return AttemptedProviders.Where(p => p != this)
                                      .SelectMany(p => p.GetAttemptedPaths(targetFramework));
+        }
+
+        public string GetMissingDependenciesWarning(FrameworkName targetFramework)
+        {
+            var sb = new StringBuilder();
+
+            // TODO: Localize messages
+
+            sb.AppendFormat("Failed to resolve the following dependencies for target framework '{0}':", targetFramework.ToString());
+            sb.AppendLine();
+
+            foreach (var d in UnresolvedDependencies.OrderBy(d => d.Identity.Name))
+            {
+                sb.AppendLine("   " + d.Identity.ToString());
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("Searched Locations:");
+
+            foreach (var path in GetAttemptedPaths(targetFramework))
+            {
+                sb.AppendLine("  " + path);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("Try running 'kpm restore'.");
+
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
parent #544 

Strictly followed instructions from parent issue #544 . If there are missing dependencies, we output warning and keep working. So it does the same amount of work as previous implementation. `kpm pack` exits with exit code `-1` when there are missing dependencies.
