### PR TITLE
* Use the presence of hash file to denote completion of package install

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packages/Add/AddCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Packages/Add/AddCommand.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.IO;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Framework.Runtime;
 
@@ -32,11 +31,9 @@ namespace Microsoft.Framework.PackageManager.Packages
 
             var library = NuGetPackageUtils.CreateLibraryFromNupkg(Options.NuGetPackage);
 
-            using (var sha512 = SHA512.Create())
             using (var stream = File.OpenRead(Options.NuGetPackage))
             {
-                Reports.Information.WriteLine("Installing {0} {1}", library.Name.Bold(), library.Version);
-                await NuGetPackageUtils.InstallFromStream(stream, library, LocalPackages, sha512);
+                await NuGetPackageUtils.InstallFromStream(stream, library, LocalPackages, Reports.Information);
             }
 
             Reports.Information.WriteLine(

--- a/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Framework.PackageManager
 {
     internal static class NuGetPackageUtils
     {
-        internal static async Task InstallFromStream(Stream stream,
+        internal static async Task InstallFromStream(
+            Stream stream,
             Library library,
             string packagesDirectory,
-            SHA512 sha512,
-            bool performingParallelInstalls = false)
+            IReport information)
         {
             var packagePathResolver = new DefaultPackagePathResolver(packagesDirectory);
 
@@ -37,18 +37,9 @@ namespace Microsoft.Framework.PackageManager
                 // waiting on this lock don't need to install it again.
                 if (createdNewLock && !File.Exists(targetNupkg))
                 {
-                    var extractPath = targetPath;
-                    if (performingParallelInstalls)
-                    {
-                        // Extracting to the {id}/{version} has an issue with concurrent installs - when a package has been partially
-                        // extracted, the Restore Operation can inadvertly conclude the package is available locally and proceed to read
-                        // partially written package contents. To avoid this we'll extract the package to a sibling directory and Move it 
-                        // to the target path.
-                        extractPath = Path.Combine(Path.GetDirectoryName(targetPath), Path.GetRandomFileName());
-                        targetNupkg = Path.Combine(extractPath, Path.GetFileName(targetNupkg));
-                    }
+                    information.WriteLine($"Installing {library.Name.Bold()} {library.Version}");
 
-                    var extractDirectory = Directory.CreateDirectory(extractPath);
+                    Directory.CreateDirectory(targetPath);
                     using (var nupkgStream = new FileStream(
                         targetNupkg,
                         FileMode.Create,
@@ -60,7 +51,7 @@ namespace Microsoft.Framework.PackageManager
                         await stream.CopyToAsync(nupkgStream);
                         nupkgStream.Seek(0, SeekOrigin.Begin);
 
-                        ExtractPackage(extractPath, nupkgStream);
+                        ExtractPackage(targetPath, nupkgStream);
                     }
 
                     // Fixup the casing of the nuspec on disk to match what we expect
@@ -86,13 +77,15 @@ namespace Microsoft.Framework.PackageManager
                     }
 
                     stream.Seek(0, SeekOrigin.Begin);
-                    var nupkgSHA = Convert.ToBase64String(sha512.ComputeHash(stream));
-                    File.WriteAllText(hashPath, nupkgSHA);
-
-                    if (performingParallelInstalls)
+                    string packageHash;
+                    using (var sha512 = SHA512.Create())
                     {
-                        extractDirectory.MoveTo(targetPath);
+                        packageHash = Convert.ToBase64String(sha512.ComputeHash(stream));
                     }
+
+                    // Note: PackageRepository relies on the hash file being written out as the final operation as part of a package install
+                    // to assume a package was fully installed.
+                    File.WriteAllText(hashPath, packageHash);
                 }
 
                 return 0;

--- a/src/Microsoft.Framework.Runtime/NuGet/Packages/Constants.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Packages/Constants.cs
@@ -19,6 +19,11 @@ namespace NuGet
         /// Represents the ".nuspec" extension.
         /// </summary>
         public static readonly string ManifestExtension = ".nuspec";
+        
+        /// <summary>
+        /// Represents the ".nupkg.sha512" extension.
+        /// </summary>
+        public static readonly string HashFileExtension = ".nupkg.sha512";
 
         /// <summary>
         /// Represents the content directory in the package.

--- a/src/Microsoft.Framework.Runtime/NuGet/Packages/DefaultPackagePathResolver.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Packages/DefaultPackagePathResolver.cs
@@ -31,7 +31,7 @@ namespace NuGet
             _useSideBySidePaths = useSideBySidePaths;
             if (fileSystem == null)
             {
-                throw new ArgumentNullException("fileSystem");
+                throw new ArgumentNullException(nameof(fileSystem));
             }
             _fileSystem = fileSystem;
         }
@@ -56,7 +56,7 @@ namespace NuGet
         public string GetHashPath(string packageId, SemanticVersion version)
         {
             return Path.Combine(GetInstallPath(packageId, version),
-                                string.Format("{0}.{1}.nupkg.sha512", packageId, version));
+                                $"{packageId}.{version}{Constants.HashFileExtension}");
         }
 
         public virtual string GetPackageDirectory(string packageId, SemanticVersion version)

--- a/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
@@ -105,6 +105,13 @@ namespace NuGet
                     {
                         continue;
                     }
+                    
+                    if (!_repositoryRoot.GetFiles(versionDir, "*" + Constants.HashFileExtension).Any())
+                    {
+                        // Writing the marker file is the last operation performed by NuGetPackageUtils.InstallFromStream. We'll use the
+                        // presence of the file to denote the package was successfully installed.
+                        continue;
+                    }
 
                     // If we need to help ensure case-sensitivity, we try to get
                     // the package id in accurate casing by extracting the name of nuspec file


### PR DESCRIPTION
operation removing the need for Directory.Move.