### PR TITLE
Fix dnx trace message

### DIFF
--- a/src/dnx.coreclr.unix/tpa.cpp
+++ b/src/dnx.coreclr.unix/tpa.cpp
@@ -6,7 +6,7 @@
 
 BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
 {
-    const size_t count = 34;
+    const size_t count = 35;
     LPCTSTR* pArray = new LPCTSTR[count];
 
     if (bNative)
@@ -25,26 +25,27 @@ BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
         pArray[11] = _T("System.Console.ni.dll");
         pArray[12] = _T("System.Core.ni.dll");
         pArray[13] = _T("System.Diagnostics.Debug.ni.dll");
-        pArray[14] = _T("System.Globalization.ni.dll");
-        pArray[15] = _T("System.IO.ni.dll");
-        pArray[16] = _T("System.IO.FileSystem.ni.dll");
-        pArray[17] = _T("System.IO.FileSystem.Primitives.ni.dll");
-        pArray[18] = _T("System.Linq.ni.dll");
-        pArray[19] = _T("System.Reflection.ni.dll");
-        pArray[20] = _T("System.Reflection.Extensions.ni.dll");
-        pArray[21] = _T("System.Reflection.Primitives.ni.dll");
-        pArray[22] = _T("System.Resources.ResourceManager.ni.dll");
-        pArray[23] = _T("System.Runtime.ni.dll");
-        pArray[24] = _T("System.Runtime.Extensions.ni.dll");
-        pArray[25] = _T("System.Runtime.Handles.ni.dll");
-        pArray[26] = _T("System.Runtime.InteropServices.ni.dll");
-        pArray[27] = _T("System.Runtime.Loader.ni.dll");
-        pArray[28] = _T("System.Text.Encoding.ni.dll");
-        pArray[29] = _T("System.Text.Encoding.Extensions.ni.dll");
-        pArray[30] = _T("System.Threading.ni.dll");
-        pArray[31] = _T("System.Threading.Overlapped.ni.dll");
-        pArray[32] = _T("System.Threading.Tasks.ni.dll");
-        pArray[33] = _T("System.Threading.ThreadPool.ni.dll");
+        pArray[14] = _T("System.Diagnostics.Tracing.ni.dll");
+        pArray[15] = _T("System.Globalization.ni.dll");
+        pArray[16] = _T("System.IO.ni.dll");
+        pArray[17] = _T("System.IO.FileSystem.ni.dll");
+        pArray[18] = _T("System.IO.FileSystem.Primitives.ni.dll");
+        pArray[19] = _T("System.Linq.ni.dll");
+        pArray[20] = _T("System.Reflection.ni.dll");
+        pArray[21] = _T("System.Reflection.Extensions.ni.dll");
+        pArray[22] = _T("System.Reflection.Primitives.ni.dll");
+        pArray[23] = _T("System.Resources.ResourceManager.ni.dll");
+        pArray[24] = _T("System.Runtime.ni.dll");
+        pArray[25] = _T("System.Runtime.Extensions.ni.dll");
+        pArray[26] = _T("System.Runtime.Handles.ni.dll");
+        pArray[27] = _T("System.Runtime.InteropServices.ni.dll");
+        pArray[28] = _T("System.Runtime.Loader.ni.dll");
+        pArray[29] = _T("System.Text.Encoding.ni.dll");
+        pArray[30] = _T("System.Text.Encoding.Extensions.ni.dll");
+        pArray[31] = _T("System.Threading.ni.dll");
+        pArray[32] = _T("System.Threading.Overlapped.ni.dll");
+        pArray[33] = _T("System.Threading.Tasks.ni.dll");
+        pArray[34] = _T("System.Threading.ThreadPool.ni.dll");
     }
     else
     {
@@ -62,26 +63,27 @@ BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
         pArray[11] = _T("System.Console.dll");
         pArray[12] = _T("System.Core.dll");
         pArray[13] = _T("System.Diagnostics.Debug.dll");
-        pArray[14] = _T("System.Globalization.dll");
-        pArray[15] = _T("System.IO.dll");
-        pArray[16] = _T("System.IO.FileSystem.dll");
-        pArray[17] = _T("System.IO.FileSystem.Primitives.dll");
-        pArray[18] = _T("System.Linq.dll");
-        pArray[19] = _T("System.Reflection.dll");
-        pArray[20] = _T("System.Reflection.Extensions.dll");
-        pArray[21] = _T("System.Reflection.Primitives.dll");
-        pArray[22] = _T("System.Resources.ResourceManager.dll");
-        pArray[23] = _T("System.Runtime.dll");
-        pArray[24] = _T("System.Runtime.Extensions.dll");
-        pArray[25] = _T("System.Runtime.Handles.dll");
-        pArray[26] = _T("System.Runtime.InteropServices.dll");
-        pArray[27] = _T("System.Runtime.Loader.dll");
-        pArray[28] = _T("System.Text.Encoding.dll");
-        pArray[29] = _T("System.Text.Encoding.Extensions.dll");
-        pArray[30] = _T("System.Threading.dll");
-        pArray[31] = _T("System.Threading.Overlapped.dll");
-        pArray[32] = _T("System.Threading.Tasks.dll");
-        pArray[33] = _T("System.Threading.ThreadPool.dll");
+        pArray[14] = _T("System.Diagnostics.Tracing.dll");
+        pArray[15] = _T("System.Globalization.dll");
+        pArray[16] = _T("System.IO.dll");
+        pArray[17] = _T("System.IO.FileSystem.dll");
+        pArray[18] = _T("System.IO.FileSystem.Primitives.dll");
+        pArray[19] = _T("System.Linq.dll");
+        pArray[20] = _T("System.Reflection.dll");
+        pArray[21] = _T("System.Reflection.Extensions.dll");
+        pArray[22] = _T("System.Reflection.Primitives.dll");
+        pArray[23] = _T("System.Resources.ResourceManager.dll");
+        pArray[24] = _T("System.Runtime.dll");
+        pArray[25] = _T("System.Runtime.Extensions.dll");
+        pArray[26] = _T("System.Runtime.Handles.dll");
+        pArray[27] = _T("System.Runtime.InteropServices.dll");
+        pArray[28] = _T("System.Runtime.Loader.dll");
+        pArray[29] = _T("System.Text.Encoding.dll");
+        pArray[30] = _T("System.Text.Encoding.Extensions.dll");
+        pArray[31] = _T("System.Threading.dll");
+        pArray[32] = _T("System.Threading.Overlapped.dll");
+        pArray[33] = _T("System.Threading.Tasks.dll");
+        pArray[34] = _T("System.Threading.ThreadPool.dll");
     }
 
     *ppNames = pArray;

