### PR TITLE
Exclude comments when getting JToken values as an array

### DIFF
--- a/src/Microsoft.Framework.Runtime/JTokenExtensions.cs
+++ b/src/Microsoft.Framework.Runtime/JTokenExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.Runtime
     {
         public static T[] ValueAsArray<T>(this JToken jToken)
         {
-            return jToken.Select(a => a.Value<T>()).ToArray();
+            return jToken.Where(x => x.Type != JTokenType.Comment).Select(a => a.Value<T>()).ToArray();
         }
 
         public static T[] ValueAsArray<T>(this JToken jToken, string name)

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFilesCollectionFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFilesCollectionFacts.cs
@@ -59,6 +59,30 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Equal(new[] { "a.cs", @"foo.js" }, target.ResourcesPatterns);
         }
 
+
+        [Fact]
+        public void FilePatternsDoNotIncludeComments()
+        {
+            var rawProject = Deserialize(@"
+{
+    ""code"": [""*.cs"", /* FOO */ ""../*.cs""],
+    ""exclude"": [""buggy/*.*"", /* FOO */],
+    ""bundleExclude"": [""no_pack/*.*"", /* FOO */],
+    ""preprocess"": [""other/**/*.cs"", /* FOO */ ""*.cs"", ""*.*""],
+    ""shared"": [""shared/**/*.cs;../../shared/*.cs"", /* FOO */],
+    ""resources"": [""a.cs"", /* FOO */ ""foo.js""]
+}");
+
+            var target = new ProjectFilesCollection(rawProject, string.Empty);
+
+            Assert.Equal(new[] { "*.cs", @"../*.cs" }, target.SourcePatterns);
+            Assert.Equal(new[] { @"buggy/*.*" }, target.ExcludePatterns);
+            Assert.Equal(new[] { @"no_pack/*.*" }, target.BundleExcludePatterns);
+            Assert.Equal(new[] { @"other/**/*.cs", "*.cs", "*.*" }, target.PreprocessPatterns);
+            Assert.Equal(new[] { @"shared/**/*.cs", @"../../shared/*.cs" }, target.SharedPatterns);
+            Assert.Equal(new[] { "a.cs", @"foo.js" }, target.ResourcesPatterns);
+        }
+
         [Fact]
         public void DefaultSourcePatternsAreUsedIfNoneSpecified()
         {

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFilesCollectionFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFilesCollectionFacts.cs
@@ -58,18 +58,17 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Equal(new[] { @"shared/**/*.cs", @"../../shared/*.cs" }, target.SharedPatterns);
             Assert.Equal(new[] { "a.cs", @"foo.js" }, target.ResourcesPatterns);
         }
-
-
+        
         [Fact]
-        public void FilePatternsDoNotIncludeComments()
+        public void FilePatternsDoNotIncludeBlockComments()
         {
             var rawProject = Deserialize(@"
 {
     ""code"": [""*.cs"", /* FOO */ ""../*.cs""],
-    ""exclude"": [""buggy/*.*"", /* FOO */],
-    ""bundleExclude"": [""no_pack/*.*"", /* FOO */],
+    ""exclude"": [""buggy/*.*"" /* FOO */],
+    ""bundleExclude"": [""no_pack/*.*"" /* FOO */],
     ""preprocess"": [""other/**/*.cs"", /* FOO */ ""*.cs"", ""*.*""],
-    ""shared"": [""shared/**/*.cs;../../shared/*.cs"", /* FOO */],
+    ""shared"": [""shared/**/*.cs;../../shared/*.cs"" /* FOO */],
     ""resources"": [""a.cs"", /* FOO */ ""foo.js""]
 }");
 
@@ -80,7 +79,38 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Equal(new[] { @"no_pack/*.*" }, target.BundleExcludePatterns);
             Assert.Equal(new[] { @"other/**/*.cs", "*.cs", "*.*" }, target.PreprocessPatterns);
             Assert.Equal(new[] { @"shared/**/*.cs", @"../../shared/*.cs" }, target.SharedPatterns);
-            Assert.Equal(new[] { "a.cs", @"foo.js" }, target.ResourcesPatterns);
+            Assert.Equal(new[] { "a.cs", "foo.js" }, target.ResourcesPatterns);
+        }
+
+        [Fact]
+        public void FilePatternsDoNotIncludeSingleLineComments()
+        {
+            var rawProject = Deserialize(@"
+{
+    ""code"": [""*.cs"", // Foo
+                ""../*.cs""],
+    ""exclude"": [""buggy/*.*""
+                // Foo
+                ],
+    ""bundleExclude"": [""no_pack/*.*"" // Foo
+                        ],
+    ""preprocess"": [""other/**/*.cs"", 
+                    // Foo
+                    ""*.cs"", ""*.*""],
+    ""shared"": [""shared/**/*.cs;../../shared/*.cs"" // Foo
+                ],
+    ""resources"": [""a.cs"", // Foo
+                    ""foo.js""]
+}");
+
+            var target = new ProjectFilesCollection(rawProject, string.Empty);
+
+            Assert.Equal(new[] { "*.cs", @"../*.cs" }, target.SourcePatterns);
+            Assert.Equal(new[] { @"buggy/*.*" }, target.ExcludePatterns);
+            Assert.Equal(new[] { @"no_pack/*.*" }, target.BundleExcludePatterns);
+            Assert.Equal(new[] { @"other/**/*.cs", "*.cs", "*.*" }, target.PreprocessPatterns);
+            Assert.Equal(new[] { @"shared/**/*.cs", @"../../shared/*.cs" }, target.SharedPatterns);
+            Assert.Equal(new[] { "a.cs", "foo.js" }, target.ResourcesPatterns);
         }
 
         [Fact]


### PR DESCRIPTION
Comments are currently included in the list of patterns used by kpm, which causes build and restore operations to fail.  I noticed this when working with the [Azure storage](https://github.com/Azure/azure-storage-net/blob/master/Lib/AspNet/Microsoft.WindowsAzure.Storage/project.json) library, as their comment causes kpm to fail.

Putting this change in the JTokenExtensions.ValueAsArray method seemed a little heavy handed, but it didn't seem like any of the references could have made use of the comments anyway.

Please let me know if there should be more tests or if there are any other changes that I should make.