### PR TITLE
Update the script executor

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Scripts/ScriptExecutor.cs
+++ b/src/Microsoft.Framework.PackageManager/Scripts/ScriptExecutor.cs
@@ -1,15 +1,16 @@
-using Microsoft.Framework.ApplicationHost.Impl.Syntax;
-using Microsoft.Framework.Runtime;
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using Microsoft.Framework.ApplicationHost.Impl.Syntax;
+using Microsoft.Framework.Runtime;
 
 namespace Microsoft.Framework.PackageManager
 {
-    /// <summary>
-    /// Summary description for ScriptExecutor
-    /// </summary>
     public class ScriptExecutor
     {
         public void Execute(Runtime.Project project, string scriptName, Func<string, string> getVariable)
@@ -26,17 +27,41 @@ namespace Microsoft.Framework.PackageManager
                     scriptCommandLine,
                     GetScriptVariable(project, getVariable));
 
-                // Command-lines on Windows are executed via "cmd /C" in order
-                // to support batch files, &&, built-in commands like echo, etc.
-                // ComSpec is Windows-specific, and contains the full path to cmd.exe
-                var comSpec = Environment.GetEnvironmentVariable("ComSpec");
-                if (!string.IsNullOrEmpty(comSpec))
+                // Ensure the array won't be empty and the first element won't be null or empty string.
+                scriptArguments = scriptArguments.Where(argument => !string.IsNullOrEmpty(argument)).ToArray();
+
+                if (scriptArguments.Length == 0)
                 {
-                    scriptArguments =
-                        new[] { comSpec, "/C", "\"" }
-                        .Concat(scriptArguments)
-                        .Concat(new[] { "\"" })
-                        .ToArray();
+                    continue;
+                }
+
+                if (!PlatformHelper.IsMono)
+                {
+                    // Forward-slash is used in script blocked only. Replace them with back-slash to correctly
+                    // locate the script. The directory separator is platform-specific. 
+                    scriptArguments[0] = scriptArguments[0].Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+                    // Command-lines on Windows are executed via "cmd /C" in order
+                    // to support batch files, &&, built-in commands like echo, etc.
+                    // ComSpec is Windows-specific, and contains the full path to cmd.exe
+                    var comSpec = Environment.GetEnvironmentVariable("ComSpec");
+                    if (!string.IsNullOrEmpty(comSpec))
+                    {
+                        scriptArguments =
+                            new[] { comSpec, "/C", "\"" }
+                            .Concat(scriptArguments)
+                            .Concat(new[] { "\"" })
+                            .ToArray();
+                    }
+                }
+                else
+                {
+                    var scriptCandiate = scriptArguments[0] + ".sh";
+                    if (File.Exists(scriptCandiate))
+                    {
+                        scriptArguments[0] = scriptCandiate;
+                        scriptArguments = new[] { "/bin/bash" }.Concat(scriptArguments).ToArray();
+                    }
                 }
 
                 var startInfo = new ProcessStartInfo
@@ -44,12 +69,12 @@ namespace Microsoft.Framework.PackageManager
                     FileName = scriptArguments.FirstOrDefault(),
                     Arguments = String.Join(" ", scriptArguments.Skip(1)),
                     WorkingDirectory = project.ProjectDirectory,
-    #if ASPNET50
-                    UseShellExecute = false,
-    #endif
+#if ASPNET50
+                    UseShellExecute = false
+#endif
                 };
-                var process = Process.Start(startInfo);
 
+                var process = Process.Start(startInfo);
                 process.WaitForExit();
             }
         }


### PR DESCRIPTION
Enhance the script executor to allow run scripts on both Windows and Mono platform.
1. Run the script in postbuild as bash script in Mono.
2. Tolerant the missing command in Mono. It happens when the command is
   Windows platform only.
3. Replace alternative directory separator in first argument with platform
   supported directory separator.

This change is part of the solution to enable build KRuntime on Mono. This change but itself won't enable the build but open up the solution to run post/pre build script on Mono. The change won't break current postbuild script blocks on Windows Platform.

This PR is split from PR #851

@davidfowl 
