### PR TITLE
Fixed running Windows-packed projects on Linux

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackProject.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Framework.PackageManager.Packing
                 UpdateJson(targetProjectJson, jsonObj =>
                 {
                     var targetWebRootPath = Path.Combine(root.OutputPath, WwwRootOut);
-                    jsonObj["webroot"] = PathUtility.GetRelativePath(targetProjectJson, targetWebRootPath);
+                    jsonObj["webroot"] = PathUtility.GetRelativePath(targetProjectJson, targetWebRootPath, '/');
                 });
             }
         }

--- a/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackRoot.cs
@@ -176,8 +176,9 @@ namespace Microsoft.Framework.PackageManager.Packing
             var applicationRoot = Path.Combine(OutputPath, PackRoot.AppRootName);
 
             rootObject["dependencies"] = dependenciesObj;
-            rootObject["packages"] = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(applicationRoot),
-                                                                 TargetPackagesPath);
+            rootObject["packages"] = PathUtility.GetRelativePath(
+                PathUtility.EnsureTrailingForwardSlash(applicationRoot),
+                TargetPackagesPath, '/');
 
             File.WriteAllText(Path.Combine(applicationRoot, GlobalSettings.GlobalFileName),
                 rootObject.ToString());


### PR DESCRIPTION
The project.json generated on Windows makes the webroot path relative to the pack folder, but does so using Path.DirectorySeparatorChar which is '\'. This path throws when runnig the project under Linux.

This PR changes the two paths in JSON files I found ('webroot' in project.json and 'packages' in global.json) to consistently use forward slashes.
