### PR TITLE
Add properties to project.json

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
@@ -240,6 +240,13 @@ namespace Microsoft.Framework.PackageManager
             builder.Id = project.Name;
             builder.Version = project.Version;
             builder.Title = project.Name;
+            builder.RequireLicenseAcceptance = project.RequireLicenseAcceptance;
+            builder.Tags.AddRange(project.Tags);
+
+            if (!string.IsNullOrEmpty(project.ProjectUrl))
+            {
+                builder.ProjectUrl = new Uri(project.ProjectUrl);
+            }
         }
 
         private void WriteSummary(List<string> warnings, List<string> errors)

--- a/src/Microsoft.Framework.Runtime/Project.cs
+++ b/src/Microsoft.Framework.Runtime/Project.cs
@@ -71,7 +71,13 @@ namespace Microsoft.Framework.Runtime
 
         public string WebRoot { get; private set; }
 
-        public string EntryPoint { get; set; }
+        public string EntryPoint { get; private set; }
+
+        public string ProjectUrl { get; private set; }
+
+        public bool RequireLicenseAcceptance { get; private set; }
+
+        public string[] Tags { get; private set; }
 
         internal IEnumerable<string> SourcePatterns { get; set; }
 
@@ -257,6 +263,7 @@ namespace Microsoft.Framework.Runtime
             // Metadata properties
             var version = rawProject["version"];
             var authors = rawProject["authors"];
+            var tags = rawProject["tags"];
 
             project.Name = projectName;
             project.Version = version == null ? new SemanticVersion("1.0.0") : new SemanticVersion(version.Value<string>());
@@ -266,6 +273,9 @@ namespace Microsoft.Framework.Runtime
             project.ProjectFilePath = Path.GetFullPath(projectPath);
             project.WebRoot = GetValue<string>(rawProject, "webroot");
             project.EntryPoint = GetValue<string>(rawProject, "entryPoint");
+            project.ProjectUrl = GetValue<string>(rawProject, "projectUrl");
+            project.RequireLicenseAcceptance = GetValue<bool?>(rawProject, "requireLicenseAcceptance") ?? false;
+            project.Tags = tags == null ? new string[] { } : tags.ToObject<string[]>();
 
             // TODO: Move this to the dependencies node
             project.EmbedInteropTypes = GetValue<bool>(rawProject, "embedInteropTypes");

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
@@ -340,5 +340,65 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Equal(new[] { "a.cs", "b.cs", "c.cs" }, project.SourcePatterns);
             Assert.Equal(new[] { "a.cs" }, project.ExcludePatterns);
         }
+
+        [Fact]
+        public void ProjectUrlIsSet()
+        {
+            var project = Project.GetProject(@"
+{
+    ""projectUrl"": ""https://github.com/aspnet/KRuntime""
+}",
+"foo",
+@"c:\foo\project.json");
+
+            Assert.Equal("https://github.com/aspnet/KRuntime", project.ProjectUrl);
+        }
+
+        [Fact]
+        public void RequireLicenseAcceptanceIsSet()
+        {
+            var project = Project.GetProject(@"
+{
+    ""requireLicenseAcceptance"": ""true""
+}",
+"foo",
+@"c:\foo\project.json");
+
+            Assert.True(project.RequireLicenseAcceptance);
+        }
+
+        [Fact]
+        public void RequireLicenseAcceptanceDefaultValueIsFalse()
+        {
+            var project = Project.GetProject(@" { }", "foo", @"c:\foo\project.json");
+
+            Assert.False(project.RequireLicenseAcceptance);
+        }
+
+        [Fact]
+        public void TagsAreSet()
+        {
+            var project = Project.GetProject(@"
+{
+    ""tags"": [""awesome"", ""fantastic"", ""aspnet""]
+}",
+"foo",
+@"c:\foo\project.json");
+            var tags = new ReadOnlyHashSet<string>(project.Tags);
+
+            Assert.Equal(3, tags.Count);
+            Assert.True(tags.Contains("awesome"));
+            Assert.True(tags.Contains("fantastic"));
+            Assert.True(tags.Contains("aspnet"));
+        }
+
+        [Fact]
+        public void EmptyTagsListWhenNotSpecified()
+        {
+            var project = Project.GetProject(@" { }", "foo", @"c:\foo\project.json");
+
+            Assert.NotNull(project.Tags);
+            Assert.Equal(0, project.Tags.Count());
+        }
     }
 }


### PR DESCRIPTION
parent #235 

Default value of `requireLicenseAcceptance` is `false`. (I guess that's the most common case)

The value of `tags` can only be an array

``` json
{
  "tags": ["tag1", "tag2", "tag3"]
}
```

Do we want to support other alternatives like string with separators?

``` json
{
  "tags": "tag1, tag2, tag3"
}
```
