### PR TITLE
Add functional tests for "kpm pack"

### DIFF
--- a/KRuntime.sln
+++ b/KRuntime.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22111.0
+VisualStudioVersion = 14.0.22207.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{189961D1-DFF4-406A-9D42-39B61221A73A}"
 	ProjectSection(SolutionItems) = preProject
@@ -64,6 +64,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		global.json = global.json
 	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.PackageManager.FunctionalTests", "test\Microsoft.Framework.PackageManager.FunctionalTests\Microsoft.Framework.PackageManager.FunctionalTests.kproj", "{C8404BE7-504E-477C-BC29-41A49B1BCBD9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -382,6 +384,20 @@ Global
 		{7E6564C3-04E3-418C-B96A-463FE2906F09}.Release|Win32.ActiveCfg = Release|Any CPU
 		{7E6564C3-04E3-418C-B96A-463FE2906F09}.Release|x64.ActiveCfg = Release|Any CPU
 		{7E6564C3-04E3-418C-B96A-463FE2906F09}.Release|x86.ActiveCfg = Release|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|Win32.ActiveCfg = Release|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|x64.ActiveCfg = Release|Any CPU
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -409,5 +425,6 @@ Global
 		{68048350-2996-4B4A-90BE-3405F088BD5A} = {13ED5001-B871-4BC3-8499-29607F596C7C}
 		{0D752D1C-3985-4E27-92C4-0BEE72B1F58D} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 		{7E6564C3-04E3-418C-B96A-463FE2906F09} = {C43EE429-DE10-4906-BB09-54E6A080948A}
+		{C8404BE7-504E-477C-BC29-41A49B1BCBD9} = {C43EE429-DE10-4906-BB09-54E6A080948A}
 	EndGlobalSection
 EndGlobal

--- a/makefile.shade
+++ b/makefile.shade
@@ -34,7 +34,7 @@ var MSBUILD = '${Path.Combine(PROGRAM_FILES_X86, "MSBuild", "14.0", "Bin", "MSBu
 
 #package-runtime .clean-sdk-dir .copy-bits .tweak-scripts .copy-package-dependencies .copy-coreclr-kpm-dependencies .copy-coreclr .nuget-pack-runtime target='package'
 
-#rebuild-package .build-mono-entrypoint .build-compile .native-compile .xunit-test .package-runtime
+#rebuild-package .build-mono-entrypoint .build-compile .native-compile .package-runtime .xunit-test
 
 #native-compile target='compile' if='!IsMono'
   var nativeProjects ='${Files.Include(Path.Combine(ROOT, "src", "**", "*.vcxproj"))}'

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DirTree.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DirTree.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class DirTree
+    {
+        private JObject _json;
+        private Dictionary<string, string> _pathToContents;
+
+        public DirTree(string json)
+        {
+            _json = JObject.Parse(json);
+            _pathToContents = new Dictionary<string, string>();
+        }
+
+        public DirTree WithFileContents(string relativePath, string contents)
+        {
+            _pathToContents.Add(relativePath, contents);
+            return this;
+        }
+
+        public DirTree WriteTo(string rootDirPath)
+        {
+            Directory.CreateDirectory(rootDirPath);
+            WriteToCore(_json, rootDirPath);
+
+            foreach (var pair in _pathToContents)
+            {
+                var path = Path.Combine(rootDirPath, pair.Key);
+                if (File.Exists(path))
+                {
+                    File.WriteAllText(path, pair.Value);
+                }
+                else
+                {
+                    var message = string.Format("'{0}' is not in created directory structure.", pair.Key);
+                    throw new Exception(message);
+                }
+            }
+
+            return this;
+        }
+
+        public bool MatchDirectoryOnDisk(string dirPath, bool compareFileContents = true)
+        {
+            // Flatten this directory structure into the dictionary _pathToContents
+            FlattenJsonToDictionary();
+
+            if (!string.IsNullOrEmpty(dirPath))
+            {
+                dirPath = dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar ?
+                        dirPath : dirPath + Path.DirectorySeparatorChar;
+            }
+
+            var dirFileList = Directory.GetFiles(dirPath, "*.*", SearchOption.AllDirectories)
+                .Select(x => x.Substring(dirPath.Length));
+
+            if (_pathToContents.Count != dirFileList.Count())
+            {
+                Console.WriteLine("Number of files in '{0}' is {1}, while expected number is {2}.",
+                    dirPath, dirFileList.Count(), _pathToContents.Count);
+                return false;
+            }
+
+            foreach (var file in dirFileList)
+            {
+                if (!_pathToContents.ContainsKey(file))
+                {
+                    Console.WriteLine("Expecting '{0}', which doesn't exist in '{1}'", file, dirPath);
+                    return false;
+                }
+
+                var fullPath = Path.Combine(dirPath, file);
+                var onDiskFileContents = File.ReadAllText(fullPath);
+                if (!string.Equals(onDiskFileContents, _pathToContents[file]))
+                {
+                    Console.WriteLine("The contents of '{0}' don't match expected contents.", fullPath);
+                    Console.WriteLine("Expected:");
+                    Console.WriteLine(_pathToContents[file]);
+                    Console.WriteLine("Actual:");
+                    Console.WriteLine(onDiskFileContents);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private void FlattenJsonToDictionary()
+        {
+            FlattenJsonToDictionaryCore(_json, path:  string.Empty);
+        }
+
+        private void FlattenJsonToDictionaryCore(JObject dirObj, string path)
+        {
+            foreach (var property in dirObj.Properties())
+            {
+                var relativePath = Path.Combine(path, string.Equals(property.Name, ".") ? string.Empty : property.Name);
+
+                if (property.Value is JValue)
+                {
+                    // The contents specified with WithFileContents() override contents in original JSON
+                    // If there are already contents for this file, the contents are specified by WithFileContents()
+                    // So we ignore original contents here
+                    if (!_pathToContents.ContainsKey(relativePath))
+                    {
+                        _pathToContents.Add(relativePath, property.Value.ToString());
+                    }
+                }
+                else if (property.Value is JArray)
+                {
+                    foreach (var element in (property.Value as JArray))
+                    {
+                        var elementFilePath = Path.Combine(relativePath, (element as JValue).Value.ToString());
+                        if (!_pathToContents.ContainsKey(elementFilePath))
+                        {
+                            _pathToContents.Add(elementFilePath, string.Empty);
+                        }
+                    }
+                }
+                else if (property.Value is JObject)
+                {
+                    FlattenJsonToDictionaryCore(property.Value as JObject, relativePath);
+                }
+            }
+        }
+
+        private void WriteToCore(JObject dirObj, string path)
+        {
+            foreach (var property in dirObj.Properties())
+            {
+                // If value of the property is a string, the name of this property represents
+                // a file and the value represents the contents of the file
+                if (property.Value is JValue)
+                {
+                    File.WriteAllText(Path.Combine(path, property.Name), property.Value.ToString());
+                }
+                // If value of the property is an array, the name of this property represents
+                // a directory and the value represents a list of empty files in the directory
+                else if (property.Value is JArray)
+                {
+                    Directory.CreateDirectory(Path.Combine(path, property.Name));
+                    foreach (var element in (property.Value as JArray))
+                    {
+                        var elementValue = (element as JValue).ToString();
+                        File.WriteAllText(Path.Combine(path, property.Name, elementValue), string.Empty);
+                    }
+                }
+                // If value of the property is an object, the name of this property represents
+                // a directory and the value is processed recursively as a sub-directory
+                else if (property.Value is JObject)
+                {
+                    Directory.CreateDirectory(Path.Combine(path, property.Name));
+                    WriteToCore(property.Value as JObject, Path.Combine(path, property.Name));
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmPackTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmPackTests.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.Framework.Runtime;
+using Xunit;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class KpmPackTests : IDisposable
+    {
+        private readonly string _projectName = "TestProject";
+        private readonly string _outputDirName = "PackOutput";
+        private readonly string _frameworksRoot;
+
+        public KpmPackTests()
+        {
+            _frameworksRoot = TestUtils.CreateTempDir();
+            var kRuntimeRoot = ProjectResolver.ResolveRootDirectory(Directory.GetCurrentDirectory());
+            var buildArtifactDir = Path.Combine(kRuntimeRoot, "artifacts", "build");
+            TestUtils.UnpackFrameworksToDir(buildArtifactDir, destination: _frameworksRoot);
+        }
+
+        public void Dispose()
+        {
+            TestUtils.DeleteFolder(_frameworksRoot);
+        }
+
+        [Fact]
+        public void KpmPackWebApp_RootAsPublicFolder()
+        {
+            var projectStructure = @"{
+  '.': ['project.json', 'Config.json', 'Program.cs', 'build_config1.bconfig'],
+  'Views': {
+    'Home': ['index.cshtml'],
+    'Shared': ['_Layout.cshtml']
+  },
+  'Controllers': ['HomeController.cs'],
+  'Models': ['User.cs', 'build_config2.bconfig'],
+  'Build': ['build_config3.bconfig'],
+  'packages': {}
+}";
+            var expectedOutputStructure = @"{
+  'wwwroot': {
+    '.': ['project.json', 'Config.json', 'Program.cs', 'build_config1.bconfig', 'k.ini'],
+      'Views': {
+        'Home': ['index.cshtml'],
+        'Shared': ['_Layout.cshtml']
+    },
+    'Controllers': ['HomeController.cs'],
+    'Models': ['User.cs', 'build_config2.bconfig'],
+    'Build': ['build_config3.bconfig']
+  },
+  'approot': {
+    'global.json': '',
+    'src': {
+      'PROJECT_NAME': {
+        '.': ['project.json', 'Config.json', 'Program.cs'],
+          'Views': {
+            'Home': ['index.cshtml'],
+            'Shared': ['_Layout.cshtml']
+        },
+        'Controllers': ['HomeController.cs'],
+        'Models': ['User.cs']
+      }
+    }
+  }
+}".Replace("PROJECT_NAME", _projectName);
+
+            foreach (var framework in Directory.EnumerateDirectories(_frameworksRoot))
+            {
+                using (var testEnv = new KpmTestEnvironment(_projectName, _outputDirName))
+                {
+                    TestUtils.CreateDirTree(projectStructure)
+                        .WithFileContents("project.json", @"{
+  ""pack-exclude"": ""**.bconfig"",
+  ""webroot"": ""to_be_overridden""
+}")
+                        .WriteTo(testEnv.ProjectPath);
+
+                    var environment = new Dictionary<string, string>()
+                    {
+                        { "KRE_PACKAGES", Path.Combine(testEnv.ProjectPath, "packages") }
+                    };
+
+                    var exitCode = TestUtils.ExecKpm(
+                        krePath: framework,
+                        subcommand: "pack",
+                        arguments: string.Format("--out {0} --wwwroot . --wwwroot-out wwwroot",
+                            testEnv.PackOutputDirPath),
+                        environment: environment,
+                        workingDir: testEnv.ProjectPath);
+                    Assert.Equal(0, exitCode);
+
+                    var expectedOutputDir = TestUtils.CreateDirTree(expectedOutputStructure)
+                        .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
+  ""pack-exclude"": ""**.bconfig"",
+  ""webroot"": ""WEB_ROOT""
+}".Replace("WEB_ROOT", Path.Combine("..", "..", "..", "wwwroot").Replace(@"\", @"\\")))
+                        .WithFileContents(Path.Combine("wwwroot", "project.json"), @"{
+  ""pack-exclude"": ""**.bconfig"",
+  ""webroot"": ""to_be_overridden""
+}")
+                        .WithFileContents(Path.Combine("wwwroot", "k.ini"), @"KRE_APPBASE=..\approot\src\"
+                            + testEnv.ProjectName)
+                        .WithFileContents(Path.Combine("approot", "global.json"), @"{
+  ""dependencies"": {},
+  ""packages"": ""packages""
+}");
+                    Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.PackOutputDirPath,
+                        compareFileContents: true));
+                }
+            }
+        }
+
+        [Fact]
+        public void KpmPackWebApp_SubfolderAsPublicFolder()
+        {
+            var projectStructure = @"{
+  '.': ['project.json', 'Config.json', 'Program.cs'],
+  'public': {
+    'Scripts': ['bootstrap.js', 'jquery.js'],
+    'Images': ['logo.png'],
+    'UselessFolder': ['file.useless']
+  },
+  'Views': {
+    'Home': ['index.cshtml'],
+    'Shared': ['_Layout.cshtml']
+  },
+  'Controllers': ['HomeController.cs'],
+  'UselessFolder': ['file.useless'],
+  'packages': {}
+}";
+            var expectedOutputStructure = @"{
+  'wwwroot': {
+    'k.ini': '',
+    'Scripts': ['bootstrap.js', 'jquery.js'],
+    'Images': ['logo.png'],
+    'UselessFolder': ['file.useless']
+  },
+  'approot': {
+    'global.json': '',
+    'src': {
+      'PROJECT_NAME': {
+        '.': ['project.json', 'Config.json', 'Program.cs'],
+          'Views': {
+            'Home': ['index.cshtml'],
+            'Shared': ['_Layout.cshtml']
+        },
+        'Controllers': ['HomeController.cs'],
+      }
+    }
+  }
+}".Replace("PROJECT_NAME", _projectName);
+
+            foreach (var framework in Directory.EnumerateDirectories(_frameworksRoot))
+            {
+                using (var testEnv = new KpmTestEnvironment(_projectName, _outputDirName))
+                {
+                    TestUtils.CreateDirTree(projectStructure)
+                        .WithFileContents("project.json", @"{
+  ""pack-exclude"": ""**.useless"",
+  ""webroot"": ""public""
+}")
+                        .WriteTo(testEnv.ProjectPath);
+
+                    var environment = new Dictionary<string, string>()
+                    {
+                        { "KRE_PACKAGES", Path.Combine(testEnv.ProjectPath, "packages") }
+                    };
+
+                    var exitCode = TestUtils.ExecKpm(
+                        krePath: framework,
+                        subcommand: "pack",
+                        arguments: string.Format("--out {0} --wwwroot-out wwwroot",
+                            testEnv.PackOutputDirPath),
+                        environment: environment,
+                        workingDir: testEnv.ProjectPath);
+                    Assert.Equal(0, exitCode);
+
+                    var expectedOutputDir = TestUtils.CreateDirTree(expectedOutputStructure)
+                        .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
+  ""pack-exclude"": ""**.useless"",
+  ""webroot"": ""WEB_ROOT""
+}".Replace("WEB_ROOT", Path.Combine("..", "..", "..", "wwwroot").Replace(@"\", @"\\")))
+                        .WithFileContents(Path.Combine("wwwroot", "k.ini"), @"KRE_APPBASE=..\approot\src\"
+                            + testEnv.ProjectName)
+                        .WithFileContents(Path.Combine("approot", "global.json"), @"{
+  ""dependencies"": {},
+  ""packages"": ""packages""
+}");
+                    Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.PackOutputDirPath,
+                        compareFileContents: true));
+                }
+            }
+        }
+
+        [Fact]
+        public void KpmPackConsoleApp()
+        {
+            var projectStructure = @"{
+  '.': ['project.json', 'Config.json', 'Program.cs'],
+  'Data': {
+    'Input': ['data1.dat', 'data2.dat'],
+    'Backup': ['backup1.dat', 'backup2.dat']
+  },
+  'packages': {}
+}";
+            var expectedOutputStructure = @"{
+  'approot': {
+    'global.json': '',
+    'src': {
+      'PROJECT_NAME': {
+        '.': ['project.json', 'Config.json', 'Program.cs'],
+          'Data': {
+            'Input': ['data1.dat', 'data2.dat']
+          }
+        }
+      }
+    }
+  }".Replace("PROJECT_NAME", _projectName);
+
+            foreach (var framework in Directory.EnumerateDirectories(_frameworksRoot))
+            {
+                using (var testEnv = new KpmTestEnvironment(_projectName, _outputDirName))
+                {
+                    TestUtils.CreateDirTree(projectStructure)
+                        .WithFileContents("project.json", @"{
+  ""pack-exclude"": ""Data/Backup/**""
+}")
+                        .WriteTo(testEnv.ProjectPath);
+
+                    var environment = new Dictionary<string, string>()
+                    {
+                        { "KRE_PACKAGES", Path.Combine(testEnv.ProjectPath, "packages") }
+                    };
+
+                    var exitCode = TestUtils.ExecKpm(
+                        krePath: framework,
+                        subcommand: "pack",
+                        arguments: string.Format("--out {0}",
+                            testEnv.PackOutputDirPath),
+                        environment: environment,
+                        workingDir: testEnv.ProjectPath);
+                    Assert.Equal(0, exitCode);
+
+                    var expectedOutputDir = TestUtils.CreateDirTree(expectedOutputStructure)
+                        .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
+  ""pack-exclude"": ""Data/Backup/**""
+}")
+                        .WithFileContents(Path.Combine("approot", "global.json"), @"{
+  ""dependencies"": {},
+  ""packages"": ""packages""
+}");
+                    Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.PackOutputDirPath,
+                        compareFileContents: true));
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmTestEnvironment.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmTestEnvironment.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class KpmTestEnvironment : IDisposable
+    {
+        private readonly string _projectName;
+        private readonly string _outputDirName;
+
+        public KpmTestEnvironment(string projectName = null, string outputDirName = null)
+        {
+            _projectName = projectName ?? "ProjectName";
+            _outputDirName = outputDirName ?? "OutputDirName";
+            RootDir = TestUtils.CreateTempDir();
+        }
+
+        public string RootDir { get; private set; }
+
+        public string ProjectName
+        {
+            get
+            {
+                return _projectName;
+            }
+        }
+
+        public string ProjectPath
+        {
+            get
+            {
+                return Path.Combine(RootDir, ProjectName);
+            }
+        }
+
+        public string PackOutputDirName
+        {
+            get
+            {
+                return _outputDirName;
+            }
+        }
+
+        public string PackOutputDirPath
+        {
+            get
+            {
+                return Path.Combine(RootDir, PackOutputDirName);
+            }
+        }
+
+        public void Dispose()
+        {
+            TestUtils.DeleteFolder(RootDir);
+        }
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/Microsoft.Framework.PackageManager.FunctionalTests.kproj
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/Microsoft.Framework.PackageManager.FunctionalTests.kproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="__ToolsVersion__" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c8404be7-504e-477c-bc29-41a49b1bcbd9</ProjectGuid>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/Project.json
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/Project.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": {
+        "Microsoft.Framework.Runtime.Common": "1.0.0-*",
+        "Xunit.KRunner": "1.0.0-*"
+    },
+
+    "frameworks": {
+        "aspnet50": { }
+    },
+
+    "commands": {
+        "test": "Xunit.KRunner"
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/TestUtils.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/TestUtils.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Framework.Runtime;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public static class TestUtils
+    {
+        public static DirTree CreateDirTree(string json)
+        {
+            return new DirTree(json);
+        }
+
+        public static string CreateTempDir()
+        {
+            var tempDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDirPath);
+            return tempDirPath;
+        }
+
+        public static int ExecKpm(string krePath, string subcommand, string arguments,
+            IDictionary<string, string> environment = null, string workingDir = null)
+        {
+            string program, commandLine;
+            if (PlatformHelper.IsMono)
+            {
+                program = Path.Combine(krePath, "bin", "kpm");
+                commandLine = string.Format("{0} {1}", subcommand, arguments);
+            }
+            else
+            {
+                program = "cmd";
+                var kpmCmdPath = Path.Combine(krePath, "bin", "kpm.cmd");
+                commandLine = string.Format("/C {0} {1} {2}", kpmCmdPath, subcommand, arguments);
+            }
+            return Exec(program, commandLine, environment, workingDir);
+        }
+
+        public static int Exec(string program, string commandLine,
+            IDictionary<string, string> environment = null, string workingDir = null)
+        {
+            var processStartInfo = new ProcessStartInfo()
+            {
+                UseShellExecute = false,
+                WorkingDirectory = workingDir,
+                FileName = program,
+                Arguments = commandLine,
+            };
+
+            if (environment != null)
+            {
+                foreach (var pair in environment)
+                {
+                    processStartInfo.EnvironmentVariables[pair.Key] = pair.Value;
+                }
+            }
+
+            var process = Process.Start(processStartInfo);
+            process.WaitForExit();
+
+            return process.ExitCode;
+        }
+
+        public static void UnpackFrameworksToDir(string buildArtifactDir, string destination)
+        {
+            var kreNupkgs = new List<string>();
+            kreNupkgs.Add(Directory.GetFiles(buildArtifactDir, "KRE-CLR-amd64.*.nupkg", SearchOption.TopDirectoryOnly).First());
+            kreNupkgs.Add(Directory.GetFiles(buildArtifactDir, "KRE-CLR-x86.*.nupkg", SearchOption.TopDirectoryOnly).First());
+            kreNupkgs.Add(Directory.GetFiles(buildArtifactDir, "KRE-CoreCLR-amd64.*.nupkg", SearchOption.TopDirectoryOnly).First());
+            kreNupkgs.Add(Directory.GetFiles(buildArtifactDir, "KRE-CoreCLR-x86.*.nupkg", SearchOption.TopDirectoryOnly).First());
+            foreach (var nupkg in kreNupkgs)
+            {
+                var kreName = Path.GetFileNameWithoutExtension(nupkg);
+                var krePath = Path.Combine(destination, kreName);
+                Directory.CreateDirectory(krePath);
+                System.IO.Compression.ZipFile.ExtractToDirectory(nupkg, krePath);
+            }
+        }
+
+        public static void DeleteFolder(string path)
+        {
+            var retryNum = 3;
+            for (int i = 0; i < retryNum; i++)
+            {
+                try
+                {
+                    Directory.Delete(path, recursive: true);
+                    return;
+                }
+                catch (Exception)
+                {
+                    if (i == retryNum - 1)
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please help to review functional tests for `kpm pack` @Eilon @davidfowl @lodejard @Praburaj.

I made utils that can create fake projects (directory tree) based on a directory structure represented by JSON. We can also represent an expected output directory structure with JSON and verify whether the actual output matches the expected output.
