### PR TITLE
Make tests show info of runtime in use when they are failed

### DIFF
--- a/test/Bootstrapper.FunctionalTests/BootstrapperTests.cs
+++ b/test/Bootstrapper.FunctionalTests/BootstrapperTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using Microsoft.Framework.FunctionalTestUtils;
 using Microsoft.Framework.PackageManager;
@@ -13,22 +12,19 @@ namespace Bootstrapper.FunctionalTests
 {
     public class BootstrapperTests
     {
-        public static IEnumerable<object[]> RuntimeHomeDirs
+        public static IEnumerable<object[]> RuntimeComponents
         {
             get
             {
-                foreach (var path in TestUtils.GetRuntimeHomeDirs())
-                {
-                    yield return new[] { path };
-                }
+                return TestUtils.GetRuntimeComponentsCombinations();
             }
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void BootstrapperReturnsNonZeroExitCodeWhenNoArgumentWasGiven(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void BootstrapperReturnsNonZeroExitCodeWhenNoArgumentWasGiven(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 string stdOut, stdErr;
                 var exitCode = BootstrapperTestUtils.ExecBootstrapper(
@@ -42,10 +38,10 @@ namespace Bootstrapper.FunctionalTests
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void BootstrapperReturnsZeroExitCodeWhenHelpOptionWasGiven(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void BootstrapperReturnsZeroExitCodeWhenHelpOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 string stdOut, stdErr;
                 var exitCode = BootstrapperTestUtils.ExecBootstrapper(
@@ -59,10 +55,10 @@ namespace Bootstrapper.FunctionalTests
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void BootstrapperShowsVersionAndReturnsZeroExitCodeWhenVersionOptionWasGiven(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void BootstrapperShowsVersionAndReturnsZeroExitCodeWhenVersionOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 string stdOut, stdErr;
                 var exitCode = BootstrapperTestUtils.ExecBootstrapper(
@@ -77,10 +73,10 @@ namespace Bootstrapper.FunctionalTests
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void BootstrapperInvokesApplicationHostWithInferredAppBase(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void BootstrapperInvokesApplicationHostWithInferredAppBase(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 var sampleAppRoot = Path.Combine(TestUtils.GetSamplesFolder(), "HelloWorld");
                 string stdOut, stdErr;

--- a/test/Microsoft.Framework.ApplicationHost.FunctionalTests/KCommandTests.cs
+++ b/test/Microsoft.Framework.ApplicationHost.FunctionalTests/KCommandTests.cs
@@ -11,22 +11,19 @@ namespace Microsoft.Framework.ApplicationHost
 {
     public class KCommandTests
     {
-        public static IEnumerable<object[]> RuntimeHomeDirs
+        public static IEnumerable<object[]> RuntimeComponents
         {
             get
             {
-                foreach (var path in TestUtils.GetRuntimeHomeDirs())
-                {
-                    yield return new[] { path };
-                }
+                return TestUtils.GetRuntimeComponentsCombinations();
             }
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KCommandReturnsNonZeroExitCodeWhenNoArgumentWasGiven(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KCommandReturnsNonZeroExitCodeWhenNoArgumentWasGiven(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 string stdOut, stdErr;
                 var exitCode = KCommandTestUtils.ExecKCommand(
@@ -41,10 +38,10 @@ namespace Microsoft.Framework.ApplicationHost
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KCommandReturnsZeroExitCodeWhenHelpOptionWasGiven(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KCommandReturnsZeroExitCodeWhenHelpOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 string stdOut, stdErr;
                 var exitCode = KCommandTestUtils.ExecKCommand(
@@ -59,10 +56,10 @@ namespace Microsoft.Framework.ApplicationHost
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KCommandShowsVersionAndReturnsZeroExitCodeWhenVersionOptionWasGiven(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KCommandShowsVersionAndReturnsZeroExitCodeWhenVersionOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 string stdOut, stdErr;
                 var exitCode = KCommandTestUtils.ExecKCommand(
@@ -78,10 +75,10 @@ namespace Microsoft.Framework.ApplicationHost
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KCommandShowsErrorWhenNoProjectJsonWasFound(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KCommandShowsErrorWhenNoProjectJsonWasFound(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             using (var emptyFolder = TestUtils.CreateTempDir())
             {
                 string stdOut, stdErr;
@@ -99,9 +96,10 @@ namespace Microsoft.Framework.ApplicationHost
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KCommandShowsErrorWhenGivenSubcommandWasNotFoundInProjectJson(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KCommandShowsErrorWhenGivenSubcommandWasNotFoundInProjectJson(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
             var projectStructure = @"{
   'project.json': '{ }'
 }";
@@ -127,10 +125,10 @@ namespace Microsoft.Framework.ApplicationHost
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KCommandRunsSampleAppGivenAppBase(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KCommandRunsSampleAppGivenAppBase(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 var sampleAppRoot = Path.Combine(TestUtils.GetSamplesFolder(), "HelloWorld");
                 string stdOut, stdErr;
@@ -147,10 +145,10 @@ namespace Microsoft.Framework.ApplicationHost
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KCommandRunsSampleAppUsingDefaultAppBase(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KCommandRunsSampleAppUsingDefaultAppBase(string flavor, string os, string architecture)
         {
-            using (runtimeHomeDir)
+            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             {
                 var sampleAppRoot = Path.Combine(TestUtils.GetSamplesFolder(), "HelloWorld");
                 string stdOut, stdErr;

--- a/test/Microsoft.Framework.FunctionalTestUtils/TestUtils.cs
+++ b/test/Microsoft.Framework.FunctionalTestUtils/TestUtils.cs
@@ -74,12 +74,12 @@ namespace Microsoft.Framework.FunctionalTestUtils
             return runtimeHomePath;
         }
 
-        public static IEnumerable<DisposableDir> GetRuntimeHomeDirs()
+        public static IEnumerable<object[]> GetRuntimeComponentsCombinations()
         {
-            yield return GetRuntimeHomeDir(flavor: "clr", os: "win", architecture: "x64");
-            yield return GetRuntimeHomeDir(flavor: "clr", os: "win", architecture: "x86");
-            yield return GetRuntimeHomeDir(flavor: "coreclr", os: "win", architecture: "x64");
-            yield return GetRuntimeHomeDir(flavor: "coreclr", os: "win", architecture: "x86");
+            yield return new[] { "clr", "win", "x64" };
+            yield return new[] { "clr", "win", "x86" };
+            yield return new[] { "coreclr", "win", "x64" };
+            yield return new[] { "coreclr", "win", "x86" };
         }
 
         public static DisposableDir GetTempTestSolution(string name)

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmBundleTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmBundleTests.cs
@@ -43,21 +43,20 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ""libraries"": {}
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString());
 
-        public static IEnumerable<object[]> RuntimeHomeDirs
+        public static IEnumerable<object[]> RuntimeComponents
         {
             get
             {
-                foreach (var path in TestUtils.GetRuntimeHomeDirs())
-                {
-                    yield return new[] { path };
-                }
+                return TestUtils.GetRuntimeComponentsCombinations();
             }
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmBundleWebApp_RootAsPublicFolder(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmBundleWebApp_RootAsPublicFolder(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json', 'Config.json', 'Program.cs', 'build_config1.bconfig'],
   'Views': {
@@ -157,9 +156,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmBundleWebApp_SubfolderAsPublicFolder(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmBundleWebApp_SubfolderAsPublicFolder(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json', 'Config.json', 'Program.cs'],
   'public': {
@@ -253,9 +254,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmBundleConsoleApp(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmBundleConsoleApp(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json', 'Config.json', 'Program.cs'],
   'Data': {
@@ -315,9 +318,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void FoldersAsFilePatternsAutoGlob(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void FoldersAsFilePatternsAutoGlob(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json', 'FileWithoutExtension'],
   'UselessFolder1': {
@@ -416,9 +421,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void WildcardMatchingFacts(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void WildcardMatchingFacts(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json'],
   'UselessFolder1': {
@@ -509,9 +516,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void CorrectlyExcludeFoldersStartingWithDots(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void CorrectlyExcludeFoldersStartingWithDots(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json', 'File', '.FileStartingWithDot', 'File.Having.Dots'],
   '.FolderStaringWithDot': {
@@ -600,9 +609,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void VerifyDefaultBundleExcludePatterns(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void VerifyDefaultBundleExcludePatterns(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json', 'File', '.FileStartingWithDot'],
   'bin': {
@@ -668,9 +679,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmBundleWebApp_CopyExistingWebConfig(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmBundleWebApp_CopyExistingWebConfig(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json'],
   'public': ['index.html', 'web.config'],
@@ -750,9 +763,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmBundleWebApp_UpdateExistingWebConfig(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmBundleWebApp_UpdateExistingWebConfig(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json'],
   'public': ['index.html', 'web.config'],
@@ -848,9 +863,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void GenerateBatchFilesAndBashScriptsWithoutBundledRuntime(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void GenerateBatchFilesAndBashScriptsWithoutBundledRuntime(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             var projectStructure = @"{
   '.': ['project.json'],
   'packages': {}
@@ -933,9 +950,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void GenerateBatchFilesAndBashScriptsWithBundledRuntime(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void GenerateBatchFilesAndBashScriptsWithBundledRuntime(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             // Each runtime home only contains one runtime package, which is the one we are currently testing against
             var runtimeRoot = Directory.EnumerateDirectories(Path.Combine(runtimeHomeDir, "runtimes"), Constants.RuntimeNamePrefix + "*").First();
             var runtimeName = new DirectoryInfo(runtimeRoot).Name;

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmWrapTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmWrapTests.cs
@@ -7,27 +7,28 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Framework.FunctionalTestUtils;
 using Microsoft.Framework.Runtime;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Framework.PackageManager
 {
     public class KpmWrapTests
     {
-        public static IEnumerable<object[]> RuntimeHomeDirs
+        public static IEnumerable<object[]> RuntimeComponents
         {
             get
             {
-                return TestUtils.GetRuntimeHomeDirs().Select(path => new[] { path });
+                return TestUtils.GetRuntimeComponentsCombinations();
             }
         }
 
         public static readonly string _msbuildPath = TestUtils.ResolveMSBuildPath();
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmWrapUpdatesExistingProjectJson(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmWrapUpdatesExistingProjectJson(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             if (PlatformHelper.IsMono)
             {
                 return;
@@ -99,9 +100,11 @@ namespace Microsoft.Framework.PackageManager
         }
 
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmWrapMaintainsAllKindsOfReferences(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmWrapMaintainsAllKindsOfReferences(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             if (PlatformHelper.IsMono)
             {
                 return;
@@ -178,9 +181,11 @@ namespace Microsoft.Framework.PackageManager
         }
         
         [Theory]
-        [MemberData("RuntimeHomeDirs")]
-        public void KpmWrapInPlaceCreateCsprojWrappersInPlace(DisposableDir runtimeHomeDir)
+        [MemberData("RuntimeComponents")]
+        public void KpmWrapInPlaceCreateCsprojWrappersInPlace(string flavor, string os, string architecture)
         {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             if (PlatformHelper.IsMono)
             {
                 return;


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1422

@davidfowl 
The failed test case will show something like
```c#
NameSpace.Class.TestCaseMethod(flavor: "coreclr", os: "win", architecture: "x64") [FAIL]
```