### PR TITLE
Fix "kpm pack" paths with dots excluding all content files

### DIFF
--- a/src/Microsoft.Framework.Runtime/NuGet/Authoring/PathResolver.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Authoring/PathResolver.cs
@@ -57,7 +57,7 @@ namespace NuGet
                 pattern = Regex.Escape(wildcard.Replace('\\', '/'));
                 // regex wildcard adjustments for *nix-style file systems
                 pattern = pattern
-                    .Replace(@"\*\*/", ".*") //For recursive wildcards /**/, include the current directory.
+                    .Replace(@"\*\*/", "(.*/)?") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*\.\*", @"\*") // "*.*" is equivalent to "*"
                     .Replace(@"\*", @"[^/]*(/)?") // For non recursive searches, limit it any character that is not a directory separator
@@ -69,7 +69,7 @@ namespace NuGet
                 // regex wildcard adjustments for Windows-style file systems
                 pattern = pattern
                     .Replace("/", @"\\") // On Windows, / is treated the same as \.
-                    .Replace(@"\*\*\\", ".*") //For recursive wildcards \**\, include the current directory.
+                    .Replace(@"\*\*\\", @"(.*\\)?") //For recursive wildcards \**\, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*\.\*", @"\*") // "*.*" is equivalent to "*"
                     .Replace(@"\*", @"[^\\]*(\\)?") // For non recursive searches, limit it any character that is not a directory separator

--- a/src/Microsoft.Framework.Runtime/Project.cs
+++ b/src/Microsoft.Framework.Runtime/Project.cs
@@ -109,7 +109,10 @@ namespace Microsoft.Framework.Runtime
                     .Select(pattern => PathResolver.NormalizeWildcardForExcludedFiles(path, pattern))
                     .ToArray();
 
-                var excludeFiles = PathResolver.GetMatches(includeFiles, x => x, excludePatterns)
+                var excludeFiles = PathResolver.GetMatches(
+                    includeFiles,
+                    x => x,
+                    excludePatterns.Select(x => Path.Combine(path, x)))
                     .ToArray();
 
                 return files.Concat(includeFiles.Except(excludeFiles)).Distinct().ToArray();
@@ -132,7 +135,10 @@ namespace Microsoft.Framework.Runtime
                     .Select(pattern => PathResolver.NormalizeWildcardForExcludedFiles(path, pattern))
                     .ToArray();
 
-                var excludeFiles = PathResolver.GetMatches(includeFiles, x => x, excludePatterns)
+                var excludeFiles = PathResolver.GetMatches(
+                    includeFiles,
+                    x => x,
+                    excludePatterns.Select(x => Path.Combine(path, x)))
                     .ToArray();
 
                 return files.Concat(includeFiles.Except(excludeFiles)).Distinct().ToArray();
@@ -196,7 +202,10 @@ namespace Microsoft.Framework.Runtime
                     .Select(pattern => PathResolver.NormalizeWildcardForExcludedFiles(path, pattern))
                     .ToArray();
 
-                var excludeFiles = PathResolver.GetMatches(includeFiles, x => x, excludePatterns)
+                var excludeFiles = PathResolver.GetMatches(
+                    includeFiles,
+                    x => x,
+                    excludePatterns.Select(x => Path.Combine(path, x)))
                     .ToArray();
 
                 return includeFiles.Except(excludeFiles).Distinct().ToArray();


### PR DESCRIPTION
When fixing #588 , I added `@"**\.*\**"` as a `pack-exclude` pattern. However, the pattern was translated to the following regex

```
^.*\.[^\\]*(\\)?\\.*$
```

, which means, all paths containing dots will be excluded. So if your project has a name containing one or more dots, for example `Microsoft.AspNet.SignalR.LoadTestHarness`, all files in this project will be excluded during packing.

Thanks @mikary for reporting this bug. I fixed it by adding proper directory separators when translating patterns to regex. Tested on both Windows and OSX.
