### PR TITLE
Update the post build scripts to use project:BuildOutputDir

### DIFF
--- a/src/Microsoft.Framework.ApplicationHost/project.json
+++ b/src/Microsoft.Framework.ApplicationHost/project.json
@@ -27,8 +27,8 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }
 }

--- a/src/Microsoft.Framework.DesignTimeHost/project.json
+++ b/src/Microsoft.Framework.DesignTimeHost/project.json
@@ -37,8 +37,8 @@
     },
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin/lib/Microsoft.Framework.DesignTimeHost",
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin/lib/Microsoft.Framework.DesignTimeHost"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin/lib/Microsoft.Framework.DesignTimeHost",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin/lib/Microsoft.Framework.DesignTimeHost"
         ]
     }
 }

--- a/src/Microsoft.Framework.PackageManager/project.json
+++ b/src/Microsoft.Framework.PackageManager/project.json
@@ -71,8 +71,8 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }
 }

--- a/src/Microsoft.Framework.Runtime.Loader/project.json
+++ b/src/Microsoft.Framework.Runtime.Loader/project.json
@@ -23,8 +23,8 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn/project.json
+++ b/src/Microsoft.Framework.Runtime.Roslyn/project.json
@@ -30,8 +30,8 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }
 }

--- a/src/Microsoft.Framework.Runtime/project.json
+++ b/src/Microsoft.Framework.Runtime/project.json
@@ -59,8 +59,8 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }
 }

--- a/src/klr.core45.managed/project.json
+++ b/src/klr.core45.managed/project.json
@@ -27,7 +27,7 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }
 }

--- a/src/klr.host/project.json
+++ b/src/klr.host/project.json
@@ -36,8 +36,8 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }
 }

--- a/src/klr.net45.managed/project.json
+++ b/src/klr.net45.managed/project.json
@@ -12,7 +12,7 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:Directory%/bin/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin"
         ]
     }
 }


### PR DESCRIPTION
The `%BuildOutputDir%` is enabled in c4d7cd4f4bfc243b5507046288671af9a0fe34ed