--- a/src/dnx.coreclr/tpa.cpp
+++ b/src/dnx.coreclr/tpa.cpp
@@ -6,7 +6,7 @@
 
 BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
 {
-    const size_t count = 34;
+    const size_t count = 35;
     LPCTSTR* pArray = new LPCTSTR[count];
 
     if (bNative)
@@ -25,26 +25,27 @@ BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
         pArray[11] = _T("System.Console.ni.dll");
         pArray[12] = _T("System.Core.ni.dll");
         pArray[13] = _T("System.Diagnostics.Debug.ni.dll");
-        pArray[14] = _T("System.Globalization.ni.dll");
-        pArray[15] = _T("System.IO.ni.dll");
-        pArray[16] = _T("System.IO.FileSystem.ni.dll");
-        pArray[17] = _T("System.IO.FileSystem.Primitives.ni.dll");
-        pArray[18] = _T("System.Linq.ni.dll");
-        pArray[19] = _T("System.Reflection.ni.dll");
-        pArray[20] = _T("System.Reflection.Extensions.ni.dll");
-        pArray[21] = _T("System.Reflection.Primitives.ni.dll");
-        pArray[22] = _T("System.Resources.ResourceManager.ni.dll");
-        pArray[23] = _T("System.Runtime.ni.dll");
-        pArray[24] = _T("System.Runtime.Extensions.ni.dll");
-        pArray[25] = _T("System.Runtime.Handles.ni.dll");
-        pArray[26] = _T("System.Runtime.InteropServices.ni.dll");
-        pArray[27] = _T("System.Runtime.Loader.ni.dll");
-        pArray[28] = _T("System.Text.Encoding.ni.dll");
-        pArray[29] = _T("System.Text.Encoding.Extensions.ni.dll");
-        pArray[30] = _T("System.Threading.ni.dll");
-        pArray[31] = _T("System.Threading.Overlapped.ni.dll");
-        pArray[32] = _T("System.Threading.Tasks.ni.dll");
-        pArray[33] = _T("System.Threading.ThreadPool.ni.dll");
+        pArray[14] = _T("System.Diagnostics.Tracing.ni.dll");
+        pArray[15] = _T("System.Globalization.ni.dll");
+        pArray[16] = _T("System.IO.ni.dll");
+        pArray[17] = _T("System.IO.FileSystem.ni.dll");
+        pArray[18] = _T("System.IO.FileSystem.Primitives.ni.dll");
+        pArray[19] = _T("System.Linq.ni.dll");
+        pArray[20] = _T("System.Reflection.ni.dll");
+        pArray[21] = _T("System.Reflection.Extensions.ni.dll");
+        pArray[22] = _T("System.Reflection.Primitives.ni.dll");
+        pArray[23] = _T("System.Resources.ResourceManager.ni.dll");
+        pArray[24] = _T("System.Runtime.ni.dll");
+        pArray[25] = _T("System.Runtime.Extensions.ni.dll");
+        pArray[26] = _T("System.Runtime.Handles.ni.dll");
+        pArray[27] = _T("System.Runtime.InteropServices.ni.dll");
+        pArray[28] = _T("System.Runtime.Loader.ni.dll");
+        pArray[29] = _T("System.Text.Encoding.ni.dll");
+        pArray[30] = _T("System.Text.Encoding.Extensions.ni.dll");
+        pArray[31] = _T("System.Threading.ni.dll");
+        pArray[32] = _T("System.Threading.Overlapped.ni.dll");
+        pArray[33] = _T("System.Threading.Tasks.ni.dll");
+        pArray[34] = _T("System.Threading.ThreadPool.ni.dll");
     }
     else
     {
@@ -62,26 +63,27 @@ BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
         pArray[11] = _T("System.Console.dll");
         pArray[12] = _T("System.Core.dll");
         pArray[13] = _T("System.Diagnostics.Debug.dll");
-        pArray[14] = _T("System.Globalization.dll");
-        pArray[15] = _T("System.IO.dll");
-        pArray[16] = _T("System.IO.FileSystem.dll");
-        pArray[17] = _T("System.IO.FileSystem.Primitives.dll");
-        pArray[18] = _T("System.Linq.dll");
-        pArray[19] = _T("System.Reflection.dll");
-        pArray[20] = _T("System.Reflection.Extensions.dll");
-        pArray[21] = _T("System.Reflection.Primitives.dll");
-        pArray[22] = _T("System.Resources.ResourceManager.dll");
-        pArray[23] = _T("System.Runtime.dll");
-        pArray[24] = _T("System.Runtime.Extensions.dll");
-        pArray[25] = _T("System.Runtime.Handles.dll");
-        pArray[26] = _T("System.Runtime.InteropServices.dll");
-        pArray[27] = _T("System.Runtime.Loader.dll");
-        pArray[28] = _T("System.Text.Encoding.dll");
-        pArray[29] = _T("System.Text.Encoding.Extensions.dll");
-        pArray[30] = _T("System.Threading.dll");
-        pArray[31] = _T("System.Threading.Overlapped.dll");
-        pArray[32] = _T("System.Threading.Tasks.dll");
-        pArray[33] = _T("System.Threading.ThreadPool.dll");
+        pArray[14] = _T("System.Diagnostics.Tracing.dll");
+        pArray[15] = _T("System.Globalization.dll");
+        pArray[16] = _T("System.IO.dll");
+        pArray[17] = _T("System.IO.FileSystem.dll");
+        pArray[18] = _T("System.IO.FileSystem.Primitives.dll");
+        pArray[19] = _T("System.Linq.dll");
+        pArray[20] = _T("System.Reflection.dll");
+        pArray[21] = _T("System.Reflection.Extensions.dll");
+        pArray[22] = _T("System.Reflection.Primitives.dll");
+        pArray[23] = _T("System.Resources.ResourceManager.dll");
+        pArray[24] = _T("System.Runtime.dll");
+        pArray[25] = _T("System.Runtime.Extensions.dll");
+        pArray[26] = _T("System.Runtime.Handles.dll");
+        pArray[27] = _T("System.Runtime.InteropServices.dll");
+        pArray[28] = _T("System.Runtime.Loader.dll");
+        pArray[29] = _T("System.Text.Encoding.dll");
+        pArray[30] = _T("System.Text.Encoding.Extensions.dll");
+        pArray[31] = _T("System.Threading.dll");
+        pArray[32] = _T("System.Threading.Overlapped.dll");
+        pArray[33] = _T("System.Threading.Tasks.dll");
+        pArray[34] = _T("System.Threading.ThreadPool.dll");
     }
 
     *ppNames = pArray;

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -321,7 +321,7 @@ int CallApplicationProcessMain(int argc, LPTSTR argv[])
         goto Finished;
     }
     if (m_fVerboseTrace)
