### PR TITLE
Fixing the casing issue with word Nuget -> NuGet

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Framework.PackageManager
                     CommandOptionType.SingleValue);
                 var optionOverwrite = c.Option("--overwrite", "Remove existing files in target folders",
                     CommandOptionType.NoValue);
-                var optionNoSource = c.Option("--no-source", "Compiles the source files into Nuget packages",
+                var optionNoSource = c.Option("--no-source", "Compiles the source files into NuGet packages",
                     CommandOptionType.NoValue);
                 var optionRuntime = c.Option("--runtime <KRE>", "Name or full path of the KRE folder to include",
                     CommandOptionType.MultipleValue);


### PR DESCRIPTION
kpm pack command line help contains the word Nuget. Fixing this to NuGet per Eilon's CR feedback.

@Eilon 
