### PR TITLE
possible project.json maxversion solution (#442)

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
@@ -129,8 +129,7 @@ namespace Microsoft.Framework.PackageManager
                 if (VersionUtility.ShouldUseConsidering(
                     current: bestResult.Version,
                     considering: result.Version,
-                    ideal: idealVersion,
-                    maxVersion: null))
+                    ideal: idealVersion))
                 {
                     bestResult = result;
                 }

--- a/src/Microsoft.Framework.PackageManager/Restore/RemoteWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RemoteWalkProvider.cs
@@ -40,8 +40,7 @@ namespace Microsoft.Framework.PackageManager
                 if (VersionUtility.ShouldUseConsidering(
                     current: bestResult == null ? null : bestResult.Version,
                     considering: result.Version,
-                    ideal: library.Version,
-                    maxVersion: library.MaxVersion))
+                    ideal: library))
                 {
                     bestResult = result;
                 }

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreOperations.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreOperations.cs
@@ -176,8 +176,7 @@ namespace Microsoft.Framework.PackageManager
                     if (VersionUtility.ShouldUseConsidering(
                         current: localMatch.Library.Version,
                         considering: remoteMatch.Library.Version,
-                        ideal: library.Version,
-                        maxVersion: library.MaxVersion))
+                        ideal: library))
                     {
                         return remoteMatch;
                     }
@@ -218,8 +217,7 @@ namespace Microsoft.Framework.PackageManager
                 if (VersionUtility.ShouldUseConsidering(
                     current: (bestMatch == null || bestMatch.Library == null) ? null : bestMatch.Library.Version,
                     considering: (match == null || match.Library == null) ? null : match.Library.Version,
-                    ideal: library.Version,
-                    maxVersion: library.MaxVersion))
+                    ideal: library))
                 {
                     bestMatch = match;
                 }
@@ -241,8 +239,7 @@ namespace Microsoft.Framework.PackageManager
                 if (VersionUtility.ShouldUseConsidering(
                     current: (bestMatch == null || bestMatch.Library == null) ? null : bestMatch.Library.Version,
                     considering: (match == null || match.Library == null) ? null : match.Library.Version,
-                    ideal: library.Version,
-                    maxVersion:library.MaxVersion))
+                    ideal: library))
                 {
                     bestMatch = match;
                 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/Library.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/Library.cs
@@ -7,14 +7,28 @@ using System.Collections.Generic;
 
 namespace Microsoft.Framework.Runtime
 {
-    public class Library : IEquatable<Library>
+    public class Library : VersionSpec,IEquatable<Library>
     {
+        public Library()
+        {
+            IsMinInclusive = true;
+            IsMaxInclusive = true;
+        }
+
+        public Library(VersionSpec version)
+        {
+            if (version == null)
+                return;
+            IsMinInclusive = version.IsMinInclusive;
+            IsMaxInclusive = version.IsMaxInclusive;
+            MinVersion = version.MinVersion;
+            MaxVersion = version.MaxVersion;
+        }
+
         public string Name { get; set; }
 
-        public SemanticVersion Version { get; set; }
-
-        public SemanticVersion MaxVersion { get; set; }
-
+        public SemanticVersion Version { get { return MinVersion; } set { MinVersion = value; } }
+        
         public bool IsGacOrFrameworkReference { get; set; }
 
         public override string ToString()
@@ -28,7 +42,10 @@ namespace Microsoft.Framework.Runtime
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return string.Equals(Name, other.Name) &&
-                Equals(Version, other.Version) &&
+                IsMaxInclusive == other.IsMaxInclusive &&
+                IsMinInclusive == other.IsMinInclusive &&
+                Equals(MinVersion, other.MinVersion) &&
+                Equals(MaxVersion, other.MaxVersion) &&
                 Equals(IsGacOrFrameworkReference, other.IsGacOrFrameworkReference);
         }
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Framework.Runtime
                 new Library
                 {
                     Name = name,
-                    Version = version
+                    MinVersion = version,
                 },
                 LibraryDependencyType.Default)
         {
@@ -53,7 +53,7 @@ namespace Microsoft.Framework.Runtime
                 new Library
                 {
                     Name = name,
-                    Version = version,
+                    MinVersion = version,
                     IsGacOrFrameworkReference = isGacOrFrameworkReference
                 },
                 type)
@@ -61,16 +61,13 @@ namespace Microsoft.Framework.Runtime
         }
         public LibraryDependency(
             string name,
-            SemanticVersion version,
+            VersionSpec versionSpec,
             bool isGacOrFrameworkReference,
-            LibraryDependencyType type,
-            SemanticVersion maxVersion) : this(
-                new Library
+            LibraryDependencyType type) : this(
+                new Library(versionSpec)
                 {
                     Name = name,
-                    Version = version,
-                    IsGacOrFrameworkReference = isGacOrFrameworkReference,
-                    MaxVersion = maxVersion
+                    IsGacOrFrameworkReference = isGacOrFrameworkReference
                 },
                 type)
         {
@@ -102,12 +99,7 @@ namespace Microsoft.Framework.Runtime
         {
             get { return Library.Version; }
         }
-
-        public SemanticVersion MaxVersion
-        {
-            get { return Library.MaxVersion; }
-        }
-
+        
         public bool IsGacOrFrameworkReference
         {
             get { return Library.IsGacOrFrameworkReference; }
@@ -128,14 +120,13 @@ namespace Microsoft.Framework.Runtime
                 isGacOrFrameworkReference: Library.IsGacOrFrameworkReference,
                 type: Type);
         }
