### PR TITLE
Fix runtime lookup during kpm pack on Mono

### DIFF
--- a/KRuntime.sln
+++ b/KRuntime.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22207.0
+VisualStudioVersion = 14.0.22209.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{189961D1-DFF4-406A-9D42-39B61221A73A}"
 	ProjectSection(SolutionItems) = preProject
@@ -66,6 +66,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.PackageManager.FunctionalTests", "test\Microsoft.Framework.PackageManager.FunctionalTests\Microsoft.Framework.PackageManager.FunctionalTests.kproj", "{C8404BE7-504E-477C-BC29-41A49B1BCBD9}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.PackageManager.Tests", "test\Microsoft.Framework.PackageManager.Tests\Microsoft.Framework.PackageManager.Tests.kproj", "{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -398,6 +400,20 @@ Global
 		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|Win32.ActiveCfg = Release|Any CPU
 		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|x64.ActiveCfg = Release|Any CPU
 		{C8404BE7-504E-477C-BC29-41A49B1BCBD9}.Release|x86.ActiveCfg = Release|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Release|Win32.ActiveCfg = Release|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Release|x64.ActiveCfg = Release|Any CPU
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -426,5 +442,6 @@ Global
 		{0D752D1C-3985-4E27-92C4-0BEE72B1F58D} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 		{7E6564C3-04E3-418C-B96A-463FE2906F09} = {C43EE429-DE10-4906-BB09-54E6A080948A}
 		{C8404BE7-504E-477C-BC29-41A49B1BCBD9} = {C43EE429-DE10-4906-BB09-54E6A080948A}
+		{C5E5BC63-37C2-44F1-B2CF-906CABE4B614} = {C43EE429-DE10-4906-BB09-54E6A080948A}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Framework.PackageManager/Packing/DependencyContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/DependencyContext.cs
@@ -57,7 +57,11 @@ namespace Microsoft.Framework.PackageManager.Packing
                 return null;
             }
             parts = parts[0].Split(new[] { '-' }, 3);
-            if (parts.Length != 3)
+            if (parts.Length < 2)
+            {
+                return null;
+            }
+            if (parts.Length == 2 && !string.Equals(parts[1].ToLowerInvariant(), "mono"))
             {
                 return null;
             }

--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
+using Microsoft.Framework.Runtime;
 
 namespace Microsoft.Framework.PackageManager.Packing
 {
@@ -108,7 +109,17 @@ namespace Microsoft.Framework.PackageManager.Packing
                     var kreHome = Environment.GetEnvironmentVariable("KRE_HOME");
                     if (string.IsNullOrEmpty(kreHome))
                     {
+#if ASPNETCORE50
                         kreHome = Environment.GetEnvironmentVariable("ProgramFiles") + @"\KRE;%USERPROFILE%\.kre";
+#else
+                        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                        kreHome = Path.Combine(userProfile, ".kre");
+                        if (!PlatformHelper.IsMono)
+                        {
+                            var programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles");
+                            kreHome = Path.Combine(programFilesPath, "KRE") + ";" + kreHome;
+                        }
+#endif
                     }
 
                     foreach (var portion in kreHome.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))

--- a/test/Microsoft.Framework.PackageManager.Tests/DependencyContextFacts.cs
+++ b/test/Microsoft.Framework.PackageManager.Tests/DependencyContextFacts.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.Framework.PackageManager.Packing;
+using Xunit;
+
+namespace Microsoft.Framework.PackageManager.Packing.Tests
+{
+    public class DependencyContextFacts
+    {
+        [Theory]
+        [InlineData("KRE-CLR-x86.1.0.0", "Asp.Net")]
+        [InlineData("KRE-CLR-amd64.1.0.0", "Asp.Net")]
+        [InlineData("KRE-CoreCLR-x86.1.0.0", "Asp.NetCore")]
+        [InlineData("KRE-CoreCLR-amd64.1.0.0", "Asp.NetCore")]
+        [InlineData("KRE-Mono.1.0.0", "Asp.Net")]  // Absence of architecture component is allowed for Mono KRE
+        [InlineData("KRE-Mono-x86.1.0.0", "Asp.Net")]
+        [InlineData("KRE-CLR.1.0.0", null)]
+        [InlineData("KRE-CoreCLR-x86", null)]
+        [InlineData("KRE-Mono", null)]
+        [InlineData("KRE", null)]
+        public void GetCorrectFrameworkNameForKREs(string runtimeName, string frameworkIdentifier)
+        {
+            var frameworkName = DependencyContext.GetFrameworkNameForRuntime(runtimeName);
+
+            Assert.Equal(frameworkIdentifier, frameworkName?.Identifier);
+        }
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.Tests/Microsoft.Framework.PackageManager.Tests.kproj
+++ b/test/Microsoft.Framework.PackageManager.Tests/Microsoft.Framework.PackageManager.Tests.kproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="__ToolsVersion__" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c5e5bc63-37c2-44f1-b2cf-906cabe4b614</ProjectGuid>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.Framework.PackageManager.Tests/project.json
+++ b/test/Microsoft.Framework.PackageManager.Tests/project.json
@@ -1,0 +1,12 @@
+{
+    "dependencies": {
+        "Microsoft.Framework.PackageManager": "1.0.0-*",
+        "Xunit.KRunner": "1.0.0-*"
+    },
+    "frameworks": {
+        "aspnet50": { }
+    },
+    "commands": {
+        "test": "Xunit.KRunner"
+    }
+}


### PR DESCRIPTION
- Fix framework name parsing: Mono KRE doesn't have architecture component
- Fix userprofile resolving on Mono

parent #644 and #272
