### PR TITLE
DNX on Linux bring-up.

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -879,17 +879,17 @@ functions @{
         content.Add("#include \"stdafx.h\"");
         content.Add("#include \"tpa.h\"");
         content.Add(string.Empty);
-        content.Add("BOOL CreateTpaBase(LPWSTR** ppNames, size_t* pcNames, bool bNative)");
+        content.Add("BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)");
         content.Add("{");
         content.Add("    const size_t count = " + tpa.Length + ";");
-        content.Add("    LPWSTR* pArray = new LPWSTR[count];");
+        content.Add("    LPCTSTR* pArray = new LPCTSTR[count];");
         content.Add(string.Empty);
         content.Add("    if (bNative)");
         content.Add("    {");
 
         for (int i = 0; i < tpa.Length; ++i)
         {
-            content.Add(string.Format("        pArray[{0}] = _wcsdup(L\"{1}{2}\");", i, tpa[i], ".ni.dll"));
+            content.Add(string.Format("        pArray[{0}] = _T(\"{1}{2}\");", i, tpa[i], ".ni.dll"));
         }
 
         content.Add("    }");
@@ -898,7 +898,7 @@ functions @{
 
         for (int i = 0; i < tpa.Length; ++i)
         {
-            content.Add(string.Format("        pArray[{0}] = _wcsdup(L\"{1}{2}\");", i, tpa[i], ".dll"));
+            content.Add(string.Format("        pArray[{0}] = _T(\"{1}{2}\");", i, tpa[i], ".dll"));
         }
 
         content.Add("    }");
@@ -909,13 +909,8 @@ functions @{
         content.Add("    return true;");
         content.Add("}");
         content.Add(string.Empty);
-        content.Add("BOOL FreeTpaBase(const LPWSTR* values, const size_t count)");
+        content.Add("BOOL FreeTpaBase(const LPCTSTR* values, const size_t count)");
         content.Add("{");
-        content.Add("    for (size_t idx = 0; idx < count; ++idx)");
-        content.Add("    {");
-        content.Add("        delete[] values[idx];");
-        content.Add("    }");
-        content.Add(string.Empty);
         content.Add("    delete[] values;");
         content.Add(string.Empty);
         content.Add("    return true;");

--- a/makefile.shade
+++ b/makefile.shade
@@ -911,7 +911,7 @@ functions @{
         content.Add("    return true;");
         content.Add("}");
         content.Add(string.Empty);
-        content.Add("BOOL FreeTpaBase(const LPCTSTR* values, const size_t count)");
+        content.Add("BOOL FreeTpaBase(const LPCTSTR* values)");
         content.Add("{");
         content.Add("    delete[] values;");
         content.Add(string.Empty);

--- a/makefile.shade
+++ b/makefile.shade
@@ -628,6 +628,7 @@ var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPE
         {
             var dotnetcoreclrDepFile = Path.Combine(BUILD_DIR2, "dotnetcoreclr-dependencies.txt");
             var tpacppFile = Path.Combine(ROOT, "src", BOOTSTRAPPER_CORECLR_NAME, "tpa.cpp");
+            var tpacppFileUnix = Path.Combine(ROOT, "src", BOOTSTRAPPER_CORECLR_NAME + ".unix", "tpa.cpp");
             Environment.SetEnvironmentVariable("DNX_TRACE", "0");
             Exec("cmd", string.Format(@"/C kpm list {0} --assemblies --runtime {1} > {2}",
                 Path.Combine(ROOT, "src", BOOTSTRAPPER_HOST_NAME),
@@ -642,6 +643,7 @@ var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPE
             };
 
             UpdateTpa(dotnetcoreclrDepFile, tpaProjects, tpacppFile);
+            UpdateTpa(dotnetcoreclrDepFile, tpaProjects, tpacppFileUnix);
         }
         finally
         {

--- a/src/Microsoft.Framework.Runtime.Loader/LoadContext.cs
+++ b/src/Microsoft.Framework.Runtime.Loader/LoadContext.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Framework.Runtime.Loader
         private string GetNativeImagePath(string ilPath)
         {
             var directory = Path.GetDirectoryName(ilPath);
-            var arch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+            var arch = IntPtr.Size == 4 ? "x86" : "AMD64";
 
             var nativeImageName = Path.GetFileNameWithoutExtension(ilPath) + ".ni.dll";
             var nativePath = Path.Combine(directory, arch, nativeImageName);

--- a/src/dnx.coreclr.unix/Makefile
+++ b/src/dnx.coreclr.unix/Makefile
@@ -1,0 +1,2 @@
+all:
+	clang++-3.5 -fPIC -shared tpa.cpp dnx.coreclr.cpp -g -o dnx.coreclr.so --std=c++11 -ldl

--- a/src/dnx.coreclr.unix/dnx.coreclr.cpp
+++ b/src/dnx.coreclr.unix/dnx.coreclr.cpp
@@ -60,7 +60,7 @@ bool GetTrustedPlatformAssembliesList(const std::string& tpaDirectory, bool isNa
 
     if (ppszTpaAssemblyNames)
     {
-        FreeTpaBase(ppszTpaAssemblyNames, cTpaAssemblyNames);
+        FreeTpaBase(ppszTpaAssemblyNames);
     }
 
     return true;

--- a/src/dnx.coreclr.unix/dnx.coreclr.cpp
+++ b/src/dnx.coreclr.unix/dnx.coreclr.cpp
@@ -1,0 +1,231 @@
+#include "stdafx.h"
+#include "tpa.h"
+#include <assert.h>
+
+// Windows types used by the ExecuteAssembly function
+typedef int32_t HRESULT;
+typedef const char* LPCSTR;
+typedef uint32_t DWORD;
+
+typedef struct CALL_APPLICATION_MAIN_DATA
+{
+    char* applicationBase;
+    char* runtimeDirectory;
+    int argc;
+    char** argv;
+    int exitcode;
+} *PCALL_APPLICATION_MAIN_DATA;
+
+// Prototype of the ExecuteAssembly function from the libcoreclr.do
+typedef HRESULT (*ExecuteAssemblyFunction)(
+                    LPCSTR exePath,
+                    LPCSTR coreClrPath,
+                    LPCSTR appDomainFriendlyName,
+                    int propertyCount,
+                    LPCSTR* propertyKeys,
+                    LPCSTR* propertyValues,
+                    int argc,
+                    LPCSTR* argv,
+                    LPCSTR managedAssemblyPath,
+                    LPCSTR entryPointAssemblyName,
+                    LPCSTR entryPointTypeName,
+                    LPCSTR entryPointMethodsName,
+                    DWORD* exitCode);
+
+const HRESULT S_OK = 0;
+const HRESULT E_FAIL = -1;
+
+bool GetTrustedPlatformAssembliesList(const std::string& tpaDirectory, bool isNative, std::string& trustedPlatformAssemblies)
+{
+    size_t cTpaAssemblyNames = 0;
+    LPCTSTR* ppszTpaAssemblyNames = nullptr;
+
+    CreateTpaBase(&ppszTpaAssemblyNames, &cTpaAssemblyNames, isNative);
+
+    assert(ppszTpaAssemblyNames != nullptr || cTpaAssemblyNames == 0);
+
+    //TODO: The Windows version of this actaully ensures the files are present.  We just fail for native and assume MSIL is present
+    if (isNative)
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < cTpaAssemblyNames; i++)
+    {
+        trustedPlatformAssemblies.append(tpaDirectory);
+        trustedPlatformAssemblies.append("/");
+        trustedPlatformAssemblies.append(ppszTpaAssemblyNames[i]);
+        trustedPlatformAssemblies.append(":");
+    }
+
+    if (ppszTpaAssemblyNames)
+    {
+        FreeTpaBase(ppszTpaAssemblyNames, cTpaAssemblyNames);
+    }
+
+    return true;
+}
+
+// TODO: Figure out if runtimeDirectory should have a trailing "/".  Need to look at what happens on Windows.
+void* LoadCoreClr(std::string& runtimeDirectory)
+{
+    void* ret = nullptr;
+
+    char* coreClrEnvVar = getenv("CORECLR_DIR");
+
+    if (coreClrEnvVar)
+    {
+        runtimeDirectory = coreClrEnvVar;
+
+        std::string coreClrDllPath = runtimeDirectory;
+        coreClrDllPath.append("/");
+        coreClrDllPath.append("libcoreclr.so");
+
+        ret = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    }
+
+    if (!ret)
+    {
+        // Try to load coreclr from application path.
+        char pathToBootstrapper[PATH_MAX];
+        ssize_t pathLen = readlink("/proc/self/exe", pathToBootstrapper, PATH_MAX - 1);
+
+        if (pathLen != -1)
+        {
+            pathToBootstrapper[pathLen] = '\0';
+            runtimeDirectory.assign(pathToBootstrapper);
+
+            size_t lastSlash = runtimeDirectory.rfind('/');
+
+            if (lastSlash != std::string::npos)
+            {
+                runtimeDirectory.erase(lastSlash);
+
+                std::string coreClrDllPath = runtimeDirectory;
+                coreClrDllPath.append("/");
+                coreClrDllPath.append("libcoreclr.so");
+
+                ret = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_GLOBAL);
+            }
+        }
+    }
+
+    return ret;
+}
+
+extern "C" HRESULT CallApplicationMain(PCALL_APPLICATION_MAIN_DATA data)
+{
+    HRESULT hr = S_OK;
+    size_t cchTrustedPlatformAssemblies = 0;
+    std::string runtimeDirectory;
+
+    if (data->runtimeDirectory)
+    {
+        runtimeDirectory = data->runtimeDirectory;
+    }
+    else
+    {
+        // TODO: This should get the directory that this library is in, not the CWD.
+        char szCurrentDirectory[PATH_MAX];
+
+        if (!getcwd(szCurrentDirectory, PATH_MAX))
+        {
+            return E_FAIL;
+        }
+
+        runtimeDirectory = std::string(szCurrentDirectory);
+    }
+
+    std::string coreClrDirectory;
+    void* coreClr = LoadCoreClr(coreClrDirectory);
+
+    if (!coreClr)
+    {
+        char* error = dlerror();
+        fprintf(stderr, "failed to locate coreclr.dll with error %s\n", error);
+        return E_FAIL;
+    }
+
+    const char* property_keys[] =
+    {
+        "APPBASE",
+        "TRUSTED_PLATFORM_ASSEMBLIES",
+        "APP_PATHS",
+    };
+
+    std::string trustedPlatformAssemblies;
+
+    // Try native images first
+    if (!GetTrustedPlatformAssembliesList(coreClrDirectory.c_str(), true, trustedPlatformAssemblies))
+    {
+        if (!GetTrustedPlatformAssembliesList(coreClrDirectory.c_str(), false, trustedPlatformAssemblies))
+        {
+            fprintf(stderr, "Failed to find files in the coreclr directory\n");
+            hr = E_FAIL;
+            return hr;
+        }
+    }
+
+    // Add the assembly containing the app domain manager to the trusted list
+    trustedPlatformAssemblies.append(runtimeDirectory);
+    trustedPlatformAssemblies.append("dnx.coreclr.managed.dll");
+
+    std::string appPaths(runtimeDirectory);
+
+    appPaths.append(":");
+    appPaths.append(coreClrDirectory);
+    appPaths.append(":");
+
+    const char* property_values[] = {
+        // APPBASE
+        data->applicationBase,
+        // TRUESTED_PLATFORM_ASSEMBLIES
+        trustedPlatformAssemblies.c_str(),
+        // APP_PATHS
+        appPaths.c_str(),
+    };
+
+    ExecuteAssemblyFunction executeAssembly = (ExecuteAssemblyFunction)dlsym(coreClr, "ExecuteAssembly");
+
+    if (!executeAssembly)
+    {
+        fprintf(stderr, "Could not find ExecuteAssembly entrypoint in coreclr.\n");
+        return E_FAIL;
+    }
+
+    setenv("DNX_FRAMEWORK", "dnxcore50", 1);
+
+    std::string coreClrDllPath(coreClrDirectory);
+    coreClrDllPath.append("/");
+    coreClrDllPath.append("libcoreclr.so");
+
+    char pathToBootstrapper[PATH_MAX];
+    ssize_t pathLen = readlink("/proc/self/exe", pathToBootstrapper, PATH_MAX - 1);
+
+    if (pathLen == -1)
+    {
+        fprintf(stderr, "Could not locate full bootstrapper path.\n");
+        return E_FAIL;
+    }
+
+    pathToBootstrapper[pathLen] = '\0';
+
+    hr = executeAssembly(pathToBootstrapper,
+                         coreClrDllPath.c_str(),
+                         "dnx.coreclr.managed",
+                         sizeof(property_keys) / sizeof(property_keys[0]),
+                         property_keys,
+                         property_values,
+                         data->argc,
+                         (const char**)data->argv,
+                         nullptr,
+                         "dnx.coreclr.managed, Version=0.1.0.0",
+                         "DomainManager",
+                         "Execute",
+                         (DWORD*)&(data->exitcode));
+
+
+    dlclose(coreClr);
+
+    return hr;
+}

--- a/src/dnx.coreclr.unix/stdafx.h
+++ b/src/dnx.coreclr.unix/stdafx.h
@@ -1,0 +1,16 @@
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <unistd.h>
+
+typedef int BOOL;
+typedef const char* LPCTSTR;
+
+const BOOL TRUE = 1;
+const BOOL FALSE = 0;
+
+#define _T(str) str
+

--- a/src/dnx.coreclr.unix/tpa.cpp
+++ b/src/dnx.coreclr.unix/tpa.cpp
@@ -1,0 +1,98 @@
+// This file will be dynamically updated during build to generate a 
+// minimal trusted platform assemblies list
+
+#include "stdafx.h"
+#include "tpa.h"
+
+BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
+{
+    const size_t count = 34;
+    LPCTSTR* pArray = new LPCTSTR[count];
+
+    if (bNative)
+    {
+        pArray[0] = _T("dnx.coreclr.managed.ni.dll");
+        pArray[1] = _T("dnx.host.ni.dll");
+        pArray[2] = _T("Internal.Uri.ni.dll");
+        pArray[3] = _T("Microsoft.Framework.Runtime.Interfaces.ni.dll");
+        pArray[4] = _T("Microsoft.Framework.Runtime.Loader.ni.dll");
+        pArray[5] = _T("mscorlib.ni.dll");
+        pArray[6] = _T("System.ni.dll");
+        pArray[7] = _T("System.AppContext.ni.dll");
+        pArray[8] = _T("System.Collections.ni.dll");
+        pArray[9] = _T("System.Collections.Concurrent.ni.dll");
+        pArray[10] = _T("System.ComponentModel.ni.dll");
+        pArray[11] = _T("System.Console.ni.dll");
+        pArray[12] = _T("System.Core.ni.dll");
+        pArray[13] = _T("System.Diagnostics.Debug.ni.dll");
+        pArray[14] = _T("System.Globalization.ni.dll");
+        pArray[15] = _T("System.IO.ni.dll");
+        pArray[16] = _T("System.IO.FileSystem.ni.dll");
+        pArray[17] = _T("System.IO.FileSystem.Primitives.ni.dll");
+        pArray[18] = _T("System.Linq.ni.dll");
+        pArray[19] = _T("System.Reflection.ni.dll");
+        pArray[20] = _T("System.Reflection.Extensions.ni.dll");
+        pArray[21] = _T("System.Reflection.Primitives.ni.dll");
+        pArray[22] = _T("System.Resources.ResourceManager.ni.dll");
+        pArray[23] = _T("System.Runtime.ni.dll");
+        pArray[24] = _T("System.Runtime.Extensions.ni.dll");
+        pArray[25] = _T("System.Runtime.Handles.ni.dll");
+        pArray[26] = _T("System.Runtime.InteropServices.ni.dll");
+        pArray[27] = _T("System.Runtime.Loader.ni.dll");
+        pArray[28] = _T("System.Text.Encoding.ni.dll");
+        pArray[29] = _T("System.Text.Encoding.Extensions.ni.dll");
+        pArray[30] = _T("System.Threading.ni.dll");
+        pArray[31] = _T("System.Threading.Overlapped.ni.dll");
+        pArray[32] = _T("System.Threading.Tasks.ni.dll");
+        pArray[33] = _T("System.Threading.ThreadPool.ni.dll");
+    }
+    else
+    {
+        pArray[0] = _T("dnx.coreclr.managed.dll");
+        pArray[1] = _T("dnx.host.dll");
+        pArray[2] = _T("Internal.Uri.dll");
+        pArray[3] = _T("Microsoft.Framework.Runtime.Interfaces.dll");
+        pArray[4] = _T("Microsoft.Framework.Runtime.Loader.dll");
+        pArray[5] = _T("mscorlib.dll");
+        pArray[6] = _T("System.dll");
+        pArray[7] = _T("System.AppContext.dll");
+        pArray[8] = _T("System.Collections.dll");
+        pArray[9] = _T("System.Collections.Concurrent.dll");
+        pArray[10] = _T("System.ComponentModel.dll");
+        pArray[11] = _T("System.Console.dll");
+        pArray[12] = _T("System.Core.dll");
+        pArray[13] = _T("System.Diagnostics.Debug.dll");
+        pArray[14] = _T("System.Globalization.dll");
+        pArray[15] = _T("System.IO.dll");
+        pArray[16] = _T("System.IO.FileSystem.dll");
+        pArray[17] = _T("System.IO.FileSystem.Primitives.dll");
+        pArray[18] = _T("System.Linq.dll");
+        pArray[19] = _T("System.Reflection.dll");
+        pArray[20] = _T("System.Reflection.Extensions.dll");
+        pArray[21] = _T("System.Reflection.Primitives.dll");
+        pArray[22] = _T("System.Resources.ResourceManager.dll");
+        pArray[23] = _T("System.Runtime.dll");
+        pArray[24] = _T("System.Runtime.Extensions.dll");
+        pArray[25] = _T("System.Runtime.Handles.dll");
+        pArray[26] = _T("System.Runtime.InteropServices.dll");
+        pArray[27] = _T("System.Runtime.Loader.dll");
+        pArray[28] = _T("System.Text.Encoding.dll");
+        pArray[29] = _T("System.Text.Encoding.Extensions.dll");
+        pArray[30] = _T("System.Threading.dll");
+        pArray[31] = _T("System.Threading.Overlapped.dll");
+        pArray[32] = _T("System.Threading.Tasks.dll");
+        pArray[33] = _T("System.Threading.ThreadPool.dll");
+    }
+
+    *ppNames = pArray;
+    *pcNames = count;
+
+    return true;
+}
+
+BOOL FreeTpaBase(const LPCTSTR* values, const size_t count)
+{
+    delete[] values;
+
+    return true;
+}

--- a/src/dnx.coreclr.unix/tpa.cpp
+++ b/src/dnx.coreclr.unix/tpa.cpp
@@ -90,7 +90,7 @@ BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
     return true;
 }
 
-BOOL FreeTpaBase(const LPCTSTR* values, const size_t count)
+BOOL FreeTpaBase(const LPCTSTR* values)
 {
     delete[] values;
 

--- a/src/dnx.coreclr.unix/tpa.h
+++ b/src/dnx.coreclr.unix/tpa.h
@@ -1,0 +1,4 @@
+#pragma once
+
+BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative);
+BOOL FreeTpaBase(const LPCTSTR* values, const size_t count);

--- a/src/dnx.coreclr.unix/tpa.h
+++ b/src/dnx.coreclr.unix/tpa.h
@@ -1,4 +1,4 @@
 #pragma once
 
 BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative);
-BOOL FreeTpaBase(const LPCTSTR* values, const size_t count);
+BOOL FreeTpaBase(const LPCTSTR* values);

--- a/src/dnx.coreclr/dnx.coreclr.cpp
+++ b/src/dnx.coreclr/dnx.coreclr.cpp
@@ -30,7 +30,7 @@ bool GetTrustedPlatformAssembliesList(WCHAR* szDirectory, bool bNative, LPWSTR p
     errno_t errno = 0;
     WIN32_FIND_DATA ffd = {};
     size_t cTpaAssemblyNames = 0;
-    LPWSTR* ppszTpaAssemblyNames = nullptr;
+    LPCTSTR* ppszTpaAssemblyNames = nullptr;
 
     // Build the list of the tpa assemblies 
     CreateTpaBase(&ppszTpaAssemblyNames, &cTpaAssemblyNames, bNative);

--- a/src/dnx.coreclr/dnx.coreclr.cpp
+++ b/src/dnx.coreclr/dnx.coreclr.cpp
@@ -74,7 +74,7 @@ bool GetTrustedPlatformAssembliesList(WCHAR* szDirectory, bool bNative, LPWSTR p
 Finished:
     if (ppszTpaAssemblyNames != nullptr)
     {
-        FreeTpaBase(ppszTpaAssemblyNames, cTpaAssemblyNames);
+        FreeTpaBase(ppszTpaAssemblyNames);
     }
 
     return ret;

--- a/src/dnx.coreclr/stdafx.h
+++ b/src/dnx.coreclr/stdafx.h
@@ -9,6 +9,8 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 
+#include <tchar.h>
+
 // Windows Headers
 // Exclude rarely-used stuff from Windows headers
 #define WIN32_LEAN_AND_MEAN

--- a/src/dnx.coreclr/tpa.cpp
+++ b/src/dnx.coreclr/tpa.cpp
@@ -4,84 +4,84 @@
 #include "stdafx.h"
 #include "tpa.h"
 
-BOOL CreateTpaBase(LPWSTR** ppNames, size_t* pcNames, bool bNative)
+BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
 {
     const size_t count = 34;
-    LPWSTR* pArray = new LPWSTR[count];
+    LPCTSTR* pArray = new LPCTSTR[count];
 
     if (bNative)
     {
-        pArray[0] = _wcsdup(L"dnx.coreclr.managed.ni.dll");
-        pArray[1] = _wcsdup(L"dnx.host.ni.dll");
-        pArray[2] = _wcsdup(L"Internal.Uri.ni.dll");
-        pArray[3] = _wcsdup(L"Microsoft.Framework.Runtime.Interfaces.ni.dll");
-        pArray[4] = _wcsdup(L"Microsoft.Framework.Runtime.Loader.ni.dll");
-        pArray[5] = _wcsdup(L"mscorlib.ni.dll");
-        pArray[6] = _wcsdup(L"System.ni.dll");
-        pArray[7] = _wcsdup(L"System.AppContext.ni.dll");
-        pArray[8] = _wcsdup(L"System.Collections.ni.dll");
-        pArray[9] = _wcsdup(L"System.Collections.Concurrent.ni.dll");
-        pArray[10] = _wcsdup(L"System.ComponentModel.ni.dll");
-        pArray[11] = _wcsdup(L"System.Console.ni.dll");
-        pArray[12] = _wcsdup(L"System.Core.ni.dll");
-        pArray[13] = _wcsdup(L"System.Diagnostics.Debug.ni.dll");
-        pArray[14] = _wcsdup(L"System.Globalization.ni.dll");
-        pArray[15] = _wcsdup(L"System.IO.ni.dll");
-        pArray[16] = _wcsdup(L"System.IO.FileSystem.ni.dll");
-        pArray[17] = _wcsdup(L"System.IO.FileSystem.Primitives.ni.dll");
-        pArray[18] = _wcsdup(L"System.Linq.ni.dll");
-        pArray[19] = _wcsdup(L"System.Reflection.ni.dll");
-        pArray[20] = _wcsdup(L"System.Reflection.Extensions.ni.dll");
-        pArray[21] = _wcsdup(L"System.Reflection.Primitives.ni.dll");
-        pArray[22] = _wcsdup(L"System.Resources.ResourceManager.ni.dll");
-        pArray[23] = _wcsdup(L"System.Runtime.ni.dll");
-        pArray[24] = _wcsdup(L"System.Runtime.Extensions.ni.dll");
-        pArray[25] = _wcsdup(L"System.Runtime.Handles.ni.dll");
-        pArray[26] = _wcsdup(L"System.Runtime.InteropServices.ni.dll");
-        pArray[27] = _wcsdup(L"System.Runtime.Loader.ni.dll");
-        pArray[28] = _wcsdup(L"System.Text.Encoding.ni.dll");
-        pArray[29] = _wcsdup(L"System.Text.Encoding.Extensions.ni.dll");
-        pArray[30] = _wcsdup(L"System.Threading.ni.dll");
-        pArray[31] = _wcsdup(L"System.Threading.Overlapped.ni.dll");
-        pArray[32] = _wcsdup(L"System.Threading.Tasks.ni.dll");
-        pArray[33] = _wcsdup(L"System.Threading.ThreadPool.ni.dll");
+        pArray[0] = _T("dnx.coreclr.managed.ni.dll");
+        pArray[1] = _T("dnx.host.ni.dll");
+        pArray[2] = _T("Internal.Uri.ni.dll");
+        pArray[3] = _T("Microsoft.Framework.Runtime.Interfaces.ni.dll");
+        pArray[4] = _T("Microsoft.Framework.Runtime.Loader.ni.dll");
+        pArray[5] = _T("mscorlib.ni.dll");
+        pArray[6] = _T("System.ni.dll");
+        pArray[7] = _T("System.AppContext.ni.dll");
+        pArray[8] = _T("System.Collections.ni.dll");
+        pArray[9] = _T("System.Collections.Concurrent.ni.dll");
+        pArray[10] = _T("System.ComponentModel.ni.dll");
+        pArray[11] = _T("System.Console.ni.dll");
+        pArray[12] = _T("System.Core.ni.dll");
+        pArray[13] = _T("System.Diagnostics.Debug.ni.dll");
+        pArray[14] = _T("System.Globalization.ni.dll");
+        pArray[15] = _T("System.IO.ni.dll");
+        pArray[16] = _T("System.IO.FileSystem.ni.dll");
+        pArray[17] = _T("System.IO.FileSystem.Primitives.ni.dll");
+        pArray[18] = _T("System.Linq.ni.dll");
+        pArray[19] = _T("System.Reflection.ni.dll");
+        pArray[20] = _T("System.Reflection.Extensions.ni.dll");
+        pArray[21] = _T("System.Reflection.Primitives.ni.dll");
+        pArray[22] = _T("System.Resources.ResourceManager.ni.dll");
+        pArray[23] = _T("System.Runtime.ni.dll");
+        pArray[24] = _T("System.Runtime.Extensions.ni.dll");
+        pArray[25] = _T("System.Runtime.Handles.ni.dll");
+        pArray[26] = _T("System.Runtime.InteropServices.ni.dll");
+        pArray[27] = _T("System.Runtime.Loader.ni.dll");
+        pArray[28] = _T("System.Text.Encoding.ni.dll");
+        pArray[29] = _T("System.Text.Encoding.Extensions.ni.dll");
+        pArray[30] = _T("System.Threading.ni.dll");
+        pArray[31] = _T("System.Threading.Overlapped.ni.dll");
+        pArray[32] = _T("System.Threading.Tasks.ni.dll");
+        pArray[33] = _T("System.Threading.ThreadPool.ni.dll");
     }
     else
     {
-        pArray[0] = _wcsdup(L"dnx.coreclr.managed.dll");
-        pArray[1] = _wcsdup(L"dnx.host.dll");
-        pArray[2] = _wcsdup(L"Internal.Uri.dll");
-        pArray[3] = _wcsdup(L"Microsoft.Framework.Runtime.Interfaces.dll");
-        pArray[4] = _wcsdup(L"Microsoft.Framework.Runtime.Loader.dll");
-        pArray[5] = _wcsdup(L"mscorlib.dll");
-        pArray[6] = _wcsdup(L"System.dll");
-        pArray[7] = _wcsdup(L"System.AppContext.dll");
-        pArray[8] = _wcsdup(L"System.Collections.dll");
-        pArray[9] = _wcsdup(L"System.Collections.Concurrent.dll");
-        pArray[10] = _wcsdup(L"System.ComponentModel.dll");
-        pArray[11] = _wcsdup(L"System.Console.dll");
-        pArray[12] = _wcsdup(L"System.Core.dll");
-        pArray[13] = _wcsdup(L"System.Diagnostics.Debug.dll");
-        pArray[14] = _wcsdup(L"System.Globalization.dll");
-        pArray[15] = _wcsdup(L"System.IO.dll");
-        pArray[16] = _wcsdup(L"System.IO.FileSystem.dll");
-        pArray[17] = _wcsdup(L"System.IO.FileSystem.Primitives.dll");
-        pArray[18] = _wcsdup(L"System.Linq.dll");
-        pArray[19] = _wcsdup(L"System.Reflection.dll");
-        pArray[20] = _wcsdup(L"System.Reflection.Extensions.dll");
-        pArray[21] = _wcsdup(L"System.Reflection.Primitives.dll");
-        pArray[22] = _wcsdup(L"System.Resources.ResourceManager.dll");
-        pArray[23] = _wcsdup(L"System.Runtime.dll");
-        pArray[24] = _wcsdup(L"System.Runtime.Extensions.dll");
-        pArray[25] = _wcsdup(L"System.Runtime.Handles.dll");
-        pArray[26] = _wcsdup(L"System.Runtime.InteropServices.dll");
-        pArray[27] = _wcsdup(L"System.Runtime.Loader.dll");
-        pArray[28] = _wcsdup(L"System.Text.Encoding.dll");
-        pArray[29] = _wcsdup(L"System.Text.Encoding.Extensions.dll");
-        pArray[30] = _wcsdup(L"System.Threading.dll");
-        pArray[31] = _wcsdup(L"System.Threading.Overlapped.dll");
-        pArray[32] = _wcsdup(L"System.Threading.Tasks.dll");
-        pArray[33] = _wcsdup(L"System.Threading.ThreadPool.dll");
+        pArray[0] = _T("dnx.coreclr.managed.dll");
+        pArray[1] = _T("dnx.host.dll");
+        pArray[2] = _T("Internal.Uri.dll");
+        pArray[3] = _T("Microsoft.Framework.Runtime.Interfaces.dll");
+        pArray[4] = _T("Microsoft.Framework.Runtime.Loader.dll");
+        pArray[5] = _T("mscorlib.dll");
+        pArray[6] = _T("System.dll");
+        pArray[7] = _T("System.AppContext.dll");
+        pArray[8] = _T("System.Collections.dll");
+        pArray[9] = _T("System.Collections.Concurrent.dll");
+        pArray[10] = _T("System.ComponentModel.dll");
+        pArray[11] = _T("System.Console.dll");
+        pArray[12] = _T("System.Core.dll");
+        pArray[13] = _T("System.Diagnostics.Debug.dll");
+        pArray[14] = _T("System.Globalization.dll");
+        pArray[15] = _T("System.IO.dll");
+        pArray[16] = _T("System.IO.FileSystem.dll");
+        pArray[17] = _T("System.IO.FileSystem.Primitives.dll");
+        pArray[18] = _T("System.Linq.dll");
+        pArray[19] = _T("System.Reflection.dll");
+        pArray[20] = _T("System.Reflection.Extensions.dll");
+        pArray[21] = _T("System.Reflection.Primitives.dll");
+        pArray[22] = _T("System.Resources.ResourceManager.dll");
+        pArray[23] = _T("System.Runtime.dll");
+        pArray[24] = _T("System.Runtime.Extensions.dll");
+        pArray[25] = _T("System.Runtime.Handles.dll");
+        pArray[26] = _T("System.Runtime.InteropServices.dll");
+        pArray[27] = _T("System.Runtime.Loader.dll");
+        pArray[28] = _T("System.Text.Encoding.dll");
+        pArray[29] = _T("System.Text.Encoding.Extensions.dll");
+        pArray[30] = _T("System.Threading.dll");
+        pArray[31] = _T("System.Threading.Overlapped.dll");
+        pArray[32] = _T("System.Threading.Tasks.dll");
+        pArray[33] = _T("System.Threading.ThreadPool.dll");
     }
 
     *ppNames = pArray;
@@ -90,13 +90,8 @@ BOOL CreateTpaBase(LPWSTR** ppNames, size_t* pcNames, bool bNative)
     return true;
 }
 
-BOOL FreeTpaBase(const LPWSTR* values, const size_t count)
+BOOL FreeTpaBase(const LPCTSTR* values, const size_t count)
 {
-    for (size_t idx = 0; idx < count; ++idx)
-    {
-        delete[] values[idx];
-    }
-
     delete[] values;
 
     return true;

--- a/src/dnx.coreclr/tpa.cpp
+++ b/src/dnx.coreclr/tpa.cpp
@@ -90,7 +90,7 @@ BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
     return true;
 }
 
-BOOL FreeTpaBase(const LPCTSTR* values, const size_t count)
+BOOL FreeTpaBase(const LPCTSTR* values)
 {
     delete[] values;
 

--- a/src/dnx.coreclr/tpa.h
+++ b/src/dnx.coreclr/tpa.h
@@ -1,4 +1,4 @@
 #pragma once
 
-BOOL CreateTpaBase(LPWSTR** ppNames, size_t* pcNames, bool bNative);
-BOOL FreeTpaBase(const LPWSTR* values, const size_t count);
+BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative);
+BOOL FreeTpaBase(const LPCTSTR* values, const size_t count);

--- a/src/dnx.coreclr/tpa.h
+++ b/src/dnx.coreclr/tpa.h
@@ -1,4 +1,4 @@
 #pragma once
 
 BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative);
-BOOL FreeTpaBase(const LPCTSTR* values, const size_t count);
+BOOL FreeTpaBase(const LPCTSTR* values);

--- a/src/dnx/Makefile
+++ b/src/dnx/Makefile
@@ -1,0 +1,2 @@
+all:
+	clang++-3.5 dnx.cpp pal.linux.cpp tchar.cpp -g -o dnx -DCORECLR_UNIX -DPLATFORM_UNIX -std=c++11 -ldl

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -3,16 +3,16 @@
 #include "stdafx.h"
 #include "dnx.h"
 
-void GetModuleDirectory(HMODULE module, LPWSTR szPath)
+void GetModuleDirectory(HMODULE module, LPTSTR szPath)
 {
     DWORD dirLength = GetModuleFileName(module, szPath, MAX_PATH);
-    for (dirLength--; dirLength >= 0 && szPath[dirLength] != '\\'; dirLength--);
-    szPath[dirLength + 1] = L'\0';
+    for (dirLength--; dirLength >= 0 && szPath[dirLength] != _T('\\'); dirLength--);
+    szPath[dirLength + 1] = _T('\0');
 }
 
-int LastIndexOfChar(LPCWSTR const pszStr, WCHAR c)
+int LastIndexOfChar(LPCTSTR const pszStr, TCHAR c)
 {
-    int nIndex = wcsnlen_s(pszStr, MAX_PATH) - 1;
+    int nIndex = _tcsnlen(pszStr, MAX_PATH) - 1;
     do
     {
         if (pszStr[nIndex] == c)
@@ -24,15 +24,15 @@ int LastIndexOfChar(LPCWSTR const pszStr, WCHAR c)
     return nIndex;
 }
 
-bool StringsEqual(LPCWSTR const pszStrA, LPCWSTR const pszStrB)
+bool StringsEqual(LPCTSTR const pszStrA, LPCTSTR const pszStrB)
 {
-    return ::_wcsnicmp(pszStrA, pszStrB, MAX_PATH) == 0;
+    return ::_tcsnicmp(pszStrA, pszStrB, MAX_PATH) == 0;
 }
 
-bool StringEndsWith(LPCWSTR const pszStr, LPCWSTR const pszSuffix)
+bool StringEndsWith(LPCTSTR const pszStr, LPCTSTR const pszSuffix)
 {
-    int nStrLen = wcsnlen_s(pszStr, MAX_PATH);
-    int nSuffixLen = wcsnlen_s(pszSuffix, MAX_PATH);
+    int nStrLen = _tcsnlen(pszStr, MAX_PATH);
+    int nSuffixLen = _tcsnlen(pszSuffix, MAX_PATH);
     int nOffset = nStrLen - nSuffixLen;
 
     if (nOffset < 0)
@@ -43,55 +43,55 @@ bool StringEndsWith(LPCWSTR const pszStr, LPCWSTR const pszSuffix)
     return StringsEqual(pszStr + nOffset, pszSuffix);
 }
 
-int LastPathSeparatorIndex(LPCWSTR const pszPath)
+int LastPathSeparatorIndex(LPCTSTR const pszPath)
 {
-    int nLastSlashIndex = LastIndexOfChar(pszPath, L'/');
-    int nLastBackSlashIndex = LastIndexOfChar(pszPath, L'\\');
+    int nLastSlashIndex = LastIndexOfChar(pszPath, _T('/'));
+    int nLastBackSlashIndex = LastIndexOfChar(pszPath, _T('\\'));
     return max(nLastSlashIndex, nLastBackSlashIndex);
 }
 
-void GetParentDir(LPCWSTR const pszPath, LPWSTR const pszParentDir)
+void GetParentDir(LPCTSTR const pszPath, LPTSTR const pszParentDir)
 {
     int nLastSeparatorIndex = LastPathSeparatorIndex(pszPath);
     if (nLastSeparatorIndex < 0)
     {
-        StringCchCopyW(pszParentDir, MAX_PATH, L".");
+        _tcscpy_s(pszParentDir, MAX_PATH, _T("."));
         return;
     }
 
-    CopyMemory(pszParentDir, pszPath, (nLastSeparatorIndex + 1) * sizeof(WCHAR));
-    pszParentDir[nLastSeparatorIndex + 1] = L'\0';
+    CopyMemory(pszParentDir, pszPath, (nLastSeparatorIndex + 1) * sizeof(TCHAR));
+    pszParentDir[nLastSeparatorIndex + 1] = _T('\0');
 }
 
-void GetFileName(LPCWSTR const pszPath, LPWSTR const pszFileName)
+void GetFileName(LPCTSTR const pszPath, LPTSTR const pszFileName)
 {
     int nLastSeparatorIndex = LastPathSeparatorIndex(pszPath);
 
     if (nLastSeparatorIndex < 0)
     {
-        StringCchCopyW(pszFileName, MAX_PATH, pszPath);
+        _tcscpy_s(pszFileName, MAX_PATH, pszPath);
         return;
     }
 
-    StringCchCopyW(pszFileName, MAX_PATH, pszPath + nLastSeparatorIndex + 1);
+    _tcscpy_s(pszFileName, MAX_PATH, pszPath + nLastSeparatorIndex + 1);
 }
 
-int BootstrapperOptionValueNum(LPCWSTR pszCandidate)
+int BootstrapperOptionValueNum(LPCTSTR pszCandidate)
 {
-    if (StringsEqual(pszCandidate, L"--appbase") ||
-        StringsEqual(pszCandidate, L"--lib") ||
-        StringsEqual(pszCandidate, L"--packages") ||
-        StringsEqual(pszCandidate, L"--configuration") ||
-        StringsEqual(pszCandidate, L"--port"))
+    if (StringsEqual(pszCandidate, _T("--appbase")) ||
+        StringsEqual(pszCandidate, _T("--lib")) ||
+        StringsEqual(pszCandidate, _T("--packages")) ||
+        StringsEqual(pszCandidate, _T("--configuration")) ||
+        StringsEqual(pszCandidate, _T("--port")))
     {
         return 1;
     }
-    else if (StringsEqual(pszCandidate, L"--watch") ||
-        StringsEqual(pszCandidate, L"--debug") ||
-        StringsEqual(pszCandidate, L"--help") ||
-        StringsEqual(pszCandidate, L"-h") ||
-        StringsEqual(pszCandidate, L"-?") ||
-        StringsEqual(pszCandidate, L"--version"))
+    else if (StringsEqual(pszCandidate, _T("--watch")) ||
+        StringsEqual(pszCandidate, _T("--debug")) ||
+        StringsEqual(pszCandidate, _T("--help")) ||
+        StringsEqual(pszCandidate, _T("-h")) ||
+        StringsEqual(pszCandidate, _T("-?")) ||
+        StringsEqual(pszCandidate, _T("--version")))
     {
         return 0;
     }
@@ -100,7 +100,7 @@ int BootstrapperOptionValueNum(LPCWSTR pszCandidate)
     return -1;
 }
 
-void FreeExpandedCommandLineArguments(int nArgc, LPWSTR* ppszArgv)
+void FreeExpandedCommandLineArguments(int nArgc, LPTSTR* ppszArgv)
 {
     for (int i = 0; i < nArgc; ++i)
     {
@@ -109,7 +109,7 @@ void FreeExpandedCommandLineArguments(int nArgc, LPWSTR* ppszArgv)
     delete[] ppszArgv;
 }
 
-bool ExpandCommandLineArguments(int nArgc, LPWSTR* ppszArgv, int& nExpandedArgc, LPWSTR*& ppszExpandedArgv)
+bool ExpandCommandLineArguments(int nArgc, LPTSTR* ppszArgv, int& nExpandedArgc, LPTSTR*& ppszExpandedArgv)
 {
     if (nArgc == 0)
     {
@@ -119,16 +119,16 @@ bool ExpandCommandLineArguments(int nArgc, LPWSTR* ppszArgv, int& nExpandedArgc,
     for (int i = 0; i < nArgc; ++i)
     {
         // If '--appbase' is already given and it has a value
-        if (StringsEqual(ppszArgv[i], L"--appbase") && (i < nArgc - 1))
+        if (StringsEqual(ppszArgv[i], _T("--appbase")) && (i < nArgc - 1))
         {
             return false;
         }
     }
 
     nExpandedArgc = nArgc + 2;
-    ppszExpandedArgv = new LPWSTR[nExpandedArgc];
-    memset(ppszExpandedArgv, 0, nExpandedArgc*sizeof(LPWSTR));
-    WCHAR szParentDir[MAX_PATH];
+    ppszExpandedArgv = new LPTSTR[nExpandedArgc];
+    memset(ppszExpandedArgv, 0, nExpandedArgc*sizeof(LPTSTR));
+    TCHAR szParentDir[MAX_PATH];
 
     // Copy all arguments (options & values) as is before the project.json/assembly path
     int nPathArgIndex = -1;
@@ -144,14 +144,14 @@ bool ExpandCommandLineArguments(int nArgc, LPWSTR* ppszArgv, int& nExpandedArgc,
         }
 
         // Copy the option
-        ppszExpandedArgv[nPathArgIndex] = new WCHAR[MAX_PATH];
-        StringCchCopyW(ppszExpandedArgv[nPathArgIndex], MAX_PATH, ppszArgv[nPathArgIndex]);
+        ppszExpandedArgv[nPathArgIndex] = new TCHAR[MAX_PATH];
+        _tcscpy_s(ppszExpandedArgv[nPathArgIndex], MAX_PATH, ppszArgv[nPathArgIndex]);
 
         // Copy the value if the option has one
         if (nOptValNum > 0 && (++nPathArgIndex < nArgc))
         {
-            ppszExpandedArgv[nPathArgIndex] = new WCHAR[MAX_PATH];
-            StringCchCopyW(ppszExpandedArgv[nPathArgIndex], MAX_PATH, ppszArgv[nPathArgIndex]);
+            ppszExpandedArgv[nPathArgIndex] = new TCHAR[MAX_PATH];
+            _tcscpy_s(ppszExpandedArgv[nPathArgIndex], MAX_PATH, ppszArgv[nPathArgIndex]);
         }
     }
 
@@ -165,23 +165,23 @@ bool ExpandCommandLineArguments(int nArgc, LPWSTR* ppszArgv, int& nExpandedArgc,
     // Allocate memory before doing expansion
     for (int i = nPathArgIndex; i < nExpandedArgc; ++i)
     {
-        ppszExpandedArgv[i] = new WCHAR[MAX_PATH];
+        ppszExpandedArgv[i] = new TCHAR[MAX_PATH];
     }
 
     // "dnx /path/App.dll arg1" --> "dnx --appbase /path/ /path/App.dll arg1"
     // "dnx /path/App.exe arg1" --> "dnx --appbase /path/ /path/App.exe arg1"
-    LPWSTR pszPathArg = ppszArgv[nPathArgIndex];
-    if (StringEndsWith(pszPathArg, L".exe") || StringEndsWith(pszPathArg, L".dll"))
+    LPTSTR pszPathArg = ppszArgv[nPathArgIndex];
+    if (StringEndsWith(pszPathArg, _T(".exe")) || StringEndsWith(pszPathArg, _T(".dll")))
     {
         GetParentDir(pszPathArg, szParentDir);
 
-        StringCchCopyW(ppszExpandedArgv[nPathArgIndex], MAX_PATH, L"--appbase");
-        StringCchCopyW(ppszExpandedArgv[nPathArgIndex + 1], MAX_PATH, szParentDir);
+        _tcscpy_s(ppszExpandedArgv[nPathArgIndex], MAX_PATH, _T("--appbase"));
+        _tcscpy_s(ppszExpandedArgv[nPathArgIndex + 1], MAX_PATH, szParentDir);
 
         // Copy all arguments/options as is
         for (int i = nPathArgIndex; i < nArgc; ++i)
         {
-            StringCchCopyW(ppszExpandedArgv[i + 2], MAX_PATH, ppszArgv[i]);
+            _tcscpy_s(ppszExpandedArgv[i + 2], MAX_PATH, ppszArgv[i]);
         }
 
         return true;
@@ -189,51 +189,51 @@ bool ExpandCommandLineArguments(int nArgc, LPWSTR* ppszArgv, int& nExpandedArgc,
 
     // "dnx /path/project.json run" --> "dnx --appbase /path/ Microsoft.Framework.ApplicationHost run"
     // "dnx /path/ run" --> "dnx --appbase /path/ Microsoft.Framework.ApplicationHost run"
-    WCHAR szFileName[MAX_PATH];
+    TCHAR szFileName[MAX_PATH];
     GetFileName(pszPathArg, szFileName);
-    if (StringsEqual(szFileName, L"project.json"))
+    if (StringsEqual(szFileName, _T("project.json")))
     {
         GetParentDir(pszPathArg, szParentDir);
     }
     else
     {
-        StringCchCopyW(szParentDir, MAX_PATH, pszPathArg);
+        _tcscpy_s(szParentDir, MAX_PATH, pszPathArg);
     }
 
-    StringCchCopyW(ppszExpandedArgv[nPathArgIndex], MAX_PATH, L"--appbase");
-    StringCchCopyW(ppszExpandedArgv[nPathArgIndex + 1], MAX_PATH, szParentDir);
-    StringCchCopyW(ppszExpandedArgv[nPathArgIndex + 2], MAX_PATH, L"Microsoft.Framework.ApplicationHost");
+    _tcscpy_s(ppszExpandedArgv[nPathArgIndex], MAX_PATH, _T("--appbase"));
+    _tcscpy_s(ppszExpandedArgv[nPathArgIndex + 1], MAX_PATH, szParentDir);
+    _tcscpy_s(ppszExpandedArgv[nPathArgIndex + 2], MAX_PATH, _T("Microsoft.Framework.ApplicationHost"));
 
     for (int i = nPathArgIndex + 1; i < nArgc; ++i)
     {
         // Copy all other arguments/options as is
-        StringCchCopyW(ppszExpandedArgv[i + 2], MAX_PATH, ppszArgv[i]);
+        _tcscpy_s(ppszExpandedArgv[i + 2], MAX_PATH, ppszArgv[i]);
     }
 
     return true;
 }
 
-int CallApplicationProcessMain(int argc, wchar_t* argv[])
+int CallApplicationProcessMain(int argc, LPTSTR argv[])
 {
     TCHAR szTrace[2];
-    DWORD nEnvTraceSize = GetEnvironmentVariableW(L"DNX_TRACE", szTrace, 2);
+    DWORD nEnvTraceSize = GetEnvironmentVariable(_T("DNX_TRACE"), szTrace, 2);
     if (nEnvTraceSize == 0)
     {
-        nEnvTraceSize = GetEnvironmentVariableW(L"DNX_TRACE", szTrace, 2);
+        nEnvTraceSize = GetEnvironmentVariable(_T("DNX_TRACE"), szTrace, 2);
     }
     bool m_fVerboseTrace = (nEnvTraceSize == 1);
     if (m_fVerboseTrace)
     {
-        szTrace[1] = L'\0';
-        m_fVerboseTrace = (_wcsnicmp(szTrace, L"1", 1) == 0);
+        szTrace[1] = _T('\0');
+        m_fVerboseTrace = (_tcsnicmp(szTrace, _T("1"), 1) == 0);
     }
 
     bool fSuccess = true;
     HMODULE m_hHostModule = nullptr;
 #if CORECLR_WIN
-    LPCWSTR pwzHostModuleName = L"dnx.coreclr.dll";
+    LPCTSTR pwzHostModuleName = _T("dnx.coreclr.dll");
 #else
-    LPCWSTR pwzHostModuleName = L"dnx.clr.dll";
+    LPCTSTR pwzHostModuleName = _T("dnx.clr.dll");
 #endif
 
     // Note: need to keep as ASCII as GetProcAddress function takes ASCII params
@@ -246,34 +246,34 @@ int CallApplicationProcessMain(int argc, wchar_t* argv[])
 
     // Set the DEFAULT_LIB environment variable to be the same directory
     // as the exe
-    SetEnvironmentVariable(L"DNX_DEFAULT_LIB", szCurrentDirectory);
+    SetEnvironmentVariable(_T("DNX_DEFAULT_LIB"), szCurrentDirectory);
 
     // Set the DNX_CONOSLE_HOST flag which will print exceptions
     // to stderr instead of throwing
-    SetEnvironmentVariable(L"DNX_CONSOLE_HOST", L"1");
+    SetEnvironmentVariable(_T("DNX_CONSOLE_HOST"), _T("1"));
 
     CALL_APPLICATION_MAIN_DATA data = { 0 };
     int nExpandedArgc = -1;
-    LPWSTR* ppszExpandedArgv = nullptr;
+    LPTSTR* ppszExpandedArgv = nullptr;
     bool bExpanded = ExpandCommandLineArguments(argc - 1, &(argv[1]), nExpandedArgc, ppszExpandedArgv);
     if (bExpanded)
     {
         data.argc = nExpandedArgc;
-        data.argv = const_cast<LPCWSTR*>(ppszExpandedArgv);
+        data.argv = const_cast<LPCTSTR*>(ppszExpandedArgv);
     }
     else
     {
         data.argc = argc - 1;
-        data.argv = const_cast<LPCWSTR*>(&argv[1]);
+        data.argv = const_cast<LPCTSTR*>(&argv[1]);
     }
 
     // Get application base from DNX_APPBASE environment variable
     // Note: this value can be overriden by --appbase option
     TCHAR szAppBase[MAX_PATH];
-    DWORD dwAppBase = GetEnvironmentVariableW(L"DNX_APPBASE", szAppBase, MAX_PATH);
+    DWORD dwAppBase = GetEnvironmentVariable(_T("DNX_APPBASE"), szAppBase, MAX_PATH);
     if (dwAppBase == 0)
     {
-        dwAppBase = GetEnvironmentVariableW(L"DNX_APPBASE", szAppBase, MAX_PATH);
+        dwAppBase = GetEnvironmentVariable(_T("DNX_APPBASE"), szAppBase, MAX_PATH);
     }
     if (dwAppBase != 0)
     {
@@ -282,7 +282,7 @@ int CallApplicationProcessMain(int argc, wchar_t* argv[])
 
     for (int i = 0; i < data.argc; ++i)
     {
-        if ((i < data.argc - 1) && StringsEqual(data.argv[i], L"--appbase"))
+        if ((i < data.argc - 1) && StringsEqual(data.argv[i], _T("--appbase")))
         {
             data.applicationBase = data.argv[i + 1];
         }
@@ -294,43 +294,43 @@ int CallApplicationProcessMain(int argc, wchar_t* argv[])
     }
 
     // Prevent coreclr native bootstrapper from failing with relative appbase
-    WCHAR szFullAppBase[MAX_PATH];
-    DWORD dwFullAppBase = GetFullPathNameW(data.applicationBase, MAX_PATH, szFullAppBase, nullptr);
+    TCHAR szFullAppBase[MAX_PATH];
+    DWORD dwFullAppBase = GetFullPathName(data.applicationBase, MAX_PATH, szFullAppBase, nullptr);
     if (!dwFullAppBase)
     {
-        ::wprintf_s(L"Failed to get full path of application base: %s\r\n", data.applicationBase);
+        ::_tprintf_s(_T("Failed to get full path of application base: %s\r\n"), data.applicationBase);
         exitCode = 1;
         goto Finished;
     }
     else if (dwFullAppBase > MAX_PATH)
     {
-        ::wprintf_s(L"Full path of application base is too long\r\n");
+        ::_tprintf_s(_T("Full path of application base is too long\r\n"));
         exitCode = 1;
         goto Finished;
     }
     data.applicationBase = szFullAppBase;
 
-    m_hHostModule = ::LoadLibraryExW(pwzHostModuleName, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    m_hHostModule = ::LoadLibraryEx(pwzHostModuleName, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
     if (!m_hHostModule)
     {
         if (m_fVerboseTrace)
-            ::wprintf_s(L"Failed to load: %s\r\n", pwzHostModuleName);
+            ::_tprintf_s(_T("Failed to load: %s\r\n"), pwzHostModuleName);
         m_hHostModule = nullptr;
         goto Finished;
     }
     if (m_fVerboseTrace)
-        ::wprintf_s(L"Loaded Module: %s\r\n", pwzHostModuleName);
+        ::_tprintf_s(_T("Loaded Module: %s\r\n"), pwzHostModuleName);
 
     pfnCallApplicationMain = (FnCallApplicationMain)::GetProcAddress(m_hHostModule, pszCallApplicationMainName);
     if (!pfnCallApplicationMain)
     {
         if (m_fVerboseTrace)
-            ::wprintf_s(L"Failed to find function %S in %s\n", pszCallApplicationMainName, pwzHostModuleName);
+            ::_tprintf_s(_T("Failed to find function %S in %s\n"), pszCallApplicationMainName, pwzHostModuleName);
         fSuccess = false;
         goto Finished;
     }
     if (m_fVerboseTrace)
-        printf_s("Found DLL Export: %s\r\n", pszCallApplicationMainName);
+        ::_tprintf_s(_T("Found DLL Export: %s\r\n"), pszCallApplicationMainName);
 
     HRESULT hr = pfnCallApplicationMain(&data);
     if (SUCCEEDED(hr))
@@ -377,12 +377,12 @@ int wmain(int argc, wchar_t* argv[])
     // Check for the debug flag before doing anything else
     for (int i = 0; i < argc; i++)
     {
-        if (StringsEqual(argv[i], L"--debug"))
+        if (StringsEqual(argv[i], _T("--debug")))
         {
             if (!IsDebuggerPresent())
             {
-                ::wprintf_s(L"Process Id: %ld\r\n", GetCurrentProcessId());
-                ::wprintf_s(L"Waiting for the debugger to attach...\r\n");
+                ::_tprintf_s(_T("Process Id: %ld\r\n"), GetCurrentProcessId());
+                ::_tprintf_s(_T("Waiting for the debugger to attach...\r\n"));
 
                 // Do not use getchar() like in corerun because it doesn't work well with remote sessions
                 while (!IsDebuggerPresent())
@@ -390,7 +390,7 @@ int wmain(int argc, wchar_t* argv[])
                     Sleep(250);
                 }
 
-                ::wprintf_s(L"Debugger attached.\r\n");
+                ::_tprintf_s(_T("Debugger attached.\r\n"));
             }
         }
     }

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -233,6 +233,8 @@ int CallApplicationProcessMain(int argc, LPTSTR argv[])
     HMODULE m_hHostModule = nullptr;
 #if CORECLR_WIN
     LPCTSTR pwzHostModuleName = _T("dnx.coreclr.dll");
+#elif CORECLR_UNIX
+    LPCTSTR pwzHostModuleName = _T("dnx.coreclr.so");
 #else
     LPCTSTR pwzHostModuleName = _T("dnx.clr.dll");
 #endif

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -2,7 +2,7 @@
 #include "dnx.h"
 #include "pal.h"
 
-bool LastIndexOfChar(LPCTSTR const pszStr, TCHAR c, size_t* pIndex)
+bool LastIndexOfCharInPath(LPCTSTR const pszStr, TCHAR c, size_t* pIndex)
 {
     size_t nIndex = _tcsnlen(pszStr, MAX_PATH) - 1;
     for (; nIndex != 0; nIndex--)
@@ -19,10 +19,10 @@ bool LastIndexOfChar(LPCTSTR const pszStr, TCHAR c, size_t* pIndex)
 
 bool StringsEqual(LPCTSTR const pszStrA, LPCTSTR const pszStrB)
 {
-    return ::_tcsnicmp(pszStrA, pszStrB, MAX_PATH) == 0;
+    return ::_tcsicmp(pszStrA, pszStrB) == 0;
 }
 
-bool StringEndsWith(LPCTSTR const pszStr, LPCTSTR const pszSuffix)
+bool PathEndsWith(LPCTSTR const pszStr, LPCTSTR const pszSuffix)
 {
     size_t nStrLen = _tcsnlen(pszStr, MAX_PATH);
     size_t nSuffixLen = _tcsnlen(pszSuffix, MAX_PATH);
@@ -34,7 +34,7 @@ bool StringEndsWith(LPCTSTR const pszStr, LPCTSTR const pszSuffix)
 
     size_t nOffset = nStrLen - nSuffixLen;
 
-    return StringsEqual(pszStr + nOffset, pszSuffix);
+    return ::_tcsnicmp(pszStr + nOffset, pszSuffix, MAX_PATH - nOffset) == 0;
 }
 
 bool LastPathSeparatorIndex(LPCTSTR const pszPath, size_t* pIndex)
@@ -42,8 +42,8 @@ bool LastPathSeparatorIndex(LPCTSTR const pszPath, size_t* pIndex)
     size_t nLastSlashIndex;
     size_t nLastBackSlashIndex;
 
-    bool hasLastSlashIndex = LastIndexOfChar(pszPath, _T('/'), &nLastSlashIndex);
-    bool hasLastBackSlashIndex = LastIndexOfChar(pszPath, _T('\\'), &nLastBackSlashIndex);
+    bool hasLastSlashIndex = LastIndexOfCharInPath(pszPath, _T('/'), &nLastSlashIndex);
+    bool hasLastBackSlashIndex = LastIndexOfCharInPath(pszPath, _T('\\'), &nLastBackSlashIndex);
 
     if (hasLastSlashIndex && hasLastBackSlashIndex)
     {
@@ -181,7 +181,7 @@ bool ExpandCommandLineArguments(int nArgc, LPTSTR* ppszArgv, int& nExpandedArgc,
     // "dnx /path/App.dll arg1" --> "dnx --appbase /path/ /path/App.dll arg1"
     // "dnx /path/App.exe arg1" --> "dnx --appbase /path/ /path/App.exe arg1"
     LPTSTR pszPathArg = ppszArgv[nPathArgIndex];
-    if (StringEndsWith(pszPathArg, _T(".exe")) || StringEndsWith(pszPathArg, _T(".dll")))
+    if (PathEndsWith(pszPathArg, _T(".exe")) || PathEndsWith(pszPathArg, _T(".dll")))
     {
         GetParentDir(pszPathArg, szParentDir);
 

--- a/src/dnx/dnx.h
+++ b/src/dnx/dnx.h
@@ -1,10 +1,10 @@
 
 typedef struct CALL_APPLICATION_MAIN_DATA
 {
-    LPCWSTR applicationBase; // application base of managed domain
-    LPCWSTR runtimeDirectory; // path to runtime helper directory
+    LPCTSTR applicationBase; // application base of managed domain
+    LPCTSTR runtimeDirectory; // path to runtime helper directory
     int argc; // Number of args in argv
-    LPCWSTR* argv; // Array of arguments
+    LPCTSTR* argv; // Array of arguments
     int exitcode; // Exit code from Managed Application
 } *PCALL_APPLICATION_MAIN_DATA;
 

--- a/src/dnx/dnx.vcxproj
+++ b/src/dnx/dnx.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -173,6 +173,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dnx.h" />
+    <ClInclude Include="pal.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="resource1.h" />
     <ClInclude Include="stdafx.h" />
@@ -180,6 +181,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dnx.cpp" />
+    <ClCompile Include="pal.win32.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/src/dnx/pal.h
+++ b/src/dnx/pal.h
@@ -1,0 +1,12 @@
+void GetNativeBootstrapperDirectory(LPTSTR szPath);
+void WaitForDebuggerToAttach();
+bool IsTracingEnabled();
+BOOL GetAppBasePathFromEnvironment(LPTSTR szPath);
+BOOL GetFullPath(LPCTSTR szPath, LPTSTR szFullPath);
+HMODULE LoadNativeHost(LPCTSTR szHostModuleName);
+BOOL FreeNativeHost(HMODULE hHost);
+FARPROC GetEntryPointFromHost(HMODULE hModule, LPCSTR lpProcName);
+
+#ifndef SetEnvironmentVariable
+BOOL SetEnvironmentVariable(LPCTSTR lpName, LPCTSTR lpValue);
+#endif //SetEnvironmentVariable

--- a/src/dnx/pal.linux.cpp
+++ b/src/dnx/pal.linux.cpp
@@ -1,0 +1,102 @@
+#include "stdafx.h"
+#include <assert.h>
+#include <dlfcn.h>
+
+void GetNativeBootstrapperDirectory(LPTSTR szPath)
+{
+    ssize_t ret = readlink("/proc/self/exe", szPath, PATH_MAX - 1);
+
+    assert(ret != -1);
+
+    szPath[ret] = '\0';
+
+    size_t lastSlash = 0;
+
+    for (size_t i = 0; szPath[i] != '\0'; i++)
+    {
+        if (szPath[i] == '/')
+        {
+            lastSlash = i;
+        }
+    }
+
+    szPath[lastSlash] = '\0';
+}
+
+void WaitForDebuggerToAttach()
+{
+    // TODO: Implement this.  procfs will be able to tell us this.
+}
+
+bool IsTracingEnabled()
+{
+    char* dnxTraceEnv = getenv("DNX_TRACE");
+    return dnxTraceEnv != NULL && (strcmp(dnxTraceEnv, "1") == 0);
+}
+
+BOOL GetAppBasePathFromEnvironment(LPTSTR szPath)
+{
+    char* appBaseEnv = getenv("DNX_APPBASE");
+
+    if (appBaseEnv != NULL && strlen(appBaseEnv) < PATH_MAX)
+    {
+        strcpy(szPath, appBaseEnv);
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+BOOL GetFullPath(LPCTSTR szPath, LPTSTR szNormalizedPath)
+{
+    if (realpath(szPath, szNormalizedPath) == nullptr)
+    {
+        printf("Failed to get full path of application base: %s\r\n", szPath);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+HMODULE LoadNativeHost(LPCTSTR szHostModuleName)
+{
+    char localPath[PATH_MAX];
+
+    GetNativeBootstrapperDirectory(localPath);
+
+    strcat(localPath, "/");
+    strcat(localPath, szHostModuleName);
+
+    return dlopen(localPath, RTLD_NOW | RTLD_GLOBAL);
+}
+
+BOOL FreeNativeHost(HMODULE hModule)
+{
+    if (hModule != nullptr)
+    {
+        return dlclose(hModule);
+    }
+
+    return TRUE;
+}
+
+FARPROC GetEntryPointFromHost(HMODULE hModule, LPCSTR lpProcName)
+{
+    return dlsym(hModule, lpProcName);
+}
+
+BOOL SetEnvironmentVariable(LPCTSTR lpName, LPCTSTR lpValue)
+{
+    int ret;
+
+    if (lpValue == nullptr)
+    {
+        ret = setenv(lpName, lpValue, 1);
+    }
+    else
+    {
+        ret = unsetenv(lpName);
+    }
+
+    return ret == 0;
+}

--- a/src/dnx/pal.linux.cpp
+++ b/src/dnx/pal.linux.cpp
@@ -89,7 +89,7 @@ BOOL SetEnvironmentVariable(LPCTSTR lpName, LPCTSTR lpValue)
 {
     int ret;
 
-    if (lpValue == nullptr)
+    if (lpValue != nullptr)
     {
         ret = setenv(lpName, lpValue, 1);
     }

--- a/src/dnx/pal.win32.cpp
+++ b/src/dnx/pal.win32.cpp
@@ -1,0 +1,77 @@
+#include "stdafx.h"
+
+void GetNativeBootstrapperDirectory(LPTSTR szPath)
+{
+    DWORD dirLength = GetModuleFileName(NULL, szPath, MAX_PATH);
+    for (dirLength--; dirLength >= 0 && szPath[dirLength] != _T('\\'); dirLength--);
+    szPath[dirLength + 1] = _T('\0');
+}
+
+void WaitForDebuggerToAttach()
+{
+    if (!IsDebuggerPresent())
+    {
+        ::_tprintf_s(_T("Process Id: %ld\r\n"), GetCurrentProcessId());
+        ::_tprintf_s(_T("Waiting for the debugger to attach...\r\n"));
+
+        // Do not use getchar() like in corerun because it doesn't work well with remote sessions
+        while (!IsDebuggerPresent())
+        {
+            Sleep(250);
+        }
+
+        ::_tprintf_s(_T("Debugger attached.\r\n"));
+    }
+}
+
+bool IsTracingEnabled()
+{
+    TCHAR szTrace[2];
+    DWORD nEnvTraceSize = GetEnvironmentVariable(_T("DNX_TRACE"), szTrace, 2);
+    bool m_fVerboseTrace = (nEnvTraceSize == 1);
+    if (m_fVerboseTrace)
+    {
+        szTrace[1] = _T('\0');
+        return _tcsnicmp(szTrace, _T("1"), 1) == 0;
+    }
+
+    return false;
+}
+
+BOOL GetAppBasePathFromEnvironment(LPTSTR pszAppBase)
+{
+    DWORD dwAppBase = GetEnvironmentVariable(_T("DNX_APPBASE"), pszAppBase, MAX_PATH);
+    return dwAppBase != 0 && dwAppBase < MAX_PATH;
+}
+
+BOOL GetFullPath(LPCTSTR szPath, LPTSTR pszNormalizedPath)
+{
+    DWORD dwFullAppBase = GetFullPathName(szPath, MAX_PATH, pszNormalizedPath, nullptr);
+    if (!dwFullAppBase)
+    {
+        ::_tprintf_s(_T("Failed to get full path of application base: %s\r\n"), szPath);
+        return FALSE;
+    }
+    else if (dwFullAppBase > MAX_PATH)
+    {
+        ::_tprintf_s(_T("Full path of application base is too long\r\n"));
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+HMODULE LoadNativeHost(LPCTSTR pszHostModuleName)
+{
+    return LoadLibraryEx(pszHostModuleName, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+}
+
+BOOL FreeNativeHost(HMODULE hHost)
+{
+    return FreeLibrary(hHost);
+}
+
+FARPROC GetEntryPointFromHost(HMODULE hHost, LPCSTR lpProcName)
+{
+    return GetProcAddress(hHost, lpProcName);
+}

--- a/src/dnx/stdafx.h
+++ b/src/dnx/stdafx.h
@@ -5,14 +5,41 @@
 
 #pragma once
 
+#include <stdio.h>
+
+#ifndef PLATFORM_UNIX
 #include "targetver.h"
 
-#include <stdio.h>
 #include <tchar.h>
 #include <strsafe.h>
 
-
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
-// Windows Header Files:
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#else // PLATFORM_UNIX
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
+typedef int BOOL;
+typedef uint32_t DWORD;
+typedef DWORD HRESULT;
+typedef void* HMODULE;
+typedef void* FARPROC;
+typedef void* HANDLE;
+
+#include "tchar.h"
+
+#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+
+#define STDAPICALLTYPE
+#define MAX_PATH PATH_MAX
+#define S_OK 0
+#define TRUE 1
+#define FALSE 0
+
+inline int max(int a, int b) { return a > b ? a : b; }
+#endif // PLATFORM_UNIX

--- a/src/dnx/tchar.cpp
+++ b/src/dnx/tchar.cpp
@@ -1,0 +1,38 @@
+#include "stdafx.h"
+#include "errno.h"
+
+int _tprintf_s(LPCTSTR format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    int ret = vprintf(format, args);
+    va_end(args);
+
+    return ret;
+}
+
+int _tcscpy_s(LPTSTR strDestination, size_t numberOfElements, LPCTSTR strSrc)
+{
+    if (strDestination == NULL || strSrc == NULL)
+    {
+        return EINVAL;
+    }
+
+    if (numberOfElements == 0)
+    {
+        return ERANGE;
+    }
+
+    strncpy(strDestination, strSrc, numberOfElements);
+
+
+    // strncpy will write null bytes to fill up strDestination if there
+    // was extra space.
+    if(strDestination[numberOfElements - 1] != '\0')
+    {
+        strDestination[0] = '\0';
+        return ERANGE;
+    }
+
+    return 0;
+}

--- a/src/dnx/tchar.h
+++ b/src/dnx/tchar.h
@@ -6,6 +6,7 @@ typedef const char* LPCSTR;
 #define _T(x) x
 
 #define _tcsnicmp strncasecmp
+#define _tcsicmp strcasecmp
 #define _tcsnlen strnlen
 
 int _tprintf_s(LPCTSTR format, ...);

--- a/src/dnx/tchar.h
+++ b/src/dnx/tchar.h
@@ -1,0 +1,12 @@
+typedef char TCHAR;
+typedef char* LPTSTR;
+typedef const char* LPCTSTR;
+typedef const char* LPCSTR;
+
+#define _T(x) x
+
+#define _tcsnicmp strncasecmp
+#define _tcsnlen strnlen
+
+int _tprintf_s(LPCTSTR format, ...);
+int _tcscpy_s(LPTSTR strDestination, size_t numberOfElements, LPCTSTR strSrc);


### PR DESCRIPTION
This seems like a good checkpoint.

The following changes make DNX cross platform and add another second level unamanged loader which can load CoreCLR on Linux and jump into it.  These components are not part of the official build yet, so instead Makefiles are provided to build them on an ad-hoc basis.

With these changes, it's possible to run a pre-compiled console hello world application, using CoreCLR on Linux, via dnx <path-to-hello-world.dll>.

The next step is to get HelloWorld running when compiled dynamically via Roslyn.

There are still some TODOs in the code that will get addressed later, for now this is enough to start getting things working.