-        public LibraryDependency ChangeVersion(SemanticVersion version, SemanticVersion maxVersion)
+        public LibraryDependency ChangeVersion(VersionSpec versionSpec)
         {
             return new LibraryDependency(
                 name: Library.Name,
-                version: version,
+                versionSpec: versionSpec,
                 isGacOrFrameworkReference: Library.IsGacOrFrameworkReference,
-                type: Type,
-                maxVersion: maxVersion);
+                type: Type);
         }
 
         public bool HasFlag(LibraryDependencyTypeFlag flag)

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -376,7 +376,7 @@ namespace Microsoft.Framework.Runtime
                     current: bestMatch != null ? bestMatch.Version : null,
                     considering: packageInfo.Version,
                     ideal: version,
-                    maxVersion: maxVersion))
+                    highest: maxVersion))
                 {
                     bestMatch = packageInfo;
                 }

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -1061,15 +1061,41 @@ namespace NuGet
         public static bool ShouldUseConsidering(
             SemanticVersion current,
             SemanticVersion considering,
+            SemanticVersion ideal)
+        {
+            var verSpec = new VersionSpec {
+                MinVersion = ideal,
+                IsMinInclusive = true
+            };
+            return ShouldUseConsidering(current, considering, verSpec);
+        }
+        public static bool ShouldUseConsidering(
+            SemanticVersion current,
+            SemanticVersion considering,
             SemanticVersion ideal,
-            SemanticVersion maxVersion)
+            SemanticVersion highest)
+        {
+            var verSpec = new VersionSpec
+            {
+                MinVersion = ideal,
+                IsMinInclusive = true,
+                MaxVersion = highest,
+                IsMaxInclusive = true
+            };
+            return ShouldUseConsidering(current, considering, verSpec);
+        }
+
+        public static bool ShouldUseConsidering(
+            SemanticVersion current,
+            SemanticVersion considering,
+            VersionSpec ideal)
         {
             if (considering == null)
             {
                 // skip nulls
                 return false;
             }
-            if (!considering.EqualsSnapshot(ideal) && considering < ideal)
+            if (!considering.EqualsSnapshot(ideal.MinVersion) && considering < ideal.MinVersion)
             {
                 // don't use anything that's less than the requested version
                 return false;
@@ -1079,14 +1105,31 @@ namespace NuGet
                 // always use version when it's the first valid
                 return true;
             }
-            if (current.EqualsSnapshot(ideal) &&
-                considering.EqualsSnapshot(ideal))
+            if ((!ideal.IsMinInclusive && considering.Equals(ideal.MinVersion)))
+            {
+                // don't use a package equal to the minimal version, if Minimal is not inclusive
+                return false;
+            }
+            if (current.EqualsSnapshot(ideal.MinVersion) && considering.EqualsSnapshot(ideal.MinVersion))
             {
                 // favor higher version when they both match a snapshot patter
                 if (current < considering)
                 {
-                    //take this version if no max version is specified or it's bellow or the same than the max version
-                    return maxVersion == null || considering <= maxVersion;
+                    if (ideal.MaxVersion == null)
+                    {
+                        // no max version is specified, take the higher version
+                        return true;
+                    }
+
+                    // take the highest allowed version
+                    if (ideal.IsMaxInclusive)
+                    {
+                        return considering <= ideal.MaxVersion;
+                    }
+                    else
+                    {
+                        return considering < ideal.MaxVersion;
+                    }
                 }
                 return false;
             }

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
@@ -62,19 +62,21 @@ namespace Microsoft.Framework.Runtime.Tests
         ""B"": ""1.0-alpha-*"",
         ""C"": ""1.0.0"",
         ""D"": { ""version"": ""2.0.0"" },
-        ""E"": { ""version"": ""2.0.1"", ""maxVersion"": ""2.13.37"" }
+        ""E"": { ""min"": ""2.0.1"", ""max"": ""2.13.37"" },
+        ""F"": ""[1.6.6,2.0.0)"",
     }
 }",
 "foo",
 @"c:\foo\project.json");
 
             Assert.NotNull(project.Dependencies);
