### PR TITLE
Show build errors for all dependency projects

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
@@ -54,14 +54,14 @@ namespace Microsoft.Framework.PackageManager
 
         public bool Build(List<ICompilationMessage> diagnostics)
         {
+            var allProjectDiagnostics = DiagnosticsUtils.GetAllReferenceProjectDiagnostics(
+                _applicationHostContext.LibraryManager,
+                _project.Name);
+            diagnostics.AddRange(allProjectDiagnostics);
+
             var builder = _applicationHostContext.CreateInstance<ProjectBuilder>();
 
             var result = builder.Build(_project.Name, _outputPath);
-
-            if (result.Diagnostics != null)
-            {
-                diagnostics.AddRange(result.Diagnostics);
-            }
 
             var errors = _applicationHostContext.DependencyWalker.GetDependencyDiagnostics(_project.ProjectFilePath);
             diagnostics.AddRange(errors);

--- a/src/Microsoft.Framework.Runtime.Compilation.Common/DiagnosticsUtils.cs
+++ b/src/Microsoft.Framework.Runtime.Compilation.Common/DiagnosticsUtils.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.Runtime.Compilation;
+
+namespace Microsoft.Framework.Runtime
+{
+    internal static class DiagnosticsUtils
+    {
+        public static List<ICompilationMessage> GetAllReferenceProjectDiagnostics(ILibraryManager libraryManager,
+            string projectName)
+        {
+            var projectExport = libraryManager.GetAllExports(projectName);
+            var metadataProjectRefs = projectExport.MetadataReferences.OfType<IMetadataProjectReference>();
+            return metadataProjectRefs.SelectMany(x => x.GetDiagnostics().Diagnostics).ToList();
+        }
+    }
+}


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/583

When building a project, show diagnostics of dependency projects as well.

Tested with both command-line and VS.

@davidfowl 