### PR TITLE
Gets tests working again by choosing a better default target framework.

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Framework.DesignTimeHost
 
         private void SetTargetFramework(string targetFrameworkValue)
         {
-            var targetFramework = VersionUtility.ParseFrameworkName(targetFrameworkValue ?? "net45");
+            var targetFramework = VersionUtility.ParseFrameworkName(targetFrameworkValue ?? "aspnet50");
             _targetFramework.Value = targetFramework == VersionUtility.UnsupportedFrameworkName ? new FrameworkName(targetFrameworkValue) : targetFramework;
         }
 


### PR DESCRIPTION
In VS the test integration wasn't passing a target framework to DTH when
starting one for tests. They are fixing that part independently.

We still might want to update this for completeness.