-            Assert.Equal(5, project.Dependencies.Count);
+            Assert.Equal(6, project.Dependencies.Count);
             var d1 = project.Dependencies[0];
             var d2 = project.Dependencies[1];
             var d3 = project.Dependencies[2];
             var d4 = project.Dependencies[3];
             var d5 = project.Dependencies[4];
+            var d6 = project.Dependencies[5];
             Assert.Equal("A", d1.Name);
             Assert.Null(d1.Version);
             Assert.Equal("B", d2.Name);
@@ -88,8 +90,13 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.False(d4.Version.IsSnapshot);
             Assert.Equal("E", d5.Name);
             Assert.Equal(SemanticVersion.Parse("2.0.1"), d5.Version);
-            Assert.Equal(SemanticVersion.Parse("2.13.37"), d5.MaxVersion);
+            Assert.Equal(SemanticVersion.Parse("2.13.37"), d5.Library.MaxVersion);
             Assert.False(d5.Version.IsSnapshot);
+            Assert.Equal("F", d6.Name);
+            Assert.Equal(SemanticVersion.Parse("1.6.6"), d6.Version);
+            Assert.True(d6.Library.IsMinInclusive);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d6.Library.MaxVersion);
+            Assert.False(d6.Library.IsMaxInclusive);
         }
 
         [Fact]
@@ -104,7 +111,8 @@ namespace Microsoft.Framework.Runtime.Tests
                 ""B"": ""1.0-alpha-*"",
                 ""C"": ""1.0.0"",
                 ""D"": { ""version"": ""2.0.0"" },
-                ""E"": { ""version"": ""2.0.1"", ""maxVersion"": ""2.13.37"" }
+                ""E"": { ""min"": ""2.0.1"", ""max"": ""2.13.37"" },
+                ""F"": ""[1.6.6,2.0.0)"",
             }
         }
     }
@@ -115,12 +123,13 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Empty(project.Dependencies);
             var targetFrameworkInfo = project.GetTargetFrameworks().First();
             Assert.NotNull(targetFrameworkInfo.Dependencies);
-            Assert.Equal(5, targetFrameworkInfo.Dependencies.Count);
+            Assert.Equal(6, targetFrameworkInfo.Dependencies.Count);
             var d1 = targetFrameworkInfo.Dependencies[0];
             var d2 = targetFrameworkInfo.Dependencies[1];
             var d3 = targetFrameworkInfo.Dependencies[2];
             var d4 = targetFrameworkInfo.Dependencies[3];
             var d5 = targetFrameworkInfo.Dependencies[4];
+            var d6 = targetFrameworkInfo.Dependencies[5];
             Assert.Equal("A", d1.Name);
             Assert.Null(d1.Version);
             Assert.Equal("B", d2.Name);
