### PR TITLE
DTH applies out-of-date lock file to reduce error messages

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
@@ -1044,7 +1044,8 @@ namespace Microsoft.Framework.DesignTimeHost
                                                                         cache: _cache,
                                                                         cacheContextAccessor: _cacheContextAccessor,
                                                                         namedCacheDependencyProvider: _namedDependencyProvider,
-                                                                        loadContextFactory: GetRuntimeLoadContextFactory(project));
+                                                                        loadContextFactory: GetRuntimeLoadContextFactory(project),
+                                                                        skipLockFileValidation: true);
 
                 applicationHostContext.DependencyWalker.Walk(project.Name, project.Version, frameworkName);
 

--- a/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Framework.Runtime
                                       ICache cache,
                                       ICacheContextAccessor cacheContextAccessor,
                                       INamedCacheDependencyProvider namedCacheDependencyProvider,
-                                      IAssemblyLoadContextFactory loadContextFactory = null)
+                                      IAssemblyLoadContextFactory loadContextFactory = null,
+                                      bool skipLockFileValidation = false)
         {
             ProjectDirectory = projectDirectory;
             Configuration = configuration;
@@ -67,7 +68,7 @@ namespace Microsoft.Framework.Runtime
                 var lockFile = lockFileFormat.Read(projectLockJsonPath);
                 validLockFile = lockFile.IsValidForProject(Project);
 
-                if (validLockFile)
+                if (validLockFile || skipLockFileValidation)
                 {
                     NuGetDependencyProvider.ApplyLockFile(lockFile);
 
@@ -81,9 +82,9 @@ namespace Microsoft.Framework.Runtime
                 }
             }
 
-            if (!lockFileExists || !validLockFile)
+            if (!validLockFile && !skipLockFileValidation)
             {
-                // If we are unable to apply the lockfile, we don't add NuGetDependencyProvider to DependencyWalker
+                // We don't add NuGetDependencyProvider to DependencyWalker
                 // It will leave all NuGet packages unresolved and give error message asking users to run "kpm restore"
                 DependencyWalker = new DependencyWalker(new IDependencyProvider[] {
                     ProjectDepencyProvider,


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1444

@davidfowl , this is the most simple way to fix https://github.com/aspnet/dnx/issues/1444. Tested with starter web app, when you add a new dependency `XYZ.1.0.0` to `project.json` and Ctrl+S, the error list only shows `XYZ.1.0.0 cannot be resolved`