### PR TITLE
Fix "kpm pack" all files as content files with '--wwwroot .'

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
@@ -377,7 +377,23 @@ root.Configuration));
             root.Reports.Quiet.WriteLine("  Source {0}", contentSourcePath);
             root.Reports.Quiet.WriteLine("  Target {0}", targetFolderPath);
 
-            root.Operations.Copy(contentSourcePath, targetFolderPath);
+            var contentFiles = new HashSet<string>(project.ContentFiles, StringComparer.OrdinalIgnoreCase);
+
+            root.Operations.Copy(contentSourcePath, targetFolderPath, (isRoot, filePath) =>
+            {
+                if (Directory.Exists(filePath))
+                {
+                    return true;
+                }
+
+                if (string.Equals(Path.GetFileName(filePath), Runtime.Project.ProjectFileName,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                return contentFiles.Contains(filePath);
+            });
         }
 
         private bool IncludeRuntimeFileInBundle(string relativePath, string fileName)


### PR DESCRIPTION
Fix regression of `kpm pack`. It was packing all files (including .cs files) to wwwroot of output if we specify `.` as value of `--wwwroot`.
