### PR TITLE
K crossgen broken - runtimePath parameter is optional and should be allowed to be empty

### DIFF
--- a/src/Microsoft.Framework.Project/CrossGenManager.cs
+++ b/src/Microsoft.Framework.Project/CrossGenManager.cs
@@ -180,8 +180,9 @@ namespace Microsoft.Framework.Project
 
         private static IDictionary<string, AssemblyInformation> BuildUniverse(string runtimePath, IEnumerable<string> paths)
         {
-            var procArch = ResolveProcessorArchitecture(Path.GetDirectoryName(runtimePath));
-            var runtimeAssemblies = Directory.EnumerateFiles(Path.GetFullPath(runtimePath), "*.dll")
+            var activeRuntimePath = Path.GetFullPath(runtimePath);
+            var procArch = ResolveProcessorArchitecture(Path.GetDirectoryName(activeRuntimePath));
+            var runtimeAssemblies = Directory.EnumerateFiles(activeRuntimePath, "*.dll")
                                              .Where(AssemblyInformation.IsValidImage)
                                              .Select(path => new AssemblyInformation(path, procArch) { IsRuntimeAssembly = true });
 


### PR DESCRIPTION
Build broke because script does not pass in runtime path parameters. We should allow this use case
