### PR TITLE
Add serviceable attribute to projects.

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost.Interfaces/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.DesignTimeHost.Interfaces/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.DesignTimeHost/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Framework.DesignTimeHost.Tests")]
+[assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Project/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Project/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime.Compilation/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime.Compilation/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime.Hosting/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime.Hosting/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime.Interfaces/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime.Interfaces/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime.Loader/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime.Loader/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime.Roslyn.Common/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn.Common/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime.Roslyn/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.Runtime/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.Runtime/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Framework.Runtime.Tests")]
+[assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/dnx.clr.managed/Properties/AssemblyInfo.cs
+++ b/src/dnx.clr.managed/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/dnx.coreclr.managed/Properties/AssemblyInfo.cs
+++ b/src/dnx.coreclr.managed/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/dnx.host/Properties/AssemblyInfo.cs
+++ b/src/dnx.host/Properties/AssemblyInfo.cs
@@ -2,7 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Framework.PackageManager.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]


### PR DESCRIPTION
I don't believe `ApplicationHost`/`ApplicationHost2` are needed but I added them for now since they were in the `src` folder