### PR TITLE
"kpm restore" offline should succeed if there is no dependency missing

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Framework.PackageManager
                 else
                 {
                     packageFeeds.Add(new PackageFeed(
-                        source.Source, source.UserName, source.Password, _restoreCommand.NoCache, Reports.Quiet));
+                        source.Source, source.UserName, source.Password, _restoreCommand.NoCache, Reports.Quiet,
+                        _restoreCommand.IgnoreFailedSources));
                 }
             }
 

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -64,6 +64,9 @@ namespace Microsoft.Framework.PackageManager
                 var optPackageFolder = c.Option("--packages", "Path to restore packages", CommandOptionType.SingleValue);
                 var optQuiet = c.Option("--quiet", "Do not show output such as HTTP request/cache information",
                     CommandOptionType.NoValue);
+                var optIgnoreFailedSources = c.Option("--ignore-failed-sources",
+                    "Ignore failed remote sources if there are local packages meeting version requirements",
+                    CommandOptionType.NoValue);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(async () =>
@@ -76,6 +79,7 @@ namespace Microsoft.Framework.PackageManager
                     command.FallbackSources = optFallbackSource.Values;
                     command.NoCache = optNoCache.HasValue();
                     command.PackageFolder = optPackageFolder.Value();
+                    command.IgnoreFailedSources = optIgnoreFailedSources.HasValue();
 
                     if (optProxy.HasValue())
                     {
@@ -215,6 +219,9 @@ namespace Microsoft.Framework.PackageManager
                 var optPackageFolder = c.Option("--packages", "Path to restore packages", CommandOptionType.SingleValue);
                 var optQuiet = c.Option("--quiet", "Do not show output such as HTTP request/cache information",
                     CommandOptionType.NoValue);
+                var optIgnoreFailedSources = c.Option("--ignore-failed-sources",
+                    "Ignore failed remote sources if there are local packages meeting version requirements",
+                    CommandOptionType.NoValue);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(async () =>
@@ -235,6 +242,7 @@ namespace Microsoft.Framework.PackageManager
                     restoreCmd.FallbackSources = optFallbackSource.Values;
                     restoreCmd.NoCache = optNoCache.HasValue();
                     restoreCmd.PackageFolder = optPackageFolder.Value();
+                    restoreCmd.IgnoreFailedSources = optIgnoreFailedSources.HasValue();
 
                     if (optProxy.HasValue())
                     {

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Framework.PackageManager
         public bool NoCache { get; set; }
         public string PackageFolder { get; set; }
         public string GlobalJsonFile { get; set; }
+        public bool IgnoreFailedSources { get; set; }
 
         public ScriptExecutor ScriptExecutor { get; private set; }
 
@@ -465,7 +466,8 @@ namespace Microsoft.Framework.PackageManager
                                 source.UserName,
                                 source.Password,
                                 NoCache,
-                                Reports.Quiet)));
+                                Reports.Quiet,
+                                ignoreFailure: IgnoreFailedSources)));
                 }
             }
         }

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreOperations.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreOperations.cs
@@ -138,7 +138,12 @@ namespace Microsoft.Framework.PackageManager
             if (library.Version.IsSnapshot)
             {
                 var remoteMatch = await FindLibraryBySnapshot(context, library, context.RemoteLibraryProviders);
-                if (remoteMatch != null)
+                if (remoteMatch == null)
+                {
+                    var localMatch = await FindLibraryBySnapshot(context, library, context.LocalLibraryProviders);
+                    return localMatch;
+                }
+                else
                 {
                     var localMatch = await FindLibraryByVersion(context, remoteMatch.Library, context.LocalLibraryProviders);
                     if (localMatch != null && localMatch.Library.Version.Equals(remoteMatch.Library.Version))
@@ -178,7 +183,6 @@ namespace Microsoft.Framework.PackageManager
 
                 return localMatch ?? remoteMatch;
             }
-            return null;
         }
 
         public async Task<WalkProviderMatch> FindLibraryByName(RestoreContext context, string name, IEnumerable<IWalkProvider> providers)


### PR DESCRIPTION
- If we know an exact minimum version (version without *) and that version
  is availale in local packages folder -> done
- If '--ignore-failed-sources' is specified and we have a package that
  satisfies the version ranges -> done
- Otherwise exit with errors

parent #591 
