### PR TITLE
Fix Linux build on a vanilla system

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ if test ! -d packages/KoreBuild; then
 fi
 
 if ! type k > /dev/null 2>&1; then
-    source setup/kvm.sh
+    source packages/KoreBuild/build/kvm.sh
 fi
 
 if ! type k > /dev/null 2>&1; then


### PR DESCRIPTION
Commit 57ad3b4 removed the scripts from the setup folder. This commit duplicates the change to build.cmd in build.sh.
This is only noticable on computers without kvm installed for the current user.