@@ -134,8 +143,13 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.False(d4.Version.IsSnapshot);
             Assert.Equal("E", d5.Name);
             Assert.Equal(SemanticVersion.Parse("2.0.1"), d5.Version);
-            Assert.Equal(SemanticVersion.Parse("2.13.37"), d5.MaxVersion);
+            Assert.Equal(SemanticVersion.Parse("2.13.37"), d5.Library.MaxVersion);
             Assert.False(d5.Version.IsSnapshot);
+            Assert.Equal("F", d6.Name);
+            Assert.Equal(SemanticVersion.Parse("1.6.6"), d6.Version);
+            Assert.True(d6.Library.IsMinInclusive);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d6.Library.MaxVersion);
+            Assert.False(d6.Library.IsMaxInclusive);
         }
 
         [Fact]
@@ -150,7 +164,8 @@ namespace Microsoft.Framework.Runtime.Tests
                 ""B"": ""1.0-alpha-*"",
                 ""C"": ""1.0.0"",
                 ""D"": { ""version"": ""2.0.0"" },
-                ""E"": { ""version"": ""2.0.1"", ""maxVersion"": ""2.13.37"" }
+                ""E"": { ""min"": ""2.0.1"", ""max"": ""2.13.37"" },
+                ""F"": ""[1.6.6,2.0.0)"",
             }
         }
     }
@@ -160,12 +175,13 @@ namespace Microsoft.Framework.Runtime.Tests
 
             Assert.Empty(project.Dependencies);
             var targetFrameworkInfo = project.GetTargetFrameworks().First();
-            Assert.Equal(5, targetFrameworkInfo.Dependencies.Count);
+            Assert.Equal(6, targetFrameworkInfo.Dependencies.Count);
             var d1 = targetFrameworkInfo.Dependencies[0];
             var d2 = targetFrameworkInfo.Dependencies[1];
             var d3 = targetFrameworkInfo.Dependencies[2];
             var d4 = targetFrameworkInfo.Dependencies[3];
             var d5 = targetFrameworkInfo.Dependencies[4];
+            var d6 = targetFrameworkInfo.Dependencies[5];
             Assert.Equal("A", d1.Name);
             Assert.Null(d1.Version);
             Assert.True(d1.IsGacOrFrameworkReference);
@@ -183,8 +199,13 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.True(d4.IsGacOrFrameworkReference);
             Assert.Equal("E", d5.Name);
             Assert.Equal(SemanticVersion.Parse("2.0.1"), d5.Version);
-            Assert.Equal(SemanticVersion.Parse("2.13.37"), d5.MaxVersion);
+            Assert.Equal(SemanticVersion.Parse("2.13.37"), d5.Library.MaxVersion);
             Assert.False(d5.Version.IsSnapshot);
+            Assert.Equal("F", d6.Name);
+            Assert.Equal(SemanticVersion.Parse("1.6.6"), d6.Version);
+            Assert.True(d6.Library.IsMinInclusive);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d6.Library.MaxVersion);
+            Assert.False(d6.Library.IsMaxInclusive);
         }
 
         [Fact]

--- a/test/Microsoft.Framework.Runtime.Tests/project.json
+++ b/test/Microsoft.Framework.Runtime.Tests/project.json
@@ -1,6 +1,9 @@
 {
     "dependencies": {
-        "Microsoft.Framework.Runtime": "1.0.0-*",
+        "Microsoft.Framework.Runtime": {
+            "version": "1.0.0-*",
+            "maxVersion": "7.0.1"
+        },
         "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*",
         "Shouldly": "1.1.1.1",
         "Xunit.KRunner": "1.0.0-*"


### PR DESCRIPTION
What do you think, is this a good way to solve the issue #442?

Also I'm wondering if it wouldn't be better to use min/max as json property keys, instead of version/maxVersion.
e.g.

```
"dependencies": {
    "some.libary": {"min": "1.0.0-*", "max": "1.99.99"}
}
```

However I don't know in which projects the "version" key is currently used nor if a possible breaking change is even still accepted in the beta.

Note: I didn't yet sign the CLA nor write a test which tests the enforcement of the max version (only updated the existing json parsing tests), before I do so, I'd like some feedback if this has any chance of being accepted
