### PR TITLE
Rename IApplicationEnvironment.TargetFramework to RuntimeFramework

### DIFF
--- a/src/Microsoft.Framework.ApplicationHost/Program.cs
+++ b/src/Microsoft.Framework.ApplicationHost/Program.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Framework.ApplicationHost
             }
             if (string.Equals(key, "env:TargetFramework", StringComparison.OrdinalIgnoreCase))
             {
-                return _environment.TargetFramework.Identifier;
+                return _environment.RuntimeFramework.Identifier;
             }
             return Environment.GetEnvironmentVariable(key);
         }
@@ -153,7 +153,7 @@ namespace Microsoft.Framework.ApplicationHost
             defaultHostOptions.WatchFiles = optionWatch.HasValue();
             defaultHostOptions.PackageDirectory = optionPackages.Value();
 
-            defaultHostOptions.TargetFramework = _environment.TargetFramework;
+            defaultHostOptions.TargetFramework = _environment.RuntimeFramework;
             defaultHostOptions.Configuration = optionConfiguration.Value() ?? _environment.Configuration ?? "Debug";
             defaultHostOptions.ApplicationBaseDirectory = _environment.ApplicationBasePath;
             var portValue = optionCompilationServer.Value() ?? Environment.GetEnvironmentVariable("KRE_COMPILATION_SERVER_PORT");

--- a/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Framework.PackageManager
             var host = new DefaultHost(new DefaultHostOptions()
             {
                 ApplicationBaseDirectory = project.ProjectDirectory,
-                TargetFramework = applicationEnvironment.TargetFramework,
+                TargetFramework = applicationEnvironment.RuntimeFramework,
                 Configuration = applicationEnvironment.Configuration
             },
             _hostServices);

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Framework.PackageManager
                         ProjectDir = argProject.Value ?? System.IO.Directory.GetCurrentDirectory(),
                         AppFolder = optionAppFolder.Value(),
                         Configuration = optionConfiguration.Value() ?? "Debug",
-                        RuntimeTargetFramework = _environment.TargetFramework,
+                        RuntimeTargetFramework = _environment.RuntimeFramework,
                         Overwrite = optionOverwrite.HasValue(),
                         NoSource = optionNoSource.HasValue(),
                         Runtimes = optionRuntime.HasValue() ?
@@ -154,7 +154,7 @@ namespace Microsoft.Framework.PackageManager
                 c.OnExecute(() =>
                 {
                     var buildOptions = new BuildOptions();
-                    buildOptions.RuntimeTargetFramework = _environment.TargetFramework;
+                    buildOptions.RuntimeTargetFramework = _environment.RuntimeFramework;
                     buildOptions.OutputDir = optionOut.Value();
                     buildOptions.ProjectDir = argProjectDir.Value ?? Directory.GetCurrentDirectory();
                     buildOptions.Configurations = optionConfiguration.Values;

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Framework.PackageManager
             {
                 contexts.Add(new RestoreContext
                 {
-                    FrameworkName = ApplicationEnvironment.TargetFramework,
+                    FrameworkName = ApplicationEnvironment.RuntimeFramework,
                     ProjectLibraryProviders = projectProviders,
                     LocalLibraryProviders = localProviders,
                     RemoteLibraryProviders = remoteProviders,
@@ -281,7 +281,7 @@ namespace Microsoft.Framework.PackageManager
 
             var context = new RestoreContext
             {
-                FrameworkName = ApplicationEnvironment.TargetFramework,
+                FrameworkName = ApplicationEnvironment.RuntimeFramework,
                 ProjectLibraryProviders = new List<IWalkProvider>(),
                 LocalLibraryProviders = localProviders,
                 RemoteLibraryProviders = remoteProviders,

--- a/src/Microsoft.Framework.Runtime.Interfaces/IApplicationEnvironment.cs
+++ b/src/Microsoft.Framework.Runtime.Interfaces/IApplicationEnvironment.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Framework.Runtime
         string Version { get; }
         string ApplicationBasePath { get; }
         string Configuration { get; }
-        FrameworkName TargetFramework { get; }
+        FrameworkName RuntimeFramework { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime/ApplicationEnvironment.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationEnvironment.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Framework.Runtime
         public string Configuration { get; private set; }
 
 
-        public FrameworkName TargetFramework
+        public FrameworkName RuntimeFramework
         {
             get { return _targetFramework; }
         }

--- a/src/klr.host/ApplicationEnvironment.cs
+++ b/src/klr.host/ApplicationEnvironment.cs
@@ -15,7 +15,7 @@ namespace klr.host
             ApplicationName = assemblyName.Name;
             Version = assemblyName.Version.ToString();
             ApplicationBasePath = appBase;
-            TargetFramework = targetFramework;
+            RuntimeFramework = targetFramework;
             Configuration = configuration;
         }
 
@@ -43,7 +43,7 @@ namespace klr.host
             private set;
         }
 
-        public FrameworkName TargetFramework
+        public FrameworkName RuntimeFramework
         {
             get;
             private set;


### PR DESCRIPTION
parent #149 

Also renamed related variables & methods. Names related to the protocol used by DTH (e.g. `ChangeTargetFrameworkMessage`, ) are not renamed because we don't want to break Tooling for now.