-        ::_tprintf_s(_T("Found DLL Export: %s\r\n"), pszCallApplicationMainName);
+        printf_s("Found DLL Export: %s\r\n", pszCallApplicationMainName);
 
     hr = pfnCallApplicationMain(&data);
     if (SUCCEEDED(hr))

--- a/src/dnx/tchar.cpp
+++ b/src/dnx/tchar.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "errno.h"
 
-int _tprintf_s(LPCTSTR format, ...)
+int printf_s(LPCTSTR format, ...)
 {
     va_list args;
     va_start(args, format);

--- a/src/dnx/tchar.h
+++ b/src/dnx/tchar.h
@@ -8,6 +8,7 @@ typedef const char* LPCSTR;
 #define _tcsnicmp strncasecmp
 #define _tcsicmp strcasecmp
 #define _tcsnlen strnlen
+#define _tprintf_s printf_s
 
-int _tprintf_s(LPCTSTR format, ...);
+int printf_s(LPCTSTR format, ...);
 int _tcscpy_s(LPTSTR strDestination, size_t numberOfElements, LPCTSTR strSrc);


### PR DESCRIPTION
My previous changes caused garbage to be printed to the console when DNX_TRACE=1 was set on Windows.  This change fixes that.

I also updated the TPA list since when I built new stuff was pended.