### PR TITLE
More friendly output for crossgen

### DIFF
--- a/src/Microsoft.Framework.Project/CrossGenManager.cs
+++ b/src/Microsoft.Framework.Project/CrossGenManager.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Framework.Project
             p.BeginOutputReadLine();
             p.WaitForExit();
 
-            Console.WriteLine("Exit code for {0}: {1}", assemblyName, p.ExitCode);
+            Log("Exit code for {0}: {1}", assemblyName, p.ExitCode);
 
             if (p.ExitCode == 0)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Framework.Project
         
             if (assemblyInfo.Closure.Any(a => !a.Generated))
             {
-                Console.WriteLine("Skipping {0}. Because one or more dependencies failed to generate", assemblyInfo.Name);
+                Log("Skipping {0}. Because one or more dependencies failed to generate", assemblyInfo.Name);
                 return false;
             }
 
@@ -104,7 +104,7 @@ namespace Microsoft.Framework.Project
             var closure = assemblyInfo.Closure.Select(d => d.NativeImagePath)
                                       .Concat(new[] { assemblyInfo.AssemblyPath });
 
-            Console.WriteLine("Generating native images for {0}", assemblyInfo.Name);
+            Log("Generating native images for {0}", assemblyInfo.Name);
 
             const string crossgenArgsTemplate = @"/Nologo /in ""{0}"" /out ""{1}"" /MissingDependenciesOK /Trusted_Platform_Assemblies ""{2}""";
 
@@ -142,7 +142,7 @@ namespace Microsoft.Framework.Project
 
             if (_options.Symbols)
             {
-                Console.WriteLine("Generating native pdb for {0}", assemblyInfo.Name);
+                Log("Generating native pdb for {0}", assemblyInfo.Name);
 
                 const string crossgenArgsTemplateCreatePdb = @"/Nologo /CreatePDB ""{0}"" /in ""{1}"" /out ""{2}"" /Trusted_Platform_Assemblies ""{3}""";
 
@@ -180,12 +180,16 @@ namespace Microsoft.Framework.Project
 
         void OnErrorDataReceived(object sender, DataReceivedEventArgs e)
         {
-            Console.Error.WriteLine(e.Data);
+            var msg = e.Data.Trim();
+            if (!string.IsNullOrEmpty(msg))
+            {
+                Console.Error.WriteLine(msg);
+            }
         }
 
         void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
         {
-            Console.WriteLine(e.Data);
+            Log(e.Data);
         }
 
         private static IDictionary<string, AssemblyInformation> BuildUniverse(string runtimePath, IEnumerable<string> paths)
@@ -249,6 +253,14 @@ namespace Microsoft.Framework.Project
             var kreName = kreFullName.Substring(0, kreFullName.IndexOf('.'));
             var arch = kreName.Substring(kreName.LastIndexOf('-') + 1);
             return arch;
+        }
+
+        private void Log(string msg, params object[] args)
+        {
+            if (_options.Verbose)
+            {
+                Console.WriteLine(msg, args);
+            }
         }
     }
 }

--- a/src/Microsoft.Framework.Project/CrossgenOptions.cs
+++ b/src/Microsoft.Framework.Project/CrossgenOptions.cs
@@ -20,5 +20,7 @@ namespace Microsoft.Framework.Project
         public bool Symbols { get; set; }
 
         public bool Partial { get; set; }
+
+        public bool Verbose { get; set; }
     }
 }

--- a/src/Microsoft.Framework.Project/Program.cs
+++ b/src/Microsoft.Framework.Project/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Common.CommandLine;
@@ -39,6 +40,7 @@ namespace Microsoft.Framework.Project
                 var optionRuntimePath = c.Option("--runtimePath <PATH>", "Runtime path", CommandOptionType.SingleValue);
                 var optionSymbols = c.Option("--symbols", "Use symbols", CommandOptionType.NoValue);
                 var optionPartial = c.Option("--partial", "Allow partial NGEN", CommandOptionType.NoValue);
+                var optionVerbose = c.Option("--verbose", "Verbose output", CommandOptionType.NoValue);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(() =>
@@ -49,13 +51,17 @@ namespace Microsoft.Framework.Project
                     crossgenOptions.CrossgenPath = optionExePath.Value();
                     crossgenOptions.Symbols = optionSymbols.HasValue();
                     crossgenOptions.Partial = optionPartial.HasValue();
+                    crossgenOptions.Verbose = optionVerbose.HasValue();
 
+                    Console.WriteLine("Crossgening runtime: " + crossgenOptions.RuntimePath);
                     var gen = new CrossgenManager(crossgenOptions);
                     if (!gen.GenerateNativeImages())
                     {
+                        Console.WriteLine("Crossgen failed.");
                         return -1;
                     }
 
+                    Console.WriteLine("Crossgen was successful.");
                     return 0;
                 });
             });


### PR DESCRIPTION
Allow user to specify --verbose option to see detailed output
If verbose is not enabled the user will only see messages about crossgen started, ended or any errors
