### PR TITLE
Fix external source files reference with "code" pattern in project.json

### DIFF
--- a/src/Microsoft.Framework.Runtime/NuGet/Authoring/PathResolver.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Authoring/PathResolver.cs
@@ -233,17 +233,20 @@ namespace NuGet
 
         internal static string NormalizeBasePath(string basePath, ref string searchPath)
         {
-            const string relativePath = @"..\";
+            const string relativePathBackSlash = @"..\";
+            const string relativePathForwardSlash = "../";
 
             // If no base path is provided, use the current directory.
-            basePath = String.IsNullOrEmpty(basePath) ? @".\" : basePath;
+            basePath = String.IsNullOrEmpty(basePath) ? "./" : basePath;
 
             // If the search path is relative, transfer the ..\ portion to the base path. 
             // This needs to be done because the base path determines the root for our enumeration.
-            while (searchPath.StartsWith(relativePath, StringComparison.OrdinalIgnoreCase))
+            while (searchPath.StartsWith(relativePathBackSlash, StringComparison.OrdinalIgnoreCase) ||
+                searchPath.StartsWith(relativePathForwardSlash, StringComparison.OrdinalIgnoreCase))
             {
-                basePath = Path.Combine(basePath, relativePath);
-                searchPath = searchPath.Substring(relativePath.Length);
+                // Forward slash works on both Windows and *nix
+                basePath = Path.Combine(basePath, relativePathForwardSlash);
+                searchPath = searchPath.Substring(relativePathForwardSlash.Length).Replace('\\', '/');
             }
 
             return Path.GetFullPath(basePath);


### PR DESCRIPTION
- Reference external source files with forward slashes on Windows works now
- Reference external source files with backslashes on Mono works now

parent #559 

It also doesn't work if you use backslashes in `code` pattern on Mono to reference source files outside project root. This PR fix the problem at the same time.
