### PR TITLE
Fix package name casing in lock file and installation process

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -389,19 +389,10 @@ namespace Microsoft.Framework.PackageManager
                     return;
                 }
 
-                // "dnu restore" is case-sensitive
                 if (!string.Equals(node.Item.Match.Library.Name, node.LibraryRange.Name, StringComparison.Ordinal))
                 {
-                    if (missingItems.Add(node.LibraryRange))
-                    {
-                        var errorMessage = string.Format("Unable to locate {0} {1}. Do you mean {2}?",
-                            node.LibraryRange.Name.Red().Bold(), node.LibraryRange.VersionRange, node.Item.Match.Library.Name.Bold());
-                        ErrorMessages.GetOrAdd(projectJsonPath, _ => new List<string>()).Add(errorMessage);
-                        Reports.Error.WriteLine(errorMessage);
-                        success = false;
-                    }
-
-                    return;
+                    // Fix casing of the library name to be installed
+                    node.Item.Match.Library.Name = node.LibraryRange.Name;
                 }
 
                 var isRemote = remoteProviders.Contains(node.Item.Match.Provider);
@@ -702,7 +693,8 @@ namespace Microsoft.Framework.PackageManager
                         package,
                         sha512,
                         frameworks,
-                        new DefaultPackagePathResolver(repository.RepositoryRoot));
+                        new DefaultPackagePathResolver(repository.RepositoryRoot),
+                        correctedPackageName: library.Name);
 
                     lockFile.Libraries.Add(lockFileLib);
                 }

--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -18,10 +18,15 @@ namespace Microsoft.Framework.PackageManager.Utils
             IPackage package,
             SHA512 sha512,
             IEnumerable<FrameworkName> frameworks,
-            IPackagePathResolver resolver)
+            IPackagePathResolver resolver,
+            string correctedPackageName = null)
         {
             var lockFileLib = new LockFileLibrary();
-            lockFileLib.Name = package.Id;
+
+            // package.Id is read from nuspec and it might be in wrong casing.
+            // correctedPackageName should be the package name used by dependency graph and
+            // it has the correct casing that runtime needs during dependency resolution.
+            lockFileLib.Name = correctedPackageName ?? package.Id;
             lockFileLib.Version = package.Version;
 
             using (var nupkgStream = package.GetStream())


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1470

We normalize all other package name casing (in lockfile & on disk) to the casing used by dependency graph (runtime)