### PR TITLE
Added frameworkAssemblies support

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/LocalWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/LocalWalkProvider.cs
@@ -41,7 +41,13 @@ namespace Microsoft.Framework.PackageManager
 
         public Task<WalkProviderMatch> FindLibraryByName(string name, FrameworkName targetFramework)
         {
-            var description = _dependencyProvider.GetDescription(name, new SemanticVersion(new Version(0, 0)), targetFramework);
+            var library = new Library
+            {
+                Name = name,
+                Version = new SemanticVersion(new Version(0, 0))
+            };
+
+            var description = _dependencyProvider.GetDescription(library, targetFramework);
             if (description == null)
             {
                 return Task.FromResult<WalkProviderMatch>(null);
@@ -56,7 +62,7 @@ namespace Microsoft.Framework.PackageManager
 
         public Task<WalkProviderMatch> FindLibraryByVersion(Library library, FrameworkName targetFramework)
         {
-            var description = _dependencyProvider.GetDescription(library.Name, library.Version, targetFramework);
+            var description = _dependencyProvider.GetDescription(library, targetFramework);
             if (description == null)
             {
                 return Task.FromResult<WalkProviderMatch>(null);
@@ -71,7 +77,7 @@ namespace Microsoft.Framework.PackageManager
 
         public Task<WalkProviderMatch> FindLibraryBySnapshot(Library library, FrameworkName targetFramework)
         {
-            var description = _dependencyProvider.GetDescription(library.Name, library.Version, targetFramework);
+            var description = _dependencyProvider.GetDescription(library, targetFramework);
             if (description == null)
             {
                 return Task.FromResult<WalkProviderMatch>(null);
@@ -86,7 +92,7 @@ namespace Microsoft.Framework.PackageManager
 
         public Task<IEnumerable<Library>> GetDependencies(WalkProviderMatch match, FrameworkName targetFramework)
         {
-            var description = _dependencyProvider.GetDescription(match.Library.Name, match.Library.Version, targetFramework);
+            var description = _dependencyProvider.GetDescription(match.Library, targetFramework);
             return Task.FromResult(description.Dependencies);
         }
 

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -169,7 +169,8 @@ namespace Microsoft.Framework.PackageManager
                     new ProjectReferenceDependencyProvider(
                         new ProjectResolver(
                             projectDirectory,
-                            rootDirectory))));
+                            rootDirectory),
+                        new EmptyFrameworkResolver())));
 
             localProviders.Add(
                 new LocalWalkProvider(

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreOperations.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreOperations.cs
@@ -130,6 +130,11 @@ namespace Microsoft.Framework.PackageManager
                 return null;
             }
 
+            if (library.IsGacOrFrameworkReference)
+            {
+                return null;
+            }
+
             if (library.Version.IsSnapshot)
             {
                 var remoteMatch = await FindLibraryBySnapshot(context, library, context.RemoteLibraryProviders);

--- a/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
@@ -31,14 +31,14 @@ namespace Microsoft.Framework.Runtime
             var referenceAssemblyDependencyResolver = new ReferenceAssemblyDependencyResolver(FrameworkReferenceResolver);
             NuGetDependencyProvider = new NuGetDependencyResolver(PackagesDirectory, FrameworkReferenceResolver);
             var gacDependencyResolver = new GacDependencyResolver();
-            ProjectDepencyProvider = new ProjectReferenceDependencyProvider(ProjectResolver);
+            ProjectDepencyProvider = new ProjectReferenceDependencyProvider(ProjectResolver, FrameworkReferenceResolver);
             UnresolvedDependencyProvider = new UnresolvedDependencyProvider();
 
             DependencyWalker = new DependencyWalker(new IDependencyProvider[] {
                 ProjectDepencyProvider,
+                NuGetDependencyProvider,
                 referenceAssemblyDependencyResolver,
                 gacDependencyResolver,
-                NuGetDependencyProvider,
                 UnresolvedDependencyProvider
             });
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
@@ -30,8 +30,13 @@ namespace Microsoft.Framework.Runtime
             return GetGacSearchPaths().Select(p => Path.Combine(p, "{name}", "{version}", "{name}.dll"));
         }
 
-        public LibraryDescription GetDescription(string name, SemanticVersion version, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
         {
+            if (!library.IsGacOrFrameworkReference)
+            {
+                return null;
+            }
+
             if (PlatformHelper.IsMono)
             {
                 return null;
@@ -41,6 +46,9 @@ namespace Microsoft.Framework.Runtime
             {
                 return null;
             }
+
+            var name = library.Name;
+            var version = library.Version;
 
             string path;
             if (!TryResolvePartialName(name, out path))
@@ -56,7 +64,13 @@ namespace Microsoft.Framework.Runtime
 
                 return new LibraryDescription
                 {
-                    Identity = new Library { Name = name, Version = assemblyVersion },
+                    Identity = new Library
+                    {
+                        Name = name,
+                        Version = assemblyVersion,
+                        IsGacOrFrameworkReference = true,
+                        IsImplicit = library.IsImplicit
+                    },
                     Dependencies = Enumerable.Empty<Library>()
                 };
             }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/IDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/IDependencyProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Framework.Runtime
 {
     public interface IDependencyProvider
     {
-        LibraryDescription GetDescription(string name, SemanticVersion version, FrameworkName targetFramework);
+        LibraryDescription GetDescription(Library library, FrameworkName targetFramework);
 
         void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework);
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/Library.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/Library.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Framework.Runtime
 
         public SemanticVersion Version { get; set; }
 
+        public bool IsGacOrFrameworkReference { get; set; }
+
+        public bool IsImplicit { get; set; }
+
         public override string ToString()
         {
             return Name + " " + Version + (Version != null && Version.IsSnapshot ? "-*" : string.Empty);

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -50,15 +50,28 @@ namespace Microsoft.Framework.Runtime
             };
         }
 
-        public LibraryDescription GetDescription(string name, SemanticVersion version, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
         {
+            if (library.IsGacOrFrameworkReference)
+            {
+                return null;
+            }
+
+            var name = library.Name;
+            var version = library.Version;
+
             var package = FindCandidate(name, version);
 
             if (package != null)
             {
                 return new LibraryDescription
                 {
-                    Identity = new Library { Name = package.Id, Version = package.Version },
+                    Identity = new Library
+                    {
+                        Name = package.Id,
+                        Version = package.Version,
+                        IsImplicit = library.IsImplicit
+                    },
                     Dependencies = GetDependencies(package, targetFramework)
                 };
             }
@@ -104,7 +117,8 @@ namespace Microsoft.Framework.Runtime
 
                     yield return new Library
                     {
-                        Name = assemblyReference.AssemblyName
+                        Name = assemblyReference.AssemblyName,
+                        IsGacOrFrameworkReference = true
                     };
                 }
             }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -36,8 +36,16 @@ namespace Microsoft.Framework.Runtime
             return Enumerable.Empty<string>();
         }
 
-        public LibraryDescription GetDescription(string name, SemanticVersion version, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
         {
+            if (!library.IsGacOrFrameworkReference)
+            {
+                return null;
+            }
+
+            var name = library.Name;
+            var version = library.Version;
+
             string path;
             if (!FrameworkResolver.TryGetAssembly(name, targetFramework, out path))
             {
@@ -52,7 +60,13 @@ namespace Microsoft.Framework.Runtime
 
                 return new LibraryDescription
                 {
-                    Identity = new Library { Name = name, Version = assemblyVersion },
+                    Identity = new Library
+                    {
+                        Name = name,
+                        Version = assemblyVersion,
+                        IsGacOrFrameworkReference = true,
+                        IsImplicit = library.IsImplicit
+                    },
                     Dependencies = Enumerable.Empty<Library>()
                 };
             }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Framework.Runtime
             UnresolvedDependencies = Enumerable.Empty<LibraryDescription>();
         }
 
-        public LibraryDescription GetDescription(string name, SemanticVersion version, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
         {
             return new LibraryDescription
             {
-                Identity = new Library { Name = name, Version = version },
+                Identity = library,
                 Dependencies = Enumerable.Empty<Library>()
             };
         }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Framework.Runtime
                 .Select(x => new
                 {
                     Resolver = x,
-                    Details = x.GetDescription(packageKey.Name, packageKey.Version, frameworkName)
+                    Details = x.GetDescription(packageKey, frameworkName)
                 })
                 .FirstOrDefault(x => x.Details != null);
 

--- a/test/Microsoft.Framework.Runtime.Tests/AssemblyLoaderFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/AssemblyLoaderFacts.cs
@@ -181,11 +181,11 @@ namespace Loader.Tests
             return null;
         }
 
-        public LibraryDescription GetDescription(string name, SemanticVersion version, FrameworkName frameworkName)
+        public LibraryDescription GetDescription(Library library, FrameworkName frameworkName)
         {
-            Trace.WriteLine(string.Format("StubAssemblyLoader.GetDependencies {0} {1} {2}", name, version, frameworkName));
+            Trace.WriteLine(string.Format("StubAssemblyLoader.GetDependencies {0} {1} {2}", library.Name, library.Version, frameworkName));
             Entry entry;
-            if (!_entries.TryGetValue(new Library { Name = name, Version = version }, out entry))
+            if (!_entries.TryGetValue(library, out entry))
             {
                 return null;
             }
@@ -195,7 +195,7 @@ namespace Loader.Tests
 
             return new LibraryDescription
             {
-                Identity = new Library { Name = name, Version = version },
+                Identity = new Library { Name = library.Name, Version = library.Version },
                 Dependencies = entry.Dependencies
             };
         }

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Linq;
 using Xunit;
 using NuGet;
 
@@ -75,6 +76,89 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Equal("D", d4.Name);
             Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Version);
             Assert.False(d4.Version.IsSnapshot);
+        }
+
+        [Fact]
+        public void DependenciesAreSetPerTargetFramework()
+        {
+            var project = Project.GetProject(@"
+{
+    ""frameworks"": {
+        ""net45"": {
+            ""dependencies"": {  
+                ""A"": """",
+                ""B"": ""1.0-alpha-*"",
+                ""C"": ""1.0.0"",
+                ""D"": { ""version"": ""2.0.0"" }
+            }
+        }
+    }
+}",
+"foo",
+@"c:\foo\project.json");
+
+            Assert.Empty(project.Dependencies);
+            var targetFrameworkInfo = project.GetTargetFrameworks().First();
+            Assert.NotNull(targetFrameworkInfo.Dependencies);
+            Assert.Equal(4, targetFrameworkInfo.Dependencies.Count);
+            var d1 = targetFrameworkInfo.Dependencies[0];
+            var d2 = targetFrameworkInfo.Dependencies[1];
+            var d3 = targetFrameworkInfo.Dependencies[2];
+            var d4 = targetFrameworkInfo.Dependencies[3];
+            Assert.Equal("A", d1.Name);
+            Assert.Null(d1.Version);
+            Assert.Equal("B", d2.Name);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha-*"), d2.Version);
+            Assert.True(d2.Version.IsSnapshot);
+            Assert.Equal("C", d3.Name);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Version);
+            Assert.False(d3.Version.IsSnapshot);
+            Assert.Equal("D", d4.Name);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Version);
+            Assert.False(d4.Version.IsSnapshot);
+        }
+
+        [Fact]
+        public void FrameworkAssembliesAreSet()
+        {
+            var project = Project.GetProject(@"
+{
+    ""frameworks"": {
+        ""net45"": {
+            ""frameworkAssemblies"": {  
+                ""A"": """",
+                ""B"": ""1.0-alpha-*"",
+                ""C"": ""1.0.0"",
+                ""D"": { ""version"": ""2.0.0"" }
+            }
+        }
+    }
+}",
+"foo",
+@"c:\foo\project.json");
+
+            Assert.Empty(project.Dependencies);
+            var targetFrameworkInfo = project.GetTargetFrameworks().First();
+            Assert.Equal(4, targetFrameworkInfo.Dependencies.Count);
+            var d1 = targetFrameworkInfo.Dependencies[0];
+            var d2 = targetFrameworkInfo.Dependencies[1];
+            var d3 = targetFrameworkInfo.Dependencies[2];
+            var d4 = targetFrameworkInfo.Dependencies[3];
+            Assert.Equal("A", d1.Name);
+            Assert.Null(d1.Version);
+            Assert.True(d1.IsGacOrFrameworkReference);
+            Assert.Equal("B", d2.Name);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha-*"), d2.Version);
+            Assert.True(d2.Version.IsSnapshot);
+            Assert.True(d2.IsGacOrFrameworkReference);
+            Assert.Equal("C", d3.Name);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Version);
+            Assert.False(d3.Version.IsSnapshot);
+            Assert.True(d3.IsGacOrFrameworkReference);
+            Assert.Equal("D", d4.Name);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Version);
+            Assert.False(d4.Version.IsSnapshot);
+            Assert.True(d4.IsGacOrFrameworkReference);
         }
 
         [Fact]


### PR DESCRIPTION
- The frameworkAssemblies section is specific to a target framework
- Refactored BuildContext to call into the ProjectReferenceDependencyProvider.
  This means that only a single place actually uses the project class directly
  (which is nice).
- GetLibraryDescription now takes a Library instead of name and version
  (we may need to revisit this and create a different poco). When @lodejard finishes
  dependency types we'll see how this ends up
- Preserve the backwards compatibility of declaring frameworkAssemblies in
  dependencies temporarily
- Added tests for parsing frameworkAssemblies
#640
#619

/cc @blowdart @GrabYourPitchforks 
