### PR TITLE
Normalize path to output dir before "kpm pack"

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Framework.PackageManager.Packing
             _hostServices = hostServices;
             _options = options;
             _options.ProjectDir = Normalize(_options.ProjectDir);
+            _options.OutputDir = Normalize(_options.OutputDir);
             ScriptExecutor = new ScriptExecutor();
         }
 


### PR DESCRIPTION
parent #646 

@lodejard , thank you for your help. I reproduced the bug with KExpense project. The root cause is that value of `--out` is `artifacts\\_PublishedWebsites\KExpense`, which is not well-formatted because it contains `\\`. I fixed this bug by normalizing the output path before any further processing.
