### PR TITLE
Moving the wait time for rapid refresh scenarios

### DIFF
--- a/src/Microsoft.Framework.Runtime/DefaultHost.cs
+++ b/src/Microsoft.Framework.Runtime/DefaultHost.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Framework.Runtime
                 var networkStream = new NetworkStream(socket);
 
                 _applicationHostContext.AddService(typeof(IDesignTimeHostCompiler),
-                    new DesignTimeHostCompiler(_shutdown, networkStream), includeInManifest: false);
+                    new DesignTimeHostCompiler(_shutdown, _watcher, networkStream), includeInManifest: false);
 
                 // Change the project reference provider
                 Project.DefaultLanguageServicesAssembly = typeof(DefaultHost).GetTypeInfo().Assembly.GetName().Name;

--- a/src/Microsoft.Framework.Runtime/DesignTime/ProcessingQueue.cs
+++ b/src/Microsoft.Framework.Runtime/DesignTime/ProcessingQueue.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Framework.Runtime
         public event Action<int, CompileResponse> ProjectCompiled;
         public event Action<int> ProjectChanged;
         public event Action Closed;
+        public event Action<IEnumerable<string>> ProjectSources;
 
         public ProcessingQueue(Stream stream)
         {
@@ -76,6 +77,17 @@ namespace Microsoft.Framework.Runtime
                         compileResponse.PdbBytes = _reader.ReadBytes(pdbBytesLength);
 
                         ProjectCompiled(id, compileResponse);
+                    }
+                    else if(messageType == "Sources")
+                    {
+                        int count = _reader.ReadInt32();
+                        var files = new List<string>();
+                        for (int i = 0; i < count; i++)
+                        {
+                            files.Add(_reader.ReadString());
+                        }
+
+                        ProjectSources(files);
                     }
                     else if (messageType == "ProjectContexts")
                     {


### PR DESCRIPTION
- Move the notification of project changed to happen before the compilation
  instead of after.
- Return the list of sources files to the runtime so that it can watch files.
  This allows the runtime (for certain changes) to shutdown faster than
  VS can tell the DTH that anything changed.

/cc @DamianEdwards @PradeepKadubandi @BillHiebert 

It might be worth looking into the time it takes to receive the message when it originates from VS. I couldn't get it fast enough just relying on the DTH communication.
