### PR TITLE
Flow correct compilation options in Roslyn compiler to Roslyn parser

### DIFF
--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
@@ -113,7 +113,9 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
             var newCompilation = assemblyNeutralWorker.Compilation;
 
-            newCompilation = ApplyVersionInfo(newCompilation, project);
+            var parseOptions = new CSharpParseOptions(languageVersion: compilationSettings.LanguageVersion,
+                                                      preprocessorSymbols: compilationSettings.Defines.AsImmutable());
+            newCompilation = ApplyVersionInfo(newCompilation, project, parseOptions);
 
             var compilationContext = new CompilationContext(newCompilation,
                 incomingReferences.Concat(outgoingReferences).ToList(),
@@ -168,15 +170,14 @@ namespace Microsoft.Framework.Runtime.Roslyn
             return compilationContext;
         }
 
-        private static CSharpCompilation ApplyVersionInfo(CSharpCompilation compilation, Project project)
+        private static CSharpCompilation ApplyVersionInfo(CSharpCompilation compilation, Project project,
+            CSharpParseOptions parseOptions)
         {
             var emptyVersion = new Version(0, 0, 0, 0);
 
             // If the assembly version is empty then set the version
             if (compilation.Assembly.Identity.Version == emptyVersion)
             {
-                var parseOptions = CSharpParseOptions.Default
-                    .WithLanguageVersion(compilation.LanguageVersion);
                 return compilation.AddSyntaxTrees(new[]
                 {
                     CSharpSyntaxTree.ParseText("[assembly: System.Reflection.AssemblyVersion(\"" + project.Version.Version + "\")]", parseOptions),


### PR DESCRIPTION
Followed @davidfowl 's suggestions here: https://github.com/aspnet/KRuntime/pull/655

However, looks like there is no easy way to get a complete `CompliationSettings` in `HelloMetaProgramming.cs`. So I didn't revert the change in this part.
