### PR TITLE
Postsharp readiness

### DIFF
--- a/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IAfterCompileContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IAfterCompileContext.cs
@@ -23,6 +23,6 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
         IList<Diagnostic> Diagnostics { get; }
 
-        IEnumerable<IMetadataReference> References { get; }
+        IList<IMetadataReference> References { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IAfterCompileContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IAfterCompileContext.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Framework.Runtime.Compilation;
 
 namespace Microsoft.Framework.Runtime.Roslyn
 {
@@ -21,5 +22,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
         Stream XmlDocStream { get; set; }
 
         IList<Diagnostic> Diagnostics { get; }
+
+        IEnumerable<IMetadataReference> References { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IBeforeCompileContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IBeforeCompileContext.cs
@@ -18,6 +18,6 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
         IList<Diagnostic> Diagnostics { get; }
 
-        IEnumerable<IMetadataReference> References { get; }
+        IList<IMetadataReference> References { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IBeforeCompileContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn.Interfaces/IBeforeCompileContext.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Framework.Runtime.Compilation;
 
 namespace Microsoft.Framework.Runtime.Roslyn
 {
@@ -16,5 +17,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
         IList<ResourceDescription> Resources { get; }
 
         IList<Diagnostic> Diagnostics { get; }
+
+        IEnumerable<IMetadataReference> References { get; }
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn/AfterCompileContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/AfterCompileContext.cs
@@ -50,6 +50,6 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
         public IList<Diagnostic> Diagnostics { get; }
 
-        public IEnumerable<IMetadataReference> References { get { return _context.References; } }
+        public IList<IMetadataReference> References { get { return _context.References; } }
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn/AfterCompileContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/AfterCompileContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Framework.Runtime.Compilation;
 
 namespace Microsoft.Framework.Runtime.Roslyn
 {
@@ -17,6 +18,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
             diagnostics.AddRange(emitDiagnostics);
 
             Diagnostics = diagnostics;
+
         }
 
         public IProjectContext ProjectContext
@@ -47,5 +49,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
         }
 
         public IList<Diagnostic> Diagnostics { get; }
+
+        public IEnumerable<IMetadataReference> References { get { return _context.References; } }
     }
 }

--- a/src/Microsoft.Framework.Runtime.Roslyn/CompilationContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/CompilationContext.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
         public IProjectContext ProjectContext { get; set; }
 
-        public IEnumerable<IMetadataReference> References { get; set; }
+        public IList<IMetadataReference> References { get; set; }
 
         public CompilationContext(CSharpCompilation compilation,
                                   ICompilationProject project,
                                   FrameworkName targetFramework,
                                   string configuration,
                                   Func<IList<ResourceDescription>> resourcesResolver,
-                                  IEnumerable<IMetadataReference> incomingReferences)
+                                  IList<IMetadataReference> incomingReferences)
         {
             References = incomingReferences;
             Compilation = compilation;

--- a/src/Microsoft.Framework.Runtime.Roslyn/CompilationContext.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/CompilationContext.cs
@@ -29,12 +29,16 @@ namespace Microsoft.Framework.Runtime.Roslyn
 
         public IProjectContext ProjectContext { get; set; }
 
+        public IEnumerable<IMetadataReference> References { get; set; }
+
         public CompilationContext(CSharpCompilation compilation,
                                   ICompilationProject project,
                                   FrameworkName targetFramework,
                                   string configuration,
-                                  Func<IList<ResourceDescription>> resourcesResolver)
+                                  Func<IList<ResourceDescription>> resourcesResolver,
+                                  IEnumerable<IMetadataReference> incomingReferences)
         {
+            References = incomingReferences;
             Compilation = compilation;
             Diagnostics = new List<Diagnostic>();
             Project = project;

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Framework.Runtime.Roslyn
                         res.Name,
                         res.StreamFactory,
                         isPublic: true))
-                    .ToList());
+                    .ToList(),
+                incomingReferences);
 
             // Apply strong-name settings
             ApplyStrongNameSettings(compilationContext);

--- a/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/RoslynCompiler.cs
@@ -82,7 +82,8 @@ namespace Microsoft.Framework.Runtime.Roslyn
                 _cacheContextAccessor.Current.Monitor(_namedDependencyProvider.GetNamedDependency(project.Name + "_Dependencies"));
             }
 
-            var exportedReferences = incomingReferences.Select(ConvertMetadataReference);
+            var incomingReferencesList = incomingReferences.ToList();
+            var exportedReferences = incomingReferencesList.Select(ConvertMetadataReference);
 
             Logger.TraceInformation("[{0}]: Compiling '{1}'", GetType().Name, name);
             var sw = Stopwatch.StartNew();
@@ -110,7 +111,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
                 parseOptions,
                 isMainAspect);
 
-            var embeddedReferences = incomingReferences.OfType<IMetadataEmbeddedReference>()
+            var embeddedReferences = incomingReferencesList.OfType<IMetadataEmbeddedReference>()
                                                        .ToDictionary(a => a.Name, ConvertMetadataReference);
 
             var references = new List<MetadataReference>();
@@ -135,7 +136,7 @@ namespace Microsoft.Framework.Runtime.Roslyn
                         res.StreamFactory,
                         isPublic: true))
                     .ToList(),
-                incomingReferences);
+                incomingReferencesList);
 
             // Apply strong-name settings
             ApplyStrongNameSettings(compilationContext);


### PR DESCRIPTION
The changes expose `IEnumerable<IMetadataReference> References { get; }` to `IAfterCompileContext` and `IBeforeCompileContext`. These changes make it possible to integrate PostSharp as an `ICompileModule` because it must know the location of all dependencies.