### PR TITLE
Print full path of nuspec when opening local package feeds

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/KpmPackageFolder.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/KpmPackageFolder.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
         public Task<Stream> OpenNuspecStreamAsync(PackageInfo package)
         {
             var nuspecPath = _pathResolver.GetManifestFilePath(package.Id, package.Version);
+            _report.WriteLine(string.Format("  OPEN {0}", _fileSystem.GetFullPath(nuspecPath)));
             return Task.FromResult<Stream>(File.Open(nuspecPath, FileMode.Open));
         }
 


### PR DESCRIPTION
Response to @davidfowl 's comments at https://github.com/aspnet/KRuntime/pull/609/files#r17280288
