### PR TITLE
Warn user when attempting to strong-name on CoreCLR

### DIFF
--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
@@ -122,9 +122,6 @@ namespace Microsoft.Framework.Runtime.Roslyn
                 references,
                 compilationSettings.CompilationOptions);
 
-            // Apply strong-name settings
-            compilation = ApplyStrongNameSettings(compilation);
-
             compilation = ApplyVersionInfo(compilation, project, parseOptions);
 
             var compilationContext = new CompilationContext(
@@ -138,6 +135,9 @@ namespace Microsoft.Framework.Runtime.Roslyn
                         res.StreamFactory,
                         isPublic: true))
                     .ToList());
+
+            // Apply strong-name settings
+            ApplyStrongNameSettings(compilationContext);
 
             if (isMainAspect && project.Files.PreprocessSourceFiles.Any())
             {
@@ -189,27 +189,31 @@ namespace Microsoft.Framework.Runtime.Roslyn
             return compilationContext;
         }
 
-        private CSharpCompilation ApplyStrongNameSettings(CSharpCompilation compilation)
+        private void ApplyStrongNameSettings(CompilationContext compilationContext)
         {
-#if DNX451
             // This is temporary, eventually we'll want a project.json feature for this
             var keyFile = Environment.GetEnvironmentVariable(EnvironmentNames.BuildKeyFile);
             if(!string.IsNullOrEmpty(keyFile))
             {
+#if DNX451
                 var delaySignString = Environment.GetEnvironmentVariable(EnvironmentNames.BuildDelaySign);
                 var delaySign = !string.IsNullOrEmpty(delaySignString) && (
                     string.Equals(delaySignString, "true", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(delaySignString, "1", StringComparison.OrdinalIgnoreCase));
 
                 var strongNameProvider = new DesktopStrongNameProvider();
-                var newOptions = compilation.Options
+                var newOptions = compilationContext.Compilation.Options
                     .WithStrongNameProvider(strongNameProvider)
                     .WithCryptoKeyFile(keyFile)
-                    .WithDelaySign(!string.IsNullOrEmpty(delaySignString) && string.Equals("true", delaySignString, StringComparison.OrdinalIgnoreCase));
-                return compilation.WithOptions(newOptions);
-            }
+                    .WithDelaySign(delaySign);
+                compilationContext.Compilation = compilationContext.Compilation.WithOptions(newOptions);
+#else
+                var diag = Diagnostic.Create(
+                    RoslynDiagnostics.StrongNamingNotSupported,
+                    null);
+                compilationContext.Diagnostics.Add(diag);
 #endif
-            return compilation;
+            }
         }
 
         private CompilationModules GetCompileModules(ILibraryKey target)

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynDiagnostics.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynDiagnostics.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Framework.Runtime.Roslyn
+{
+    internal class RoslynDiagnostics
+    {
+        internal static readonly DiagnosticDescriptor StrongNamingNotSupported = new DiagnosticDescriptor(
+            id: "DNX1001",
+            title: "Strong name generation is not supported on this platform",
+            messageFormat: "Strong name generation is not supported on CoreCLR. Skipping strong name generation.",
+            category: "StrongNaming",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+    }
+}


### PR DESCRIPTION
We just silently fail to strong-name when the environment variable is present on CoreCLR. We can't strong-name on CoreCLR (yet) but we should warn the user of this.

![capture](https://cloud.githubusercontent.com/assets/7574/7008497/26cb6ca0-dc48-11e4-84ef-ba94e126afa3.PNG)
