### PR TITLE
Incremental on mono

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,0 @@
-CURDIR=`pwd`
-
-all: compile
-
-prepare-output:
-	mkdir -p artifacts/build/klr.mono.managed
-
-compile: prepare-output
-	mcs src/klr.mono.managed/EntryPoint.cs src/klr.hosting.shared/RuntimeBootstrapper.cs src/klr.hosting.shared/LoaderEngine.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineParser.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOptions.cs src/Microsoft.Framework.CommandLineUtils/CommandLine/CommandOptionType.cs /target:exe /unsafe /out:artifacts/build/klr.mono.managed/klr.mono.managed.dll /r:"System;System.Core" /define:NET45

--- a/src/Microsoft.Framework.ApplicationHost/project.json
+++ b/src/Microsoft.Framework.ApplicationHost/project.json
@@ -28,6 +28,7 @@
     "scripts": {
         "postbuild": [
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-Mono/bin",
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }

--- a/src/Microsoft.Framework.DesignTimeHost/project.json
+++ b/src/Microsoft.Framework.DesignTimeHost/project.json
@@ -38,6 +38,7 @@
     "scripts": {
         "postbuild": [
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin/lib/Microsoft.Framework.DesignTimeHost",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-Mono/bin/lib/Microsoft.Framework.DesignTimeHost",
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin/lib/Microsoft.Framework.DesignTimeHost"
         ]
     }

--- a/src/Microsoft.Framework.PackageManager/project.json
+++ b/src/Microsoft.Framework.PackageManager/project.json
@@ -71,8 +71,9 @@
 
     "scripts": {
         "postbuild": [
-            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
-            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin/lib/Microsoft.Framework.PackageManager",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-Mono/bin/lib/Microsoft.Framework.PackageManager",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin/lib/Microsoft.Framework.PackageManager"
         ]
     }
 }

--- a/src/Microsoft.Framework.Runtime.Loader/project.json
+++ b/src/Microsoft.Framework.Runtime.Loader/project.json
@@ -24,6 +24,7 @@
     "scripts": {
         "postbuild": [
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-Mono/bin",
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }

--- a/src/Microsoft.Framework.Runtime.Roslyn/project.json
+++ b/src/Microsoft.Framework.Runtime.Roslyn/project.json
@@ -31,6 +31,7 @@
     "scripts": {
         "postbuild": [
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-Mono/bin",
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }

--- a/src/Microsoft.Framework.Runtime/project.json
+++ b/src/Microsoft.Framework.Runtime/project.json
@@ -60,6 +60,7 @@
     "scripts": {
         "postbuild": [
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-CLR-x86/bin",
+            "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/KRE-Mono/bin",
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnetcore50/*.* %project:Directory%/../../artifacts/build/KRE-CoreCLR-x86/bin"
         ]
     }

--- a/src/klr.mono.managed/makefile
+++ b/src/klr.mono.managed/makefile
@@ -1,0 +1,6 @@
+CURDIR=`pwd`
+
+all: compile
+
+compile: 
+	mcs EntryPoint.cs ../klr.hosting.shared/RuntimeBootstrapper.cs ../klr.hosting.shared/LoaderEngine.cs ../Microsoft.Framework.CommandLineUtils/CommandLine/CommandArgument.cs ../Microsoft.Framework.CommandLineUtils/CommandLine/CommandLineApplication.cs ../Microsoft.Framework.CommandLineUtils/CommandLine/CommandOption.cs ../Microsoft.Framework.CommandLineUtils/CommandLine/CommandOptionType.cs /target:exe /unsafe /out:../../artifacts/build/KRE-Mono/bin/klr.mono.managed.dll /r:"System;System.Core" /define:ASPNET50


### PR DESCRIPTION
- Allow incremental builds of the runtime on mono
- Updated the script blocks to copy things to the right folders
- Moved makefile into klr.mono.managed folder where it belongs. This
  allows customizing the mono bootstrapped itself.
