### PR TITLE
Fix path for --out in dnu pack

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Framework.PackageManager
                         using (var fs = File.Create(nupkg))
                         {
                             packageBuilder.Save(fs);
-                            _buildOptions.Reports.Quiet.WriteLine("{0} -> {1}", project.Name, nupkg);
+                            _buildOptions.Reports.Quiet.WriteLine("{0} -> {1}", project.Name, Path.GetFullPath(nupkg));
                         }
 
                         if (symbolPackageBuilder.Files.Any())
@@ -186,9 +186,8 @@ namespace Microsoft.Framework.PackageManager
                             using (var fs = File.Create(symbolsNupkg))
                             {
                                 symbolPackageBuilder.Save(fs);
+                                _buildOptions.Reports.Quiet.WriteLine("{0} -> {1}", project.Name, Path.GetFullPath(symbolsNupkg));
                             }
-
-                            _buildOptions.Reports.Quiet.WriteLine("{0} -> {1}", project.Name, symbolsNupkg);
                         }
                     }
                 }

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPackTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPackTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Framework.CommonTestUtils;
+using Xunit;
+
+namespace Microsoft.Framework.PackageManager
+{
+    public class DnuPackTests
+    {
+        public static IEnumerable<object[]> RuntimeComponents
+        {
+            get
+            {
+                return TestUtils.GetRuntimeComponentsCombinations();
+            }
+        }
+
+        [Theory]
+        [MemberData("RuntimeComponents")]
+        public void DnuPack_NoArgs(string flavor, string os, string architecture)
+        {
+            string expectedDNX =
+            @"Building {0} for DNX,Version=v4.5.1
+  Using Project dependency {0} 1.0.0
+    Source: {1}/project.json".Replace('/', Path.DirectorySeparatorChar);
+            string expectedDNXCore =
+            @"Building {0} for DNXCore,Version=v5.0
+  Using Project dependency {0} 1.0.0
+    Source: {1}/project.json".Replace('/', Path.DirectorySeparatorChar);
+            string expectedNupkg =
+            @"{0} -> {1}/bin/Debug/{0}.1.0.0.nupkg
+{0} -> {1}/bin/Debug/{0}.1.0.0.symbols.nupkg
+
+Build succeeded.
+    0 Warnings(s)
+    0 Error(s)
+".Replace('/', Path.DirectorySeparatorChar);
+            string stdOut;
+            string stdError;
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            int exitCode;
+
+            using (var testEnv = new DnuTestEnvironment(runtimeHomeDir))
+            {
+                File.WriteAllText($"{testEnv.RootDir}/project.json",
+                @"{
+                    ""frameworks"": {
+                        ""dnx451"": {
+                        },
+                        ""dnxcore50"": {
+                            ""dependencies"": {
+                                ""System.Runtime"":""4.0.20-*""
+                            }
+                        }
+                    }
+                  }");
+                DnuTestUtils.ExecDnu(runtimeHomeDir, "restore", "", out stdOut, out stdError, environment: null, workingDir: testEnv.RootDir);
+                exitCode = DnuTestUtils.ExecDnu(runtimeHomeDir, "pack", "", out stdOut, out stdError, environment: null, workingDir: testEnv.RootDir);
+
+                Assert.Empty(stdError);
+                Assert.Contains(string.Format(expectedDNX, Path.GetFileName(testEnv.RootDir), testEnv.RootDir), stdOut);
+                Assert.Contains(string.Format(expectedDNXCore, Path.GetFileName(testEnv.RootDir), testEnv.RootDir), stdOut);
+                Assert.Contains(string.Format(expectedNupkg, Path.GetFileName(testEnv.RootDir), testEnv.RootDir), stdOut);
+                Assert.Equal(0, exitCode);
+                Assert.True(Directory.Exists($"{testEnv.RootDir}/bin"));
+            }
+        }
+
+        [Theory]
+        [MemberData("RuntimeComponents")]
+        public void DnuPack_FrameworkSpecified(string flavor, string os, string architecture)
+        {
+            string expectedDNX =
+            @"Building {0} for DNX,Version=v4.5.1
+  Using Project dependency {0} 1.0.0
+    Source: {1}/project.json".Replace('/', Path.DirectorySeparatorChar);
+            string expectedNupkg =
+            @"{0} -> {1}/bin/Debug/{0}.1.0.0.nupkg
+{0} -> {1}/bin/Debug/{0}.1.0.0.symbols.nupkg
+
+Build succeeded.
+    0 Warnings(s)
+    0 Error(s)
+".Replace('/', Path.DirectorySeparatorChar);
+            string stdOut;
+            string stdError;
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            int exitCode;
+
+            using (var testEnv = new DnuTestEnvironment(runtimeHomeDir))
+            {
+                File.WriteAllText($"{testEnv.RootDir}/project.json",
+                @"{
+                    ""frameworks"": {
+                        ""dnx451"": {
+                        },
+                        ""dnxcore50"": {
+                            ""dependencies"": {
+                                ""System.Runtime"":""4.0.20-*""
+                            }
+                        }
+                    }
+                  }");
+                DnuTestUtils.ExecDnu(runtimeHomeDir, "restore", "", out stdOut, out stdError, environment: null, workingDir: testEnv.RootDir);
+                exitCode = DnuTestUtils.ExecDnu(runtimeHomeDir, "pack", "--framework dnx451", out stdOut, out stdError, environment: null, workingDir: testEnv.RootDir);
+
+                Assert.Empty(stdError);
+                Assert.Contains(string.Format(expectedDNX, Path.GetFileName(testEnv.RootDir), testEnv.RootDir), stdOut);
+                Assert.DoesNotContain("DNXCore", stdOut);
+                Assert.Contains(string.Format(expectedNupkg, Path.GetFileName(testEnv.RootDir), testEnv.RootDir), stdOut);
+                Assert.Equal(0, exitCode);
+                Assert.True(Directory.Exists($"{testEnv.RootDir}/bin"));
+            }
+        }
+
+        [Theory]
+        [MemberData("RuntimeComponents")]
+        public void DnuPack_OutPathSpecified(string flavor, string os, string architecture)
+        {
+            string expectedNupkg =
+            @"{0} -> {1}/CustomOutput/Debug/{0}.1.0.0.nupkg
+{0} -> {1}/CustomOutput/Debug/{0}.1.0.0.symbols.nupkg
+
+Build succeeded.
+    0 Warnings(s)
+    0 Error(s)
+";
+            string stdOut;
+            string stdError;
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            int exitCode;
+
+            using (var testEnv = new DnuTestEnvironment(runtimeHomeDir))
+            {
+                File.WriteAllText($"{testEnv.RootDir}/project.json",
+                @"{
+                    ""frameworks"": {
+                        ""dnx451"": {
+                        },
+                        ""dnxcore50"": {
+                            ""dependencies"": {
+                                ""System.Runtime"":""4.0.20-*""
+                            }
+                        }
+                    }
+                  }");
+                DnuTestUtils.ExecDnu(runtimeHomeDir, "restore", "", out stdOut, out stdError, environment: null, workingDir: testEnv.RootDir);
+                exitCode = DnuTestUtils.ExecDnu(runtimeHomeDir, "pack", "--out CustomOutput", out stdOut, out stdError, environment: null, workingDir: testEnv.RootDir);
+
+                Assert.Empty(stdError);
+                Assert.Contains(string.Format(expectedNupkg, Path.GetFileName(testEnv.RootDir), testEnv.RootDir), stdOut);
+                Assert.Equal(0, exitCode);
+                Assert.True(Directory.Exists($"{testEnv.RootDir}/CustomOutput"));
+            }
+        }
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPackTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPackTests.cs
@@ -32,12 +32,7 @@ namespace Microsoft.Framework.PackageManager
     Source: {1}/project.json".Replace('/', Path.DirectorySeparatorChar);
             string expectedNupkg =
             @"{0} -> {1}/bin/Debug/{0}.1.0.0.nupkg
-{0} -> {1}/bin/Debug/{0}.1.0.0.symbols.nupkg
-
-Build succeeded.
-    0 Warnings(s)
-    0 Error(s)
-".Replace('/', Path.DirectorySeparatorChar);
+{0} -> {1}/bin/Debug/{0}.1.0.0.symbols.nupkg".Replace('/', Path.DirectorySeparatorChar);
             string stdOut;
             string stdError;
             var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
@@ -79,12 +74,7 @@ Build succeeded.
     Source: {1}/project.json".Replace('/', Path.DirectorySeparatorChar);
             string expectedNupkg =
             @"{0} -> {1}/bin/Debug/{0}.1.0.0.nupkg
-{0} -> {1}/bin/Debug/{0}.1.0.0.symbols.nupkg
-
-Build succeeded.
-    0 Warnings(s)
-    0 Error(s)
-".Replace('/', Path.DirectorySeparatorChar);
+{0} -> {1}/bin/Debug/{0}.1.0.0.symbols.nupkg".Replace('/', Path.DirectorySeparatorChar);
             string stdOut;
             string stdError;
             var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
@@ -122,12 +112,7 @@ Build succeeded.
         {
             string expectedNupkg =
             @"{0} -> {1}/CustomOutput/Debug/{0}.1.0.0.nupkg
-{0} -> {1}/CustomOutput/Debug/{0}.1.0.0.symbols.nupkg
-
-Build succeeded.
-    0 Warnings(s)
-    0 Error(s)
-";
+{0} -> {1}/CustomOutput/Debug/{0}.1.0.0.symbols.nupkg".Replace('/', Path.DirectorySeparatorChar);
             string stdOut;
             string stdError;
             var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);


### PR DESCRIPTION
Running ```dnu pack --out <somefoldername>``` would not include the full path in the output for nupkg location