### PR TITLE
Add IRuntimeEnvironment

### DIFF
--- a/DNX.sln
+++ b/DNX.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22806.0
+VisualStudioVersion = 14.0.22809.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{189961D1-DFF4-406A-9D42-39B61221A73A}"
 	ProjectSection(SolutionItems) = preProject
@@ -141,6 +141,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Runtime.Compilation.Common", "src\Microsoft.Framework.Runtime.Compilation.Common\Microsoft.Framework.Runtime.Compilation.Common.xproj", "{333205C2-BE8B-4258-BEA4-4C68D9340986}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Runtime.Compilation.DesignTime", "src\Microsoft.Framework.Runtime.Compilation.DesignTime\Microsoft.Framework.Runtime.Compilation.DesignTime.xproj", "{19D39312-A4A4-449D-B53F-653F951A11F8}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dnx.host.Tests", "test\dnx.host.Tests\dnx.host.Tests.xproj", "{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1068,6 +1070,26 @@ Global
 		{19D39312-A4A4-449D-B53F-653F951A11F8}.Release|x64.Build.0 = Release|Any CPU
 		{19D39312-A4A4-449D-B53F-653F951A11F8}.Release|x86.ActiveCfg = Release|Any CPU
 		{19D39312-A4A4-449D-B53F-653F951A11F8}.Release|x86.Build.0 = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|Win32.Build.0 = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|Win32.ActiveCfg = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|Win32.Build.0 = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|x64.Build.0 = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1133,5 +1155,6 @@ Global
 		{7004FC14-677B-491F-A98B-E44C61733B46} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 		{333205C2-BE8B-4258-BEA4-4C68D9340986} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 		{19D39312-A4A4-449D-B53F-653F951A11F8} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
+		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2} = {C43EE429-DE10-4906-BB09-54E6A080948A}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Framework.Runtime.Interfaces/IRuntimeEnvironment.cs
+++ b/src/Microsoft.Framework.Runtime.Interfaces/IRuntimeEnvironment.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Framework.Runtime
+{
+    public interface IRuntimeEnvironment
+    {
+        string OperatingSystem { get; }
+
+        string OperatingSystemVersion { get; }
+
+        string RuntimeType { get; }
+
+        string RuntimeArchitecture { get; }
+
+        string RuntimeVersion { get; }
+    }
+}

--- a/src/dnx.host/Bootstrapper.cs
+++ b/src/dnx.host/Bootstrapper.cs
@@ -73,6 +73,7 @@ namespace dnx.host
                 serviceProvider.Add(typeof(IAssemblyLoaderContainer), container);
                 serviceProvider.Add(typeof(IAssemblyLoadContextAccessor), accessor);
                 serviceProvider.Add(typeof(IApplicationEnvironment), applicationEnvironment);
+                serviceProvider.Add(typeof(IRuntimeEnvironment), new RuntimeEnvironment());
 
                 CallContextServiceLocator.Locator.ServiceProvider = serviceProvider;
 

