### PR TITLE
Make "kpm restore" case-sensitive

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/KpmPackageFolder.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/KpmPackageFolder.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
             string physicalPath,
             IReport report)
         {
-            _repository = new PackageRepository(physicalPath);
+            // We need to help "kpm restore" to ensure case-sensitivity here
+            // Turn on the flag to get package ids in accurate casing
+            _repository = new PackageRepository(physicalPath, checkPackageIdCase: true);
             _fileSystem = new PhysicalFileSystem(physicalPath);
             _pathResolver = new DefaultPackagePathResolver(_fileSystem);
             _report = report;

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/PackageFeed.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/PackageFeed.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
     public class PackageFeed : IPackageFeed
     {
         static readonly XName _xnameEntry = XName.Get("entry", "http://www.w3.org/2005/Atom");
+        static readonly XName _xnameTitle = XName.Get("title", "http://www.w3.org/2005/Atom");
         static readonly XName _xnameContent = XName.Get("content", "http://www.w3.org/2005/Atom");
         static readonly XName _xnameLink = XName.Get("link", "http://www.w3.org/2005/Atom");
         static readonly XName _xnameProperties = XName.Get("properties", "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata");
@@ -137,7 +138,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 
             return new PackageInfo
             {
-                Id = id,
+                Id = element.Element(_xnameTitle).Value,
                 Version = SemanticVersion.Parse(properties.Element(_xnameVersion).Value),
                 ContentUri = element.Element(_xnameContent).Attribute("src").Value,
             };

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Framework.PackageManager
             Reports.Information.WriteLine(string.Format("{0}, {1}ms elapsed", "Resolving complete".Green(), sw.ElapsedMilliseconds));
 
             var installItems = new List<GraphItem>();
-            var missingItems = new List<Library>();
+            var missingItems = new HashSet<Library>();
             ForEach(graphs, node =>
             {
                 if (node == null || node.Library == null)
@@ -223,10 +223,20 @@ namespace Microsoft.Framework.PackageManager
                 }
                 if (node.Item == null || node.Item.Match == null)
                 {
-                    if (node.Library.Version != null && !missingItems.Contains(node.Library))
+                    if (node.Library.Version != null && missingItems.Add(node.Library))
                     {
-                        missingItems.Add(node.Library);
                         Reports.Information.WriteLine(string.Format("Unable to locate {0} >= {1}", node.Library.Name.Red().Bold(), node.Library.Version));
+                        success = false;
+                    }
+                    return;
+                }
+                // "kpm restore" is case-sensitive
+                if (!string.Equals(node.Item.Match.Library.Name, node.Library.Name, StringComparison.Ordinal))
+                {
+                    if (missingItems.Add(node.Library))
+                    {
+                        Reports.Information.WriteLine("Unable to locate {0} >= {1}. Do you mean {2}?",
+                            node.Library.Name.Red().Bold(), node.Library.Version, node.Item.Match.Library.Name.Bold());
                         success = false;
                     }
                     return;

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Framework.Runtime
 
         public NuGetDependencyResolver(string packagesPath, IFrameworkReferenceResolver frameworkReferenceResolver)
         {
-            _repository = new PackageRepository(packagesPath);
+            // Runtime already ensures case-sensitivity, so we don't need package ids in accurate casing here
+            _repository = new PackageRepository(packagesPath, checkPackageIdCase: false);
             _frameworkReferenceResolver = frameworkReferenceResolver;
             Dependencies = Enumerable.Empty<LibraryDescription>();
         }


### PR DESCRIPTION
parent #581 

Shows user-friendly warning:
`Unable to locate System.console >= 4.0.0.0. Do you mean System.Console?`
