### PR TITLE
Add kpm wrap assembly

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
@@ -47,6 +47,12 @@ namespace Microsoft.Framework.PackageManager
             var extension = Path.GetExtension(InputFilePath);
             if (string.Equals(extension, ".csproj", StringComparison.OrdinalIgnoreCase))
             {
+                if (PlatformHelper.IsMono)
+                {
+                    Reports.Error.WriteLine("Wrapping csproj is not supported on non-Windows platforms");
+                    return false;
+                }
+
                 return WrapCsProject();
             }
             else if (string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -517,6 +517,9 @@ namespace Microsoft.Framework.PackageManager
                     var optInPlace = c.Option("-i|--in-place",
                         "Generate or update project.json files in project directories of csprojs",
                         CommandOptionType.NoValue);
+                    var optFramework = c.Option("-f|--framework",
+                        "Target framework of assembly to be wrapped",
+                        CommandOptionType.SingleValue);
                     c.HelpOption("-?|-h|--help");
 
                     c.OnExecute(() =>
@@ -525,10 +528,11 @@ namespace Microsoft.Framework.PackageManager
 
                         var command = new WrapCommand();
                         command.Reports = reports;
-                        command.CsProjectPath = argPath.Value;
+                        command.InputFilePath = argPath.Value;
                         command.Configuration = optConfiguration.Value();
                         command.MsBuildPath = optMsBuildPath.Value();
                         command.InPlace = optInPlace.HasValue();
+                        command.Framework = optFramework.Value();
 
                         var success = command.ExecuteCommand();
 

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmWrapTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmWrapTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Framework.PackageManager
   }
 }";
             var expectedGlobalJson = @"{
-    ""sources"": [ ""src"", ""test"" ]
+    ""projects"": [ ""src"", ""test"" ]
 }";
             using (runtimeHomeDir)
             using (var testSolutionDir = TestUtils.GetTempTestSolution("ConsoleApp1"))
@@ -147,7 +147,7 @@ namespace Microsoft.Framework.PackageManager
   }
 }";
             var expectedGlobalJson = @"{
-  ""sources"": [
+  ""projects"": [
     ""src"",
     ""test"",
     ""wrap""
@@ -226,7 +226,7 @@ namespace Microsoft.Framework.PackageManager
   }
 }";
             var expectedGlobalJson = @"{
-  ""sources"": [
+  ""projects"": [
     ""src"",
     ""test"",
     ""wrap"",


### PR DESCRIPTION
parent https://github.com/aspnet/DNX/issues/1385 https://github.com/aspnet/DNX/issues/1316

- Automatically wrap dependency assemblies in same dir
- Automatically wrap pdb in same dir

Functional tests will be added soon. This PR allows people help to review usage ASAP.

@davidfowl @lodejard @muratg 