--- a/src/dnx.host/NativeMethods.cs
+++ b/src/dnx.host/NativeMethods.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Framework.Runtime
+{
+    internal static class NativeMethods
+    {
+        public unsafe static string Uname()
+        {
+            var buffer = stackalloc byte[8192];
+            try
+            {
+                if (uname((IntPtr)buffer) == 0)
+                {
+                    return Marshal.PtrToStringAnsi((IntPtr)buffer);
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        // Linux and Mac import
+        [DllImport("libc")]
+        private static extern int uname(IntPtr buf);
+
+#if DNXCORE50
+        public static Version OSVersion
+        {
+            get
+            {
+                uint dwVersion = GetVersion();
+
+                int major = (int)(dwVersion & 0xFF);
+                int minor = (int)((dwVersion >> 8) & 0xFF);
+
+                return new Version(major, minor);
+            }
+        }
+
+        private static uint GetVersion()
+        {
+            try
+            {
+                return GetVersion_ApiSet();
+            }
+            catch (DllNotFoundException)
+            {
+                return GetVersion_Kernel32();
+            }
+        }
+
+        // The API set is required by OneCore based systems
+        // and it is available only on Win 8 and newer
+        [DllImport("api-ms-win-core-sysinfo-l1-2-1", EntryPoint = "GetVersion")]
+        private static extern uint GetVersion_ApiSet();
+
+        // For Win 7 and Win 2008 compatibility
+        [DllImport("kernel32.dll", EntryPoint = "GetVersion")]
+        private static extern uint GetVersion_Kernel32();
+#endif
+    }
+}

--- a/src/dnx.host/Properties/AssemblyInfo.cs
+++ b/src/dnx.host/Properties/AssemblyInfo.cs
@@ -2,5 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("dnx.host.Tests")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/dnx.host/RuntimeEnvironment.cs
+++ b/src/dnx.host/RuntimeEnvironment.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Framework.Runtime
+{
+    public class RuntimeEnvironment : IRuntimeEnvironment
+    {
+        private string _runtimeVersion;
+
+        public RuntimeEnvironment()
+        {
+#if DNXCORE50
+            RuntimeType = "CoreCLR";
+            RuntimeArchitecture = IntPtr.Size == 8 ? "x64" : "x86";
+#else
+            RuntimeType = Type.GetType("Mono.Runtime") == null ? "CLR" : "Mono";
+            RuntimeArchitecture = Environment.Is64BitProcess ? "x64" : "x86";
+#endif
+
+            string uname = NativeMethods.Uname();
+            if (!string.IsNullOrEmpty(uname))
+            {
+                OperatingSystem = uname;
+                OperatingSystemVersion = null;
+            }
+            else
+            {
+                OperatingSystem = "Windows";
+#if DNXCORE50
+                OperatingSystemVersion = NativeMethods.OSVersion.ToString();
+#else
+                OperatingSystemVersion = Environment.OSVersion.Version.ToString();
+#endif
+            }
+        }
+
+        public string OperatingSystem { get; private set; }
+
+        public string OperatingSystemVersion { get; private set; }
+
+        public string RuntimeType { get; private set; }
+
+        public string RuntimeArchitecture { get; private set; }
+
+        public string RuntimeVersion
+        {
+            get
+            {
+                if (_runtimeVersion == null)
+                {
+                    _runtimeVersion = typeof(RuntimeEnvironment)
+                        .GetTypeInfo()
+                        .Assembly
+                        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                        .InformationalVersion;
+                }
+
+                return _runtimeVersion;
+
+            }
+        }
+    }
+}

--- a/src/dnx.host/project.json
+++ b/src/dnx.host/project.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0-*",
-    "compilationOptions": { "define": [ "TRACE" ], "warningsAsErrors": true },
+    "compilationOptions": { "define": [ "TRACE" ], "allowUnsafe": true, "warningsAsErrors": true },
     "dependencies": {
         "Microsoft.Framework.CommandLineUtils": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Common": { "version": "1.0.0-*", "type": "build" },
@@ -37,4 +37,3 @@
         ]
     }
 }
-

--- a/test/dnx.host.Tests/RuntimeEnvironmentTests.cs
+++ b/test/dnx.host.Tests/RuntimeEnvironmentTests.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.Runtime;
+using Xunit;
+
+namespace dnx.hostTests
+{
+    public class RuntimeEnvironmentTests
+    {
+        [Fact]
+        public void RuntimeEnvironment_OS()
+        {
+            RuntimeEnvironment runtimeEnv = new RuntimeEnvironment();
+
+            var os = NativeMethods.Uname();
+            if (os == null)
+            {
+                os = "Windows";
+                Assert.NotNull(runtimeEnv.OperatingSystemVersion);
+            }
+            else
+            {
+                Assert.Null(runtimeEnv.OperatingSystemVersion);
+            }
+
+            Assert.Equal(os, runtimeEnv.OperatingSystem);
+        }
+
+        [Fact]
+        public void RuntimeEnvironment_RuntimeVersion()
+        {
+            RuntimeEnvironment runtimeEnv = new RuntimeEnvironment();
+            Assert.NotNull(runtimeEnv.RuntimeVersion);
+        }
+
+        [Fact]
+        public void RuntimeEnvironment_RuntimeArchitecture()
+        {
+            RuntimeEnvironment runtimeEnv = new RuntimeEnvironment();
+            var runtimeArchitecture = IntPtr.Size == 8 ? "x64" : "x86";
+            Assert.Equal(runtimeArchitecture, runtimeEnv.RuntimeArchitecture);
+        }
+
+        [Fact]
+        public void RuntimeEnvironment_RuntimeType()
+        {
+            RuntimeEnvironment runtimeEnv = new RuntimeEnvironment();
+#if DNXCORE50
+            Assert.Equal("CoreCLR", runtimeEnv.RuntimeType);
+#else
+            var runtime = Type.GetType("Mono.Runtime") == null ? "CLR" : "Mono";
+            Assert.Equal(runtime, runtimeEnv.RuntimeType);
+#endif
+        }
+    }
+}

--- a/test/dnx.host.Tests/dnx.host.Tests.xproj
+++ b/test/dnx.host.Tests/dnx.host.Tests.xproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>ccc1f7f8-8d3b-49c3-bad4-17c784499af1</ProjectGuid>
+    <ProjectGuid>6f59a0b7-745d-4ada-a913-6a1ad1ab49c2</ProjectGuid>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>

--- a/test/dnx.host.Tests/project.json
+++ b/test/dnx.host.Tests/project.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": {
+        "dnx.host": "1.0.0-*",
+        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+    },
+
+    "frameworks": {
+        "dnx451": { }
+    },
+
+    "commands": {
+        "test": "xunit.runner.aspnet"
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aspnet/dnx/issues/310

I also moved the `RuntimeFramework` from `IApplicationEnvironment` to `IRuntimeEnvironment`. However, I cannot remove the old one because xunit is using it. Therefore, I'll keep both for now, send a PR to xunit and then remove the old one. If I remove the old one, our build will fail.

cc @davidfowl 