### PR TITLE
Exposed LoadableAssemblies on ILibraryInformation

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
@@ -158,6 +158,9 @@ namespace Microsoft.Framework.PackageManager.Packing
                 // Update the project entrypoint
                 jsonObj["entryPoint"] = _libraryDescription.Identity.Name;
 
+                // Set mark this as non loadable
+                jsonObj["loadable"] = false;
+
                 // Update the dependencies node to reference the main project
                 var deps = new JObject();
                 jsonObj["dependencies"] = deps;

--- a/src/Microsoft.Framework.Runtime.Interfaces/ILibraryInformation.cs
+++ b/src/Microsoft.Framework.Runtime.Interfaces/ILibraryInformation.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.Framework.Runtime
 {
@@ -17,5 +18,7 @@ namespace Microsoft.Framework.Runtime
         string Type { get; }
 
         IEnumerable<string> Dependencies { get; }
+
+        IEnumerable<AssemblyName> LoadableAssemblies { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Framework.Runtime
                         Version = assemblyVersion,
                         IsGacOrFrameworkReference = true
                     },
+                    LoadableAssemblies = new[] { name },
                     Dependencies = Enumerable.Empty<LibraryDependency>()
                 };
             }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDescription.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDescription.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Framework.Runtime
         public string Type { get; set; }
         public FrameworkName Framework { get; set; }
         public IEnumerable<LibraryDependency> Dependencies { get; set; }
+        public IEnumerable<string> LoadableAssemblies { get; set; }
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryInformation.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryInformation.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Framework.Runtime
 {
@@ -15,6 +16,7 @@ namespace Microsoft.Framework.Runtime
             Path = description.Path;
             Type = description.Type;
             Dependencies = description.Dependencies.Select(d => d.Name);
+            LoadableAssemblies = description.LoadableAssemblies.Select(a => new AssemblyName(a));
         }
 
         public LibraryInformation(string name, IEnumerable<string> dependencies)
@@ -48,6 +50,12 @@ namespace Microsoft.Framework.Runtime
         }
 
         public IEnumerable<string> Dependencies
+        {
+            get;
+            private set;
+        }
+
+        public IEnumerable<AssemblyName> LoadableAssemblies
         {
             get;
             private set;

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -171,6 +171,8 @@ namespace Microsoft.Framework.Runtime
                     packageDescription.ContractPath = contractPath;
                 }
 
+                var assemblies = new List<string>();
+
                 foreach (var assemblyInfo in GetPackageAssemblies(packageDescription, targetFramework))
                 {
                     _packageAssemblyLookup[assemblyInfo.Name] = new PackageAssembly()
@@ -179,7 +181,11 @@ namespace Microsoft.Framework.Runtime
                         RelativePath = assemblyInfo.RelativePath,
                         Library = dependency
                     };
+
+                    assemblies.Add(assemblyInfo.Name);
                 }
+
+                dependency.LoadableAssemblies = assemblies;
             }
         }
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
@@ -69,6 +69,13 @@ namespace Microsoft.Framework.Runtime
 
             var dependencies = project.Dependencies.Concat(targetFrameworkDependencies).ToList();
 
+            var loadableAssemblies = new List<string>();
+
+            if (project.IsLoadable)
+            {
+                loadableAssemblies.Add(project.Name);
+            }
+
             return new LibraryDescription
             {
                 Identity = new Library
@@ -80,6 +87,7 @@ namespace Microsoft.Framework.Runtime
                 Path = project.ProjectFilePath,
                 Framework = targetFrameworkInfo.FrameworkName,
                 Dependencies = dependencies,
+                LoadableAssemblies = loadableAssemblies
             };
         }
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Framework.Runtime
                         Version = assemblyVersion,
                         IsGacOrFrameworkReference = true
                     },
+                    LoadableAssemblies = new[] { name },
                     Dependencies = Enumerable.Empty<LibraryDependency>()
                 };
             }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
@@ -288,7 +288,8 @@ namespace Microsoft.Framework.Runtime
                         Path = entry.Value.Description.Path,
                         Type = entry.Value.Description.Type,
                         Framework = entry.Value.Description.Framework ?? frameworkName,
-                        Dependencies = entry.Value.Dependencies.SelectMany(CorrectDependencyVersion).ToList()
+                        Dependencies = entry.Value.Dependencies.SelectMany(CorrectDependencyVersion).ToList(),
+                        LoadableAssemblies = entry.Value.Description.LoadableAssemblies ?? Enumerable.Empty<string>()
                     };
                 }).ToList();
 

--- a/src/Microsoft.Framework.Runtime/Project.cs
+++ b/src/Microsoft.Framework.Runtime/Project.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Framework.Runtime
 
         public bool RequireLicenseAcceptance { get; private set; }
 
+        public bool IsLoadable { get; set; }
+
         public string[] Tags { get; private set; }
 
         internal IEnumerable<string> SourcePatterns { get; set; }
@@ -285,6 +287,7 @@ namespace Microsoft.Framework.Runtime
             project.ProjectUrl = GetValue<string>(rawProject, "projectUrl");
             project.RequireLicenseAcceptance = GetValue<bool?>(rawProject, "requireLicenseAcceptance") ?? false;
             project.Tags = tags == null ? new string[] { } : tags.ToObject<string[]>();
+            project.IsLoadable = GetValue<bool?>(rawProject, "loadable") ?? true;
 
             // TODO: Move this to the dependencies node
             project.EmbedInteropTypes = GetValue<bool>(rawProject, "embedInteropTypes");


### PR DESCRIPTION
- Expose reliable set of assembly names that load can be called on safely.
- Expose the set of assemblies from each dependency provider
- Changed kpm pack --no-source to put loadable: false in the project.json.
  This means the project won't be loadable
#339
