### PR TITLE
Made changes to error handling

### DIFF
--- a/src/Microsoft.Framework.Runtime.Common/Impl/EntryPointExecutor.cs
+++ b/src/Microsoft.Framework.Runtime.Common/Impl/EntryPointExecutor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Framework.Runtime.Common.DependencyInjection;
 
@@ -24,13 +25,25 @@ namespace Microsoft.Framework.Runtime.Common
             object result = null;
             var parameters = entryPoint.GetParameters();
 
-            if (parameters.Length == 0)
+            try
             {
-                result = entryPoint.Invoke(instance, null);
+                if (parameters.Length == 0)
+                {
+                    result = entryPoint.Invoke(instance, null);
+                }
+                else if (parameters.Length == 1)
+                {
+                    result = entryPoint.Invoke(instance, new object[] { args });
+                }
             }
-            else if (parameters.Length == 1)
+            catch (Exception ex)
             {
-                result = entryPoint.Invoke(instance, new object[] { args });
+                if (ex is TargetInvocationException)
+                {
+                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                }
+
+                throw;
             }
 
             if (result is int)

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -253,7 +253,7 @@ int CallApplicationProcessMain(int argc, LPTSTR argv[])
 
     // Set the DNX_CONOSLE_HOST flag which will print exceptions
     // to stderr instead of throwing
-    SetEnvironmentVariable(_T("DNX_CONSOLE_HOST"), _T("1"));
+    SetConsoleHost();
 
     CALL_APPLICATION_MAIN_DATA data = { 0 };
     int nExpandedArgc = -1;

--- a/src/dnx/pal.h
+++ b/src/dnx/pal.h
@@ -1,6 +1,7 @@
 void GetNativeBootstrapperDirectory(LPTSTR szPath);
 void WaitForDebuggerToAttach();
 bool IsTracingEnabled();
+void SetConsoleHost();
 BOOL GetAppBasePathFromEnvironment(LPTSTR szPath);
 BOOL GetFullPath(LPCTSTR szPath, LPTSTR szFullPath);
 HMODULE LoadNativeHost(LPCTSTR szHostModuleName);

--- a/src/dnx/pal.linux.cpp
+++ b/src/dnx/pal.linux.cpp
@@ -34,6 +34,16 @@ bool IsTracingEnabled()
     return dnxTraceEnv != NULL && (strcmp(dnxTraceEnv, "1") == 0);
 }
 
+void SetConsoleHost()
+{
+    char* dnxConsoleHostEnv = getenv("DNX_CONSOLE_HOST");
+
+    if (dnxConsoleHostEnv == NULL)
+    {
+        setenv("DNX_CONSOLE_HOST", "1", 1);
+    }
+}
+
 BOOL GetAppBasePathFromEnvironment(LPTSTR szPath)
 {
     char* appBaseEnv = getenv("DNX_APPBASE");

--- a/src/dnx/pal.win32.cpp
+++ b/src/dnx/pal.win32.cpp
@@ -38,6 +38,16 @@ bool IsTracingEnabled()
     return false;
 }
 
+void SetConsoleHost()
+{
+    TCHAR szConsoleHost[2];
+    DWORD nEnvConsoleHostSize = GetEnvironmentVariable(_T("DNX_CONSOLE_HOST"), szConsoleHost, 2);
+    if (nEnvConsoleHostSize == 0)
+    {
+        SetEnvironmentVariable(_T("DNX_CONSOLE_HOST"), _T("1"));
+    }
+}
+
 BOOL GetAppBasePathFromEnvironment(LPTSTR pszAppBase)
 {
     DWORD dwAppBase = GetEnvironmentVariable(_T("DNX_APPBASE"), pszAppBase, MAX_PATH);


### PR DESCRIPTION
- Allow overriding the console host env var
- This allows VS to set it so that exceptions that occur before
the application runs, throw proper exceptions instead of disappearing
with a quick console window when f5 is hit in VS.
- Added SetConsoleHost to PAL
- Handle unwrapping exceptions in the EntryPointExecutor

#1202 #726