### PR TITLE
Move Copy file from Bundle to FileOperationUtils

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Bundle/BundlePackage.cs
+++ b/src/Microsoft.Framework.PackageManager/Bundle/BundlePackage.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
             }
 
             Directory.CreateDirectory(targetFolder);
-            root.Operations.Copy(srcFolder, targetFolder);
+            FileOperationUtils.Copy(srcFolder, targetFolder);
         }
 
         private void CopyFile(BundleRoot root, string srcPath, string targetPath)

--- a/src/Microsoft.Framework.PackageManager/Bundle/BundleProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Bundle/BundleProject.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
                 wwwRootPath = string.Empty;
             }
 
-            root.Operations.Copy(project.ProjectDirectory, targetPath, itemPath =>
+            FileOperationUtils.Copy(project.ProjectDirectory, targetPath, itemPath =>
             {
                 // If current file/folder is in the exclusion list, we don't copy it
                 if (excludeSet.Contains(itemPath))
@@ -559,7 +559,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
             root.Reports.Quiet.WriteLine("  Source {0}", contentSourcePath);
             root.Reports.Quiet.WriteLine("  Target {0}", targetFolderPath);
 
-            root.Operations.Copy(contentSourcePath, targetFolderPath);
+            FileOperationUtils.Copy(contentSourcePath, targetFolderPath);
         }
 
         private static string GetWwwRootSourcePath(string projectDirectory, string wwwRoot)

--- a/src/Microsoft.Framework.PackageManager/Bundle/BundleRuntime.cs
+++ b/src/Microsoft.Framework.PackageManager/Bundle/BundleRuntime.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Framework.PackageManager.Bundle
                 Directory.CreateDirectory(TargetPath);
             }
 
-            new BundleOperations().Copy(_runtimePath, TargetPath);
+            FileOperationUtils.Copy(_runtimePath, TargetPath);
 
             if (PlatformHelper.IsMono)
             {

--- a/src/Microsoft.Framework.PackageManager/Utils/FileOperationUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/FileOperationUtils.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Framework.Runtime;
+using NuGet;
 
 namespace Microsoft.Framework.PackageManager
 {
@@ -15,6 +17,7 @@ namespace Microsoft.Framework.PackageManager
             // Calling DeleteRecursive rather than Directory.Delete(..., recursive: true)
             // due to an infrequent exception which can be thrown from that API
             DeleteRecursive(folderPath);
+            Directory.Delete(folderPath);
         }
 
         private static void DeleteRecursive(string deletePath)
@@ -55,6 +58,55 @@ namespace Microsoft.Framework.PackageManager
             process.WaitForExit();
 
             return process.ExitCode == 0;
+        }
+
+        public static void Copy(string sourcePath, string targetPath)
+        {
+            Copy(
+                sourcePath,
+                targetPath,
+                shouldInclude: _ => true);
+        }
+
+        public static void Copy(string sourcePath, string targetPath, Func<string, bool> shouldInclude)
+        {
+            sourcePath = PathUtility.EnsureTrailingSlash(sourcePath);
+            targetPath = PathUtility.EnsureTrailingSlash(targetPath);
+
+            // Directory.EnumerateFiles(path) throws "path is too long" exception if path is longer than 248 characters
+            // So we flatten the enumeration here with SearchOption.AllDirectories,
+            // instead of calling Directory.EnumerateFiles(path) with SearchOption.TopDirectoryOnly in each subfolder
+            foreach (var sourceFilePath in Directory.EnumerateFiles(sourcePath, "*.*", SearchOption.AllDirectories))
+            {
+                var fileName = Path.GetFileName(sourceFilePath);
+                Debug.Assert(fileName != null, "fileName != null");
+
+                if (!shouldInclude(sourceFilePath))
+                {
+                    continue;
+                }
+
+                var targetFilePath = sourceFilePath.Replace(sourcePath, targetPath);
+                var targetFileParentFolder = Path.GetDirectoryName(targetFilePath);
+
+                // Create directory before copying a file
+                if (!Directory.Exists(targetFileParentFolder))
+                {
+                    Directory.CreateDirectory(targetFileParentFolder);
+                }
+
+                File.Copy(
+                    sourceFilePath,
+                    targetFilePath,
+                    overwrite: true);
+
+                // clear read-only bit if set
+                var fileAttributes = File.GetAttributes(targetFilePath);
+                if ((fileAttributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                {
+                    File.SetAttributes(targetFilePath, fileAttributes & ~FileAttributes.ReadOnly);
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Framework.PackageManager
                         nupkgStream.Seek(0, SeekOrigin.Begin);
 
                         ExtractPackage(extractPath, nupkgStream);
-                        Directory.Move(extractPath, targetPath);
+                        FileOperationUtils.Copy(extractPath, targetPath);
+                        FileOperationUtils.DeleteFolder(extractPath);
                     }
 
                     // Fixup the casing of the nuspec on disk to match what we expect

--- a/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
@@ -47,8 +47,18 @@ namespace Microsoft.Framework.PackageManager
                         nupkgStream.Seek(0, SeekOrigin.Begin);
 
                         ExtractPackage(extractPath, nupkgStream);
-                        FileOperationUtils.Copy(extractPath, targetPath);
-                        FileOperationUtils.DeleteFolder(extractPath);
+                        for (var i = 0; i < 2; ++i)
+                        {
+                            try
+                            {
+                                Directory.Move(extractPath, targetPath);
+                                break;
+                            }
+                            //Directory.Move sometimes throws
+                            catch (IOException)
+                            {
+                            }
+                        }
                     }
 
                     // Fixup the casing of the nuspec on disk to match what we expect


### PR DESCRIPTION
Use Copy instead of Directory.Move since it sometimes throws
#1366 
@davidfowl @ChengTian 