### PR TITLE
PEReader needs to be used in using block

### DIFF
--- a/src/Microsoft.Framework.Project/AssemblyInformation.cs
+++ b/src/Microsoft.Framework.Project/AssemblyInformation.cs
@@ -69,9 +69,8 @@ namespace Microsoft.Framework.Project
             var dependencies = new HashSet<string>();
 
             using (var stream = File.OpenRead(AssemblyPath))
+            using (var peReader = new PEReader(stream))
             {
-                var peReader = new PEReader(stream);
-
                 var reader = peReader.GetMetadataReader();
 
                 foreach (var a in reader.AssemblyReferences)
@@ -95,9 +94,8 @@ namespace Microsoft.Framework.Project
             }
 
             using (var stream = File.OpenRead(path))
+            using (var peReader = new PEReader(stream))
             {
-                var peReader = new PEReader(stream);
-
                 return peReader.HasMetadata;
             }
         }

--- a/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/EmbeddedReferencesHelper.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/AssemblyNeutral/EmbeddedReferencesHelper.cs
@@ -101,9 +101,8 @@ namespace Microsoft.Framework.Runtime.Roslyn
             var references = new List<string>();
 
             using (var stream = new MemoryStream(buffer))
+            using (var peReader = new PEReader(stream))
             {
-                var peReader = new PEReader(stream);
-
                 var reader = peReader.GetMetadataReader();
 
                 foreach (var a in reader.AssemblyReferences)


### PR DESCRIPTION
We failed to use PEReader in using block. This would cause PEReader to be open to be collected while metadata is being read.
