### PR TITLE
Add '--wwwroot' and '--wwwroot-out' option to "kpm pack"

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -106,6 +106,31 @@ namespace Microsoft.Framework.PackageManager.Packing
                 return false;
             }
 
+            // '--wwwroot' option can override 'webroot' property in project.json
+            _options.WwwRoot = _options.WwwRoot ?? project.WebRoot;
+            _options.WwwRootOut = _options.WwwRootOut ?? _options.WwwRoot;
+
+            if (string.IsNullOrEmpty(_options.WwwRoot) && !string.IsNullOrEmpty(_options.WwwRootOut))
+            {
+                Console.WriteLine("'--wwwroot-out' option can be used only when the '--wwwroot' option or 'webroot' in project.json is specified.");
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(_options.WwwRoot) &&
+                !Directory.Exists(Path.Combine(project.ProjectDirectory, _options.WwwRoot)))
+            {
+                Console.WriteLine("The specified wwwroot folder '{0}' doesn't exist in the project directory.",
+                    _options.WwwRoot);
+                return false;
+            }
+
+            if (string.Equals(_options.WwwRootOut, PackRoot.AppRootName, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine("'{0}' is a reserved folder name. Please choose another name for the wwwroot-out folder.",
+                    PackRoot.AppRootName);
+                return false;
+            }
+
             var sw = Stopwatch.StartNew();
 
             string outputPath = _options.OutputDir ?? Path.Combine(_options.ProjectDir, "bin", "output");
@@ -206,7 +231,8 @@ namespace Microsoft.Framework.PackageManager.Packing
                         var packProject = new PackProject(dependencyContext.ProjectReferenceDependencyProvider, dependencyContext.ProjectResolver, libraryDescription);
                         if (packProject.Name == project.Name)
                         {
-                            packProject.AppFolder = _options.AppFolder;
+                            packProject.WwwRoot = _options.WwwRoot;
+                            packProject.WwwRootOut = _options.WwwRootOut;
                         }
                         root.Projects.Add(packProject);
                     }

--- a/src/Microsoft.Framework.PackageManager/Packing/PackOptions.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackOptions.cs
@@ -12,9 +12,11 @@ namespace Microsoft.Framework.PackageManager.Packing
 
         public string ProjectDir { get; set; }
 
-        public string AppFolder { get; set; }
-
         public string Configuration { get; set; }
+
+        public string WwwRoot { get; set; }
+
+        public string WwwRootOut { get; set; }
 
         public FrameworkName RuntimeTargetFramework { get; set; }
 

--- a/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Framework.PackageManager.Packing
     {
         private readonly Runtime.Project _project;
         public static readonly string AppRootName = "approot";
-        public static readonly string DefaultAppFolderName = "public";
 
         public PackRoot(Runtime.Project project, string outputPath, IServiceProvider hostServices)
         {

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -101,10 +101,13 @@ namespace Microsoft.Framework.PackageManager
                     CommandOptionType.NoValue);
                 var optionRuntime = c.Option("--runtime <KRE>", "Names or paths to KRE files to include",
                     CommandOptionType.MultipleValue);
-                var optionAppFolder = c.Option("--appfolder <NAME>",
-                    "Determine the name of the application primary folder", CommandOptionType.SingleValue);
                 var optionNative = c.Option("--native", "Build and include native images. User must provide targeted CoreCLR runtime versions along with this option.",
                     CommandOptionType.NoValue);
+                var optionWwwRoot = c.Option("--wwwroot <NAME>", "Name of public folder in the project directory",
+                    CommandOptionType.SingleValue);
+                var optionWwwRootOut = c.Option("--wwwroot-out <NAME>",
+                    "Name of public folder in the packed image, can be used only when the '--wwwroot' option or 'webroot' in project.json is specified",
+                    CommandOptionType.SingleValue);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(() =>
@@ -118,9 +121,10 @@ namespace Microsoft.Framework.PackageManager
                     {
                         OutputDir = optionOut.Value(),
                         ProjectDir = argProject.Value ?? System.IO.Directory.GetCurrentDirectory(),
-                        AppFolder = optionAppFolder.Value(),
                         Configuration = optionConfiguration.Value() ?? "Debug",
                         RuntimeTargetFramework = _environment.RuntimeFramework,
+                        WwwRoot = optionWwwRoot.Value(),
+                        WwwRootOut = optionWwwRootOut.Value() ?? optionWwwRoot.Value(),
                         Overwrite = optionOverwrite.HasValue(),
                         NoSource = optionNoSource.HasValue(),
                         Runtimes = optionRuntime.HasValue() ?


### PR DESCRIPTION
- '--wwwroot' specifies the name of public folder in project dir
- '--wwwroot-out' specifies the name of public folder in packed image
- '--appfolder' is replaced by '--wwwroot-out'
- If '--wwwroot-out' is not specified, the packed image doesn't contain a public
  folder

parent #543 
Also implement part of #541 , that is, if `--wwwroot-out` doesn't have a value, we don't create public folder in packed image.
