### PR TITLE
Fixed 2 issues

### DIFF
--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
@@ -75,6 +75,8 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
                     _cacheContextAccessor.Current.Monitor(_namedDependencyProvider.GetNamedDependency(buildOutputsName));
                 }
+
+                _cacheContextAccessor.Current.Monitor(_namedDependencyProvider.GetNamedDependency(project.Name + "_Dependencies"));
             }
 
             var exportedReferences = incomingReferences.Select(ConvertMetadataReference);

--- a/src/Microsoft.Framework.Runtime/Loader/DesignTimeCompilationException.cs
+++ b/src/Microsoft.Framework.Runtime/Loader/DesignTimeCompilationException.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.Runtime
     internal class DesignTimeCompilationException : Exception, ICompilationException
     {
         public DesignTimeCompilationException(IList<CompilationMessage> compileResponseErrors)
-            : base(string.Join(Environment.NewLine, compileResponseErrors.SelectMany(e => e.FormattedMessage)))
+            : base(string.Join(Environment.NewLine, compileResponseErrors.Select(e => e.FormattedMessage)))
         {
             CompilationFailures = compileResponseErrors.GroupBy(g => g.SourceFilePath, StringComparer.OrdinalIgnoreCase)
                                                        .Select(g => new CompilationFailure


### PR DESCRIPTION
- Handle design time compilation errors properly. It ended
up using SelectMany instead of Select which turned the error message
into a list of chars instead of a list of new line separated strings
- Make preprocessors respect changes in dependencies.