### PR TITLE
Configure KRE to enable the latest behavior for back compat

### DIFF
--- a/src/klr.core45/klr.core45.cpp
+++ b/src/klr.core45/klr.core45.cpp
@@ -432,6 +432,7 @@ extern "C" __declspec(dllexport) bool __stdcall CallApplicationMain(PCALL_APPLIC
         // NATIVE_DLL_SEARCH_DIRECTORIES
         // - The list of paths that will be probed for native DLLs called by PInvoke
         //
+        L"AppDomainCompatSwitch",
     };
 
     cchTrustedPlatformAssemblies = TRUSTED_PLATFORM_ASSEMBLIES_STRING_BUFFER_SIZE_CCH;
@@ -483,6 +484,8 @@ extern "C" __declspec(dllexport) bool __stdcall CallApplicationMain(PCALL_APPLIC
         pwszTrustedPlatformAssemblies,
         // APP_PATHS
         wszAppPaths,
+        // Use the latest behavior when TFM not specified
+        L"UseLatestBehaviorWhenTFMNotSpecified",
     };
 
     DWORD domainId;

--- a/src/klr.net45.managed/DomainManager.cs
+++ b/src/klr.net45.managed/DomainManager.cs
@@ -19,6 +19,7 @@ public class DomainManager : AppDomainManager
         if (!string.IsNullOrEmpty(_info.ApplicationBase))
         {
             appDomainInfo.ApplicationBase = _info.ApplicationBase;
+            appDomainInfo.TargetFrameworkName = ".NETFramework,Version=v4.6";
         }
     }
 


### PR DESCRIPTION
 - Enable the CoreCLR host to pass the right compat switch
 - Set the .Net 4.6 TFM for the desktop host

#931