### PR TITLE
Bold new behavior

### DIFF
--- a/src/Microsoft.Framework.CommandLineUtils/CommandLine/AnsiConsole.cs
+++ b/src/Microsoft.Framework.CommandLineUtils/CommandLine/AnsiConsole.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
             OriginalForegroundColor = Console.ForegroundColor;
         }
 
+        private int _boldRecursion;
+
         public static AnsiConsole Output = new AnsiConsole(Console.Out);
 
         public static AnsiConsole Error = new AnsiConsole(Console.Error);
@@ -30,7 +32,13 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
 
         private void SetBold(bool bold)
         {
-            Console.ForegroundColor = (ConsoleColor)(((int)Console.ForegroundColor & 0x07) | (bold ? 0x08 : 0x00));
+            _boldRecursion += bold ? 1 : -1;
+            if (_boldRecursion > 1 || (_boldRecursion == 1 && !bold))
+            {
+                return;
+            }
+
+            Console.ForegroundColor = (ConsoleColor)((int)Console.ForegroundColor ^ 0x08);
         }
 
         public void WriteLine(string message)


### PR DESCRIPTION
#801 
![bold](https://cloud.githubusercontent.com/assets/7574801/6627500/d6dbdb02-c8bb-11e4-8ed4-02480b2de3ab.PNG)

Bold should not compromise the console color you had before running a command
Bold is now the opposite of the starting console color, i.e. Red bolded = dark red, Dark Magenta bolded = Magenta