### PR TITLE
Temporarily include System.Private.DataContractSerialization.dll in

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -567,7 +567,7 @@ var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPE
             // copy required CoreCLR assemblies
             if (target.Framework == "dnxcore50")
             {
-                foreach (var file in Directory.GetFiles(coreclrFolder).Where(f => !Path.GetFileName(f).StartsWith("System")))
+                foreach (var file in Directory.GetFiles(coreclrFolder).Where(f => Path.GetFileName(f).Equals("System.Private.DataContractSerialization.dll") || !Path.GetFileName(f).StartsWith("System")))
                 {
                     var targetFilePath = Path.Combine(target.TargetFolder, Path.GetFileName(file));
                     Log.Info("Copying " + file + " to " + targetFilePath);


### PR DESCRIPTION
coreclr runtime.