### PR TITLE
Make sure we use newly built runtime to generate lock file for tests

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -934,6 +934,17 @@ functions @{
     void KTest(string projectFolder)
     {
         projectFolder = Path.GetDirectoryName(projectFolder);
+
+        // Make sure we use the newly built runtime to generate lock file for tests
+        if (IsMono)
+        {
+            Exec("dnu", string.Format("restore {0}", projectFolder));
+        }
+        else
+        {
+            Exec("cmd", string.Format("/C dnu restore {0}", projectFolder));
+        }
+
         var testArgs = IsMono ? " -parallel none" : "";
         K(("test" + testArgs), projectFolder, "");
     }

--- a/test/Bootstrapper.FunctionalTests/BootstrapperTestUtils.cs
+++ b/test/Bootstrapper.FunctionalTests/BootstrapperTestUtils.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Framework.CommonTestUtils;
+using Microsoft.Framework.PackageManager;
 using Microsoft.Framework.Runtime;
+using Newtonsoft.Json.Linq;
 
 namespace Bootstrapper.FunctionalTests
 {
@@ -27,6 +30,44 @@ namespace Bootstrapper.FunctionalTests
             stdOut = stdOutStr;
             stdErr = stdErrStr;
             return exitCode;
+        }
+
+        public static DisposableDir PrepareTemporarySamplesFolder(string runtimeHomeDir)
+        {
+            var tempDir = new DisposableDir();
+            TestUtils.CopyFolder(TestUtils.GetSamplesFolder(), tempDir);
+
+            // Make sure sample projects depend on runtime components from newly built dnx
+            var currentDnxSolutionRootDir = ProjectResolver.ResolveRootDirectory(Directory.GetCurrentDirectory());
+            var currentDnxSolutionSrcPath = Path.Combine(currentDnxSolutionRootDir, "src").Replace("\\", "\\\\");
+            var samplesGlobalJson = new JObject();
+            samplesGlobalJson["projects"] = new JArray(new[] { currentDnxSolutionSrcPath });
+            File.WriteAllText(Path.Combine(tempDir, GlobalSettings.GlobalFileName), samplesGlobalJson.ToString());
+
+            // Make sure package restore can be successful
+            const string nugetConfigName = "NuGet.Config";
+            File.Copy(Path.Combine(currentDnxSolutionRootDir, nugetConfigName), Path.Combine(tempDir, nugetConfigName));
+
+            // Use the newly built runtime to generate lock files for samples
+            string stdOut, stdErr;
+            int exitCode;
+            foreach (var projectDir in Directory.EnumerateDirectories(tempDir))
+            {
+                exitCode = DnuTestUtils.ExecDnu(
+                    runtimeHomeDir,
+                    subcommand: "restore",
+                    arguments: projectDir,
+                    stdOut: out stdOut,
+                    stdErr: out stdErr);
+
+                if (exitCode != 0)
+                {
+                    Console.WriteLine(stdOut);
+                    Console.WriteLine(stdErr);
+                }
+            }
+
+            return tempDir;
         }
     }
 }


### PR DESCRIPTION
@davidfowl 

Tested locally with experimental lock file format change (bumping version up by 1)