### PR TITLE
Enable Background GC

### DIFF
--- a/src/klr.core45/klr.core45.cpp
+++ b/src/klr.core45/klr.core45.cpp
@@ -390,7 +390,8 @@ extern "C" __declspec(dllexport) bool __stdcall CallApplicationMain(PCALL_APPLIC
     STARTUP_FLAGS dwStartupFlags = (STARTUP_FLAGS)(
         STARTUP_FLAGS::STARTUP_LOADER_OPTIMIZATION_SINGLE_DOMAIN |
         STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN |
-        STARTUP_FLAGS::STARTUP_SERVER_GC
+        STARTUP_FLAGS::STARTUP_SERVER_GC |
+        STARTUP_FLAGS::STARTUP_CONCURRENT_GC
         );
 
     pCLRRuntimeHost->SetStartupFlags(dwStartupFlags);

--- a/src/klr.net45/KatanaManager.h
+++ b/src/klr.net45/KatanaManager.h
@@ -128,7 +128,8 @@ public:
 
         _HR(runtimeInfo->SetDefaultStartupFlags(
             STARTUP_LOADER_OPTIMIZATION_MULTI_DOMAIN_HOST |
-            STARTUP_SERVER_GC,
+            STARTUP_SERVER_GC |
+            STARTUP_CONCURRENT_GC,
             _clrConfigFilePath));
 
         ICLRRuntimeHostPtr runtimeHost;


### PR DESCRIPTION
This change enables background GC.
Without this flag klr.exe runs with non-concurrent GC.