### PR TITLE
Do validation before following locked lockfile

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -318,6 +318,15 @@ namespace Microsoft.Framework.PackageManager
                 useLockFile = true;
             }
 
+            if (useLockFile && !lockFile.IsValidForProject(project))
+            {
+                // Exhibit the same behavior as if it has been run with "kpm restore -lock"
+                Reports.Information.WriteLine("Updating the invalid lock file with {0}",
+                    "kpm restore --lock".Yellow().Bold());
+                useLockFile = false;
+                Lock = true;
+            }
+
             Func<string, string> getVariable = key =>
             {
                 return null;

--- a/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Framework.Runtime
             {
                 var lockFileFormat = new LockFileFormat();
                 var lockFile = lockFileFormat.Read(projectLockJsonPath);
-                validLockFile = IsValidLockFile(lockFile);
+                validLockFile = lockFile.IsValidForProject(Project);
 
                 if (validLockFile)
                 {
@@ -123,48 +123,6 @@ namespace Microsoft.Framework.Runtime
 
             var compilerOptionsProvider = new CompilerOptionsProvider(ProjectResolver);
             _serviceProvider.Add(typeof(ICompilerOptionsProvider), compilerOptionsProvider);
-        }
-
-        private bool IsValidLockFile(LockFile lockFile)
-        {
-            var actualTargetFrameworks = Project.GetTargetFrameworks();
-
-            // The lock file should contain dependencies for each framework plus dependencies shared by all frameworks
-            if (lockFile.ProjectFileDependencyGroups.Count != actualTargetFrameworks.Count() + 1)
-            {
-                return false;
-            }
-
-            foreach (var group in lockFile.ProjectFileDependencyGroups)
-            {
-                IOrderedEnumerable<string> actualDependencies;
-                var expectedDependencies = group.Dependencies.OrderBy(x => x);
-
-                // If the framework name is empty, the associated dependencies are shared by all frameworks
-                if (string.IsNullOrEmpty(group.FrameworkName))
-                {
-                    actualDependencies = Project.Dependencies.Select(x => x.LibraryRange.ToString()).OrderBy(x => x);
-                }
-                else
-                {
-                    var framework = actualTargetFrameworks
-                        .FirstOrDefault(f =>
-                            string.Equals(f.FrameworkName.ToString(), group.FrameworkName, StringComparison.Ordinal));
-                    if (framework == null)
-                    {
-                        return false;
-                    }
-
-                    actualDependencies = framework.Dependencies.Select(d => d.LibraryRange.ToString()).OrderBy(x => x);
-                }
-
-                if (!actualDependencies.SequenceEqual(expectedDependencies))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         public void AddService(Type type, object instance, bool includeInManifest)

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFile.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFile.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Framework.Runtime.DependencyManagement
 {
@@ -12,5 +13,47 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
         public IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get; set; } =
             new List<ProjectFileDependencyGroup>();
         public IList<LockFileLibrary> Libraries { get; set; } = new List<LockFileLibrary>();
+
+        public bool IsValidForProject(Project project)
+        {
+            var actualTargetFrameworks = project.GetTargetFrameworks();
+
+            // The lock file should contain dependencies for each framework plus dependencies shared by all frameworks
+            if (ProjectFileDependencyGroups.Count != actualTargetFrameworks.Count() + 1)
+            {
+                return false;
+            }
+
+            foreach (var group in ProjectFileDependencyGroups)
+            {
+                IOrderedEnumerable<string> actualDependencies;
+                var expectedDependencies = group.Dependencies.OrderBy(x => x);
+
+                // If the framework name is empty, the associated dependencies are shared by all frameworks
+                if (string.IsNullOrEmpty(group.FrameworkName))
+                {
+                    actualDependencies = project.Dependencies.Select(x => x.LibraryRange.ToString()).OrderBy(x => x);
+                }
+                else
+                {
+                    var framework = actualTargetFrameworks
+                        .FirstOrDefault(f =>
+                            string.Equals(f.FrameworkName.ToString(), group.FrameworkName, StringComparison.Ordinal));
+                    if (framework == null)
+                    {
+                        return false;
+                    }
+
+                    actualDependencies = framework.Dependencies.Select(d => d.LibraryRange.ToString()).OrderBy(x => x);
+                }
+
+                if (!actualDependencies.SequenceEqual(expectedDependencies))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
parent #1368 

@davidfowl @lodejard 
Sample output when a locked lockfile is out-of-date:
![capture](https://cloud.githubusercontent.com/assets/1383883/6610490/34582460-c81d-11e4-9755-17b589d56991.PNG)
