### PR TITLE
Propagate build errors during pack to a proper exit code

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Bundle/BundleManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Bundle/BundleManager.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
                 }
             }
 
-            root.Emit();
+            var emitSuccess = root.Emit();
 
             if (!ScriptExecutor.Execute(project, "postbundle", getVariable))
             {
@@ -264,7 +264,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
             sw.Stop();
 
             _options.Reports.Information.WriteLine("Time elapsed {0}", sw.Elapsed);
-            return !anyUnresolvedDependency;
+            return !anyUnresolvedDependency && emitSuccess;
         }
 
         bool TryAddRuntime(BundleRoot root, FrameworkName frameworkName, string runtimePath)

--- a/src/Microsoft.Framework.PackageManager/Bundle/BundleRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Bundle/BundleRoot.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
 
         public IServiceProvider HostServices { get; private set; }
 
-        public void Emit()
+        public bool Emit()
         {
             Reports.Quiet.WriteLine("Copying to output path {0}", OutputPath);
 
@@ -60,9 +60,11 @@ namespace Microsoft.Framework.PackageManager.Bundle
                 deploymentPackage.Emit(this);
             }
 
+            var success = true;
+
             foreach (var deploymentProject in Projects)
             {
-                deploymentProject.Emit(this);
+                success &= deploymentProject.Emit(this);
             }
 
             foreach (var deploymentRuntime in Runtimes)
@@ -79,6 +81,8 @@ namespace Microsoft.Framework.PackageManager.Bundle
 
             // Generate executables (bash scripts without .sh extension) for *nix
             GenerateBashScripts();
+
+            return success;
         }
 
         private void GenerateBatchFiles()


### PR DESCRIPTION
When building during packing fails, this is only visible through the log messages---the pack command returns a 0 success code. The end result is a folder with everything including the script files except the actual package folder with actual project.

I was blinkered during these changes, but all in all, the error handling seemed quite messy :-/