### PR TITLE
Quick strong-naming in Roslyn

### DIFF
--- a/src/Microsoft.Framework.Runtime.Common/Impl/EnvironmentNames.cs
+++ b/src/Microsoft.Framework.Runtime.Common/Impl/EnvironmentNames.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Framework.Runtime
         public static readonly string Configuration = CommonPrefix + "CONFIGURATION";
         public static readonly string ConsoleHost = CommonPrefix + "CONSOLE_HOST";
         public static readonly string DefaultLib = CommonPrefix + "DEFAULT_LIB";
+        public static readonly string BuildKeyFile = CommonPrefix + "BUILD_KEY_FILE";
+        public static readonly string BuildDelaySign = CommonPrefix + "BUILD_DELAY_SIGN";
     }
 }


### PR DESCRIPTION
1. Only works when running `dnu build/pack` on desktop (you **can** build **for** CoreCLR, just not **on** CoreCLR)
1. No project.json support
1. Enabled via the presence of the `DNX_BUILD_KEY_FILE` environment variable
1. Set `DNX_BUILD_DELAY_SIGN` to `true` to do delay signing instead of full signing

/cc @emgarten @davidfowl