### PR TITLE
Don't run post build/pack scripts if build failed. (fixes #1372)

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
@@ -198,17 +198,20 @@ namespace Microsoft.Framework.PackageManager
                 }
             }
 
-            if (!ScriptExecutor.Execute(project, "postbuild", GetScriptVariable))
+            if (success)
             {
-                LogError(ScriptExecutor.ErrorMessage);
-                return false;
-            }
+                if (!ScriptExecutor.Execute(project, "postbuild", GetScriptVariable))
+                {
+                    WriteError(ScriptExecutor.ErrorMessage);
+                    success = false;
+                }
 
-            if (_buildOptions.GeneratePackages &&
-                !ScriptExecutor.Execute(project, "postpack", GetScriptVariable))
-            {
-                LogError(ScriptExecutor.ErrorMessage);
-                return false;
+                if (_buildOptions.GeneratePackages &&
+                    !ScriptExecutor.Execute(project, "postpack", GetScriptVariable))
+                {
+                    WriteError(ScriptExecutor.ErrorMessage);
+                    success = false;
+                }
             }
 
             sw.Stop();


### PR DESCRIPTION
In addition to #1372, "postpack" scripts are also skipped if the build failed, although I couldn't find the use of "postpack" and the potential difference between "postbuild" and "postpack".