### PR TITLE
Update project.json schema warnings

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
@@ -33,17 +33,12 @@ namespace Microsoft.Framework.PackageManager
 
         public bool Build()
         {
-            var warnings = new List<FileFormatWarning>();
+            var projectDiagnostics = new List<FileFormatWarning>();
             Runtime.Project project;
-            if (!Runtime.Project.TryGetProject(_buildOptions.ProjectDir, out project, warnings))
+            if (!Runtime.Project.TryGetProject(_buildOptions.ProjectDir, out project, projectDiagnostics))
             {
                 LogError(string.Format("Unable to locate {0}.", Runtime.Project.ProjectFileName));
                 return false;
-            }
-
-            foreach (var warning in warnings)
-            {
-                _buildOptions.Reports.Information.WriteLine(string.Format("Warning: At line {0} - {1}", warning.Line, warning.Message).Yellow());
             }
 
             var sw = Stopwatch.StartNew();
@@ -213,6 +208,9 @@ namespace Microsoft.Framework.PackageManager
 
             sw.Stop();
 
+            projectDiagnostics.ForEach(d => LogWarning(d.FormattedMessage));
+
+            allDiagnostics.AddRange(projectDiagnostics);
             WriteSummary(allDiagnostics);
 
             _buildOptions.Reports.Information.WriteLine("Time elapsed {0}", sw.Elapsed);

--- a/src/Microsoft.Framework.PackageManager/Bundle/BundleManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Bundle/BundleManager.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
 
             foreach (var warning in warnings)
             {
-                _options.Reports.Information.WriteLine(string.Format("Warning: At line {0} - {1}", warning.Line, warning.Message).Yellow());
+                _options.Reports.Information.WriteLine(warning.FormattedMessage.Yellow());
             }
 
             // '--wwwroot' option can override 'webroot' property in project.json

--- a/src/Microsoft.Framework.Runtime.Hosting/FileFormatWarning.cs
+++ b/src/Microsoft.Framework.Runtime.Hosting/FileFormatWarning.cs
@@ -6,25 +6,43 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Framework.Runtime
 {
-    public sealed class FileFormatWarning
+    public class FileFormatWarning : ICompilationMessage
     {
+        private static readonly string FormattedMessageTemplate = "{0}({1},{2}): warning: {3}";
+
         public FileFormatWarning(string message, string projectFilePath, JToken token)
         {
             Message = message;
-            Path = projectFilePath;
+            SourceFilePath = projectFilePath;
 
             var lineInfo = (IJsonLineInfo)token;
 
-            Column = lineInfo.LinePosition;
-            Line = lineInfo.LineNumber;
+            StartColumn = lineInfo.LinePosition;
+            EndColumn = StartColumn;
+            StartLine = lineInfo.LineNumber;
+            EndLine = StartLine;
+        }
+
+        public string FormattedMessage
+        {
+            get
+            {
+                return string.Format(FormattedMessageTemplate, SourceFilePath, StartLine, StartColumn, Message);
+            }
         }
 
         public string Message { get; }
 
-        public string Path { get; }
+        public string SourceFilePath { get; }
 
-        public int Line { get; }
+        public CompilationMessageSeverity Severity { get { return CompilationMessageSeverity.Warning; } }
 
-        public int Column { get; }
+        public int StartLine { get; }
+
+        public int StartColumn { get; }
+
+        public int EndLine { get; }
+
+        public int EndColumn { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime.Hosting/PatternGroup.cs
+++ b/src/Microsoft.Framework.Runtime.Hosting/PatternGroup.cs
@@ -54,8 +54,8 @@ namespace Microsoft.Framework.Runtime
                     if (warnings != null)
                     {
                         warnings.Add(new FileFormatWarning(
-                            string.Format("Property {0} is deprecated. It is replaced by {1}", legacyName, name),
-                            projectDirectory,
+                            string.Format("Property \"{0}\" is deprecated. It is replaced by \"{1}\".", legacyName, name),
+                            projectFilePath,
                             token));
                     }
                 }


### PR DESCRIPTION
Including path to the project.json

After fix:
```
$ kpm build
Warning: C:\myk\DNX\src\Microsoft.Framework.Runtime at line 5 - Property code is deprecated. It is replaced by compile
```