### PR TITLE
Introduce test collection to improve test performance

### DIFF
--- a/test/Bootstrapper.FunctionalTests/BootstrapperTestCollection.cs
+++ b/test/Bootstrapper.FunctionalTests/BootstrapperTestCollection.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.CommonTestUtils;
+using Xunit;
+
+namespace Bootstrapper.FunctionalTests
+{
+    [CollectionDefinition("BootstrapperTestCollection")]
+    public class BootstrapperTestCollection : ICollectionFixture<DnxRuntimeFixture>
+    {
+    }
+}

--- a/test/Bootstrapper.FunctionalTests/BootstrapperTests.cs
+++ b/test/Bootstrapper.FunctionalTests/BootstrapperTests.cs
@@ -11,8 +11,16 @@ using Xunit;
 
 namespace Bootstrapper.FunctionalTests
 {
+    [Collection("BootstrapperTestCollection")]
     public class BootstrapperTests
     {
+        private readonly DnxRuntimeFixture _fixture;
+
+        public BootstrapperTests(DnxRuntimeFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         public static IEnumerable<object[]> RuntimeComponents
         {
             get
@@ -41,59 +49,58 @@ namespace Bootstrapper.FunctionalTests
         [MemberData("RuntimeComponents")]
         public void BootstrapperReturnsNonZeroExitCodeWhenNoArgumentWasGiven(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
-            {
-                string stdOut, stdErr;
-                var exitCode = BootstrapperTestUtils.ExecBootstrapper(
-                    runtimeHomeDir,
-                    arguments: string.Empty,
-                    stdOut: out stdOut,
-                    stdErr: out stdErr);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
-                Assert.NotEqual(0, exitCode);
-            }
+            string stdOut, stdErr;
+            var exitCode = BootstrapperTestUtils.ExecBootstrapper(
+                runtimeHomeDir,
+                arguments: string.Empty,
+                stdOut: out stdOut,
+                stdErr: out stdErr);
+
+            Assert.NotEqual(0, exitCode);
         }
 
         [Theory]
         [MemberData("RuntimeComponents")]
         public void BootstrapperReturnsZeroExitCodeWhenHelpOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
-            {
-                string stdOut, stdErr;
-                var exitCode = BootstrapperTestUtils.ExecBootstrapper(
-                    runtimeHomeDir,
-                    arguments: "--help",
-                    stdOut: out stdOut,
-                    stdErr: out stdErr);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
-                Assert.Equal(0, exitCode);
-            }
+            string stdOut, stdErr;
+            var exitCode = BootstrapperTestUtils.ExecBootstrapper(
+                runtimeHomeDir,
+                arguments: "--help",
+                stdOut: out stdOut,
+                stdErr: out stdErr);
+
+            Assert.Equal(0, exitCode);
         }
 
         [Theory]
         [MemberData("RuntimeComponents")]
         public void BootstrapperShowsVersionAndReturnsZeroExitCodeWhenVersionOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
-            {
-                string stdOut, stdErr;
-                var exitCode = BootstrapperTestUtils.ExecBootstrapper(
-                    runtimeHomeDir,
-                    arguments: "--version",
-                    stdOut: out stdOut,
-                    stdErr: out stdErr);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
-                Assert.Equal(0, exitCode);
-                Assert.Contains(TestUtils.GetRuntimeVersion(), stdOut);
-            }
+            string stdOut, stdErr;
+            var exitCode = BootstrapperTestUtils.ExecBootstrapper(
+                runtimeHomeDir,
+                arguments: "--version",
+                stdOut: out stdOut,
+                stdErr: out stdErr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(TestUtils.GetRuntimeVersion(), stdOut);
+
         }
 
         [Theory]
         [MemberData("RuntimeComponents")]
         public void BootstrapperInvokesApplicationHostWithInferredAppBase_ProjectDirAsArgument(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             using (var tempSamplesDir = BootstrapperTestUtils.PrepareTemporarySamplesFolder(runtimeHomeDir))
             {
                 var testAppPath = Path.Combine(tempSamplesDir, "HelloWorld");
@@ -123,7 +130,8 @@ command
         [MemberData("RuntimeComponents")]
         public void BootstrapperInvokesApplicationHostWithInferredAppBase_ProjectFileAsArgument(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+
             using (var tempSamplesDir = BootstrapperTestUtils.PrepareTemporarySamplesFolder(runtimeHomeDir))
             {
                 var testAppPath = Path.Combine(tempSamplesDir, "HelloWorld");
@@ -155,8 +163,8 @@ command
         public void BootstrapperInvokesAssemblyWithInferredAppBaseAndLibPathOnClr(string flavor, string os, string architecture)
         {
             var outputFolder = flavor == "coreclr" ? "dnxcore50" : "dnx451";
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
             using (var tempSamplesDir = BootstrapperTestUtils.PrepareTemporarySamplesFolder(runtimeHomeDir))
             using (var tempDir = TestUtils.CreateTempDir())
             {

--- a/test/Microsoft.Framework.ApplicationHost.FunctionalTests/AppHostTests.cs
+++ b/test/Microsoft.Framework.ApplicationHost.FunctionalTests/AppHostTests.cs
@@ -14,8 +14,16 @@ using Xunit;
 
 namespace Microsoft.Framework.ApplicationHost
 {
+    [Collection("ApplicationHostTestCollection")]
     public class AppHostTests
     {
+        private readonly DnxRuntimeFixture _fixture;
+
+        public AppHostTests(DnxRuntimeFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         public static IEnumerable<object[]> RuntimeComponents
         {
             get
@@ -28,59 +36,57 @@ namespace Microsoft.Framework.ApplicationHost
         [MemberData("RuntimeComponents")]
         public void AppHostReturnsNonZeroExitCodeWhenNoSubCommandWasGiven(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
-            {
-                string stdOut, stdErr;
-                var exitCode = BootstrapperTestUtils.ExecBootstrapper(
-                    runtimeHomeDir,
-                    arguments: ".",
-                    stdOut: out stdOut,
-                    stdErr: out stdErr);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
-                Assert.NotEqual(0, exitCode);
-            }
+            string stdOut, stdErr;
+            var exitCode = BootstrapperTestUtils.ExecBootstrapper(
+                runtimeHomeDir,
+                arguments: ".",
+                stdOut: out stdOut,
+                stdErr: out stdErr);
+
+            Assert.NotEqual(0, exitCode);
         }
 
         [Theory]
         [MemberData("RuntimeComponents")]
         public void AppHostReturnsZeroExitCodeWhenHelpOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
-            {
-                string stdOut, stdErr;
-                var exitCode = BootstrapperTestUtils.ExecBootstrapper(
-                    runtimeHomeDir,
-                    arguments: ". --help",
-                    stdOut: out stdOut,
-                    stdErr: out stdErr);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
-                Assert.Equal(0, exitCode);
-            }
+            string stdOut, stdErr;
+            var exitCode = BootstrapperTestUtils.ExecBootstrapper(
+                runtimeHomeDir,
+                arguments: ". --help",
+                stdOut: out stdOut,
+                stdErr: out stdErr);
+
+            Assert.Equal(0, exitCode);
         }
 
         [Theory]
         [MemberData("RuntimeComponents")]
         public void AppHostShowsVersionAndReturnsZeroExitCodeWhenVersionOptionWasGiven(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
-            {
-                string stdOut, stdErr;
-                var exitCode = BootstrapperTestUtils.ExecBootstrapper(
-                    runtimeHomeDir,
-                    arguments: ". --version",
-                    stdOut: out stdOut,
-                    stdErr: out stdErr);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
-                Assert.Equal(0, exitCode);
-                Assert.Contains(TestUtils.GetRuntimeVersion(), stdOut);
-            }
+            string stdOut, stdErr;
+            var exitCode = BootstrapperTestUtils.ExecBootstrapper(
+                runtimeHomeDir,
+                arguments: ". --version",
+                stdOut: out stdOut,
+                stdErr: out stdErr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(TestUtils.GetRuntimeVersion(), stdOut);
         }
 
         [Theory]
         [MemberData("RuntimeComponents")]
         public void AppHostShowsErrorWhenNoProjectJsonWasFound(string flavor, string os, string architecture)
         {
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
+
             using (var emptyFolder = TestUtils.CreateTempDir())
             {
                 string stdOut, stdErr;
@@ -99,12 +105,11 @@ namespace Microsoft.Framework.ApplicationHost
         [MemberData("RuntimeComponents")]
         public void AppHostShowsErrorWhenGivenSubcommandWasNotFoundInProjectJson(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
             var projectStructure = @"{
   'project.json': '{ }'
 }";
 
-            using (runtimeHomeDir)
             using (var projectPath = TestUtils.CreateTempDir())
             {
                 DirTree.CreateFromJson(projectStructure).WriteTo(projectPath);

--- a/test/Microsoft.Framework.ApplicationHost.FunctionalTests/ApplicationHostTestCollection.cs
+++ b/test/Microsoft.Framework.ApplicationHost.FunctionalTests/ApplicationHostTestCollection.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.CommonTestUtils;
+using Xunit;
+
+namespace Microsoft.Framework.ApplicationHost.FunctionalTests
+{
+    [CollectionDefinition("ApplicationHostTestCollection")]
+    public class ApplicationHostTestCollection: ICollectionFixture<DnxRuntimeFixture>
+    {
+    }
+}

--- a/test/Microsoft.Framework.CommonTestUtils/DnxRuntimeFixture.cs
+++ b/test/Microsoft.Framework.CommonTestUtils/DnxRuntimeFixture.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Framework.CommonTestUtils
+{
+    public class DnxRuntimeFixture : IDisposable
+    {
+        private Dictionary<Tuple<string, string, string>, DisposableDir> _runtimeDirs = 
+            new Dictionary<Tuple<string, string, string>, DisposableDir>();
+
+        public virtual void Dispose()
+        {
+            foreach (var runtimeDir in _runtimeDirs.Values)
+            {
+                runtimeDir.Dispose();
+            }
+        }
+
+        public string GetRuntimeHomeDir(string flavor, string os, string architecture)
+        {
+            var key = Tuple.Create(flavor, os, architecture);
+
+            DisposableDir runtimeDir;
+            if (!_runtimeDirs.TryGetValue(key, out runtimeDir))
+            {
+                runtimeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+                _runtimeDirs[key] = runtimeDir;
+            }
+
+            return runtimeDir.DirPath;
+        }
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuListTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuListTests.cs
@@ -11,14 +11,15 @@ using Xunit;
 
 namespace Microsoft.Framework.PackageManager.FunctionalTests
 {
-    public class DnuListTests : IClassFixture<DnuListTestContext>, IDisposable
+    [Collection(nameof(PackageManagerFunctionalTestCollection))]
+    public class DnuListTests : IDisposable
     {
-        private readonly DnuListTestContext _context;
+        private readonly PackageManagerFunctionalTestFixture _fixture;
         private readonly DisposableDir _workingDir;
 
-        public DnuListTests(DnuListTestContext context)
+        public DnuListTests(PackageManagerFunctionalTestFixture fixture)
         {
-            _context = context;
+            _fixture = fixture;
             _workingDir = TestUtils.CreateTempDir();
         }
 
@@ -37,7 +38,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
         public void DnuList_EmptyProject_Default(string flavor, string os, string architecture)
         {
             string stdOut, stdErr;
-            var runtimeHomePath = _context.GetRuntimeHome(flavor, os, architecture);
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
             var expectedTitle = string.Format(
                 @"Listing dependencies for {0} ({1})",
                 Path.GetFileName(_workingDir.DirPath),
@@ -58,7 +59,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
         public void DnuList_EmptyProject_Details(string flavor, string os, string architecture)
         {
             string stdOut, stdErr;
-            var runtimeHomePath = _context.GetRuntimeHome(flavor, os, architecture);
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
             var expectedTitle = string.Format(
                 @"Listing dependencies for {0} ({1})",
                 Path.GetFileName(_workingDir.DirPath),
@@ -79,7 +80,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
         public void DnuList_SingleDependencyProject(string flavor, string os, string architecture)
         {
             string stdOut, stdErr;
-            var runtimeHomePath = _context.GetRuntimeHome(flavor, os, architecture);
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             CreateProjectJson(new
             {
@@ -95,7 +96,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
             });
 
             // restore the packages
-            Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "restore", "--source " + _context.PackageSource, workingDir: _workingDir.DirPath));
+            Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "restore", "--source " + _fixture.PackageSource, workingDir: _workingDir.DirPath));
 
             // run dnu list
             Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "list", "", out stdOut, out stdErr, environment: null, workingDir: _workingDir.DirPath));
@@ -111,7 +112,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
         public void DnuList_SingleDependencyProject_Detailed(string flavor, string os, string architecture)
         {
             string stdOut, stdErr;
-            var runtimeHomePath = _context.GetRuntimeHome(flavor, os, architecture);
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
             var projectName = Path.GetFileName(_workingDir.DirPath);
 
             CreateProjectJson(new
@@ -128,7 +129,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
             });
 
             // restore the packages
-            Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "restore", "--source " + _context.PackageSource, workingDir: _workingDir.DirPath));
+            Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "restore", "--source " + _fixture.PackageSource, workingDir: _workingDir.DirPath));
 
             // run dnu list
             Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "list", "--details", out stdOut, out stdErr, environment: null, workingDir: _workingDir.DirPath));
@@ -154,7 +155,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
         public void DnuList_Unresolved(string flavor, string os, string architecture)
         {
             string stdOut, stdErr;
-            var runtimeHomePath = _context.GetRuntimeHome(flavor, os, architecture);
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
             var projectName = Path.GetFileName(_workingDir.DirPath);
 
             CreateProjectJson(new
@@ -172,7 +173,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
             });
 
             // restore the packages, it should fail because missing package beta
-            Assert.Equal(1, DnuTestUtils.ExecDnu(runtimeHomePath, "restore", "--source " + _context.PackageSource, workingDir: _workingDir.DirPath));
+            Assert.Equal(1, DnuTestUtils.ExecDnu(runtimeHomePath, "restore", "--source " + _fixture.PackageSource, workingDir: _workingDir.DirPath));
 
             // run dnu list
             Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "list", "", out stdOut, out stdErr, environment: null, workingDir: _workingDir.DirPath));

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
@@ -9,12 +9,14 @@ using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.DependencyManagement;
 using Xunit;
 
-namespace Microsoft.Framework.PackageManager
+namespace Microsoft.Framework.PackageManager.FunctionalTests
 {
+    [Collection(nameof(PackageManagerFunctionalTestCollection))]
     public class DnuPublishTests
     {
         private readonly string _projectName = "TestProject";
         private readonly string _outputDirName = "PublishOutput";
+        private readonly PackageManagerFunctionalTestFixture _fixture;
 
         private static readonly string BatchFileTemplate = @"
 @""{0}{1}.exe"" --appbase ""%~dp0approot\src\{2}"" Microsoft.Framework.ApplicationHost {3} %*
@@ -47,6 +49,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   }
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString());
 
+        public DnuPublishTests(PackageManagerFunctionalTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         public static IEnumerable<object[]> RuntimeComponents
         {
             get
@@ -75,7 +82,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void DnuPublishWebApp_RootAsPublicFolder(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json', 'Config.json', 'Program.cs', 'build_config1.bconfig'],
@@ -129,6 +135,8 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                 Constants.WebConfigRuntimeVersion,
                 Constants.WebConfigRuntimeFlavor,
                 Constants.WebConfigRuntimeAppBase);
+
+            string runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             using (var testEnv = new DnuTestEnvironment(runtimeHomeDir, _projectName, _outputDirName))
             {
@@ -186,7 +194,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void DnuPublishWebApp_SubfolderAsPublicFolder(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json', 'Config.json', 'Program.cs'],
@@ -288,7 +296,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void DnuPublishConsoleApp(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json', 'Config.json', 'Program.cs'],
@@ -358,7 +366,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void FoldersAsFilePatternsAutoGlob(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json', 'FileWithoutExtension'],
@@ -477,7 +485,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void WildcardMatchingFacts(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json'],
@@ -576,7 +584,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void CorrectlyExcludeFoldersStartingWithDots(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json', 'File', '.FileStartingWithDot', 'File.Having.Dots'],
@@ -675,7 +683,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void VerifyDefaultPublishExcludePatterns(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json', 'File', '.FileStartingWithDot'],
@@ -751,7 +759,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void DnuPublishWebApp_CopyExistingWebConfig(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json'],
@@ -839,7 +847,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void DnuPublishWebApp_UpdateExistingWebConfig(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json'],
@@ -941,7 +949,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void GenerateBatchFilesAndBashScriptsWithoutPublishedRuntime(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json'],
@@ -1032,7 +1040,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void GenerateBatchFilesAndBashScriptsWithPublishedRuntime(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             // Each runtime home only contains one runtime package, which is the one we are currently testing against
             var runtimeRoot = Directory.EnumerateDirectories(Path.Combine(runtimeHomeDir, "runtimes"), Constants.RuntimeNamePrefix + "*").First();
@@ -1204,7 +1212,8 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   }
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString());
 
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
+
             using (var tempDir = TestUtils.CreateTempDir())
             {
                 var publishOutputPath = Path.Combine(tempDir, "output");
@@ -1309,7 +1318,8 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString())
 .Replace("LOCKFILE_NAME", LockFileFormat.LockFileName);
 
-            using (var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture))
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
+
             using (var tempDir = TestUtils.CreateTempDir())
             {
                 var publishOutputPath = Path.Combine(tempDir, "output");
@@ -1353,7 +1363,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         [MemberData("RuntimeComponents")]
         public void PublishExcludeWithLongPath(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             var projectStructure = @"{
   '.': ['project.json', 'Config.json', 'Program.cs'],

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuTestEnvironment.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuTestEnvironment.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Framework.PackageManager
     {
         private readonly string _projectName;
         private readonly string _outputDirName;
-        private readonly DisposableDir _runtimePath;
+        private readonly string _runtimePath;
 
-        public DnuTestEnvironment(DisposableDir runtimePath, string projectName = null, string outputDirName = null)
+        public DnuTestEnvironment(string runtimePath, string projectName = null, string outputDirName = null)
         {
             _projectName = projectName ?? "ProjectName";
             _outputDirName = outputDirName ?? "OutputDirName";
@@ -58,8 +58,6 @@ namespace Microsoft.Framework.PackageManager
         public void Dispose()
         {
             TestUtils.DeleteFolder(RootDir);
-
-            _runtimePath?.Dispose();
         }
     }
 }

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuWrapTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuWrapTests.cs
@@ -1,18 +1,20 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Framework.CommonTestUtils;
 using Microsoft.Framework.Runtime;
 using Xunit;
 
-namespace Microsoft.Framework.PackageManager
+namespace Microsoft.Framework.PackageManager.FunctionalTests
 {
+    [Collection(nameof(PackageManagerFunctionalTestCollection))]
     public class DnuWrapTests
     {
+        private readonly PackageManagerFunctionalTestFixture _fixture;
+
         public static IEnumerable<object[]> RuntimeComponents
         {
             get
@@ -23,11 +25,16 @@ namespace Microsoft.Framework.PackageManager
 
         public static readonly string _msbuildPath = TestUtils.ResolveMSBuildPath();
 
+        public DnuWrapTests(PackageManagerFunctionalTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Theory]
         [MemberData("RuntimeComponents")]
         public void DnuWrapUpdatesExistingProjectJson(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             if (PlatformHelper.IsMono)
             {
@@ -64,7 +71,7 @@ namespace Microsoft.Framework.PackageManager
             var expectedGlobalJson = @"{
     ""projects"": [ ""src"", ""test"" ]
 }";
-            using (runtimeHomeDir)
+
             using (var testSolutionDir = TestUtils.GetTempTestSolution("ConsoleApp1"))
             {
                 var libBetaPclCsprojPath = Path.Combine(testSolutionDir, "LibraryBeta.PCL", "LibraryBeta.PCL.csproj");
@@ -103,7 +110,7 @@ namespace Microsoft.Framework.PackageManager
         [MemberData("RuntimeComponents")]
         public void DnuWrapMaintainsAllKindsOfReferences(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             if (PlatformHelper.IsMono)
             {
@@ -156,7 +163,7 @@ namespace Microsoft.Framework.PackageManager
     ""wrap""
   ]
 }";
-            using (runtimeHomeDir)
+
             using (var testSolutionDir = TestUtils.GetTempTestSolution("ConsoleApp1"))
             {
                 var libGammaCsprojPath = Path.Combine(testSolutionDir, "LibraryGamma", "LibraryGamma.csproj");
@@ -184,7 +191,7 @@ namespace Microsoft.Framework.PackageManager
         [MemberData("RuntimeComponents")]
         public void DnuWrapInPlaceCreateCsprojWrappersInPlace(string flavor, string os, string architecture)
         {
-            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
             if (PlatformHelper.IsMono)
             {
@@ -238,7 +245,7 @@ namespace Microsoft.Framework.PackageManager
     "".""
   ]
 }";
-            using (runtimeHomeDir)
+
             using (var testSolutionDir = TestUtils.GetTempTestSolution("ConsoleApp1"))
             {
                 var libGammaCsprojPath = Path.Combine(testSolutionDir, "LibraryGamma", "LibraryGamma.csproj");

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/PackageManagerFunctionalTestCollection.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/PackageManagerFunctionalTestCollection.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Framework.PackageManager.FunctionalTests
+{
+    [CollectionDefinition(nameof(PackageManagerFunctionalTestCollection))]
+    public class PackageManagerFunctionalTestCollection :
+        ICollectionFixture<PackageManagerFunctionalTestFixture>
+    {
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/PackageManagerFunctionalTestFixture.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/PackageManagerFunctionalTestFixture.cs
@@ -2,39 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Framework.CommonTestUtils;
 
 namespace Microsoft.Framework.PackageManager.FunctionalTests
 {
-    public class DnuListTestContext : IDisposable
+    public class PackageManagerFunctionalTestFixture : DnxRuntimeFixture
     {
-        private readonly IDictionary<Tuple<string, string, string>, DisposableDir> _runtimeHomeDirs =
-            new Dictionary<Tuple<string, string, string>, DisposableDir>();
-
         private readonly DisposableDir _contextDir;
 
-        public DnuListTestContext()
+        public PackageManagerFunctionalTestFixture() : base()
         {
             _contextDir = TestUtils.CreateTempDir();
             PackageSource = Path.Combine(_contextDir.DirPath, "packages");
             Directory.CreateDirectory(PackageSource);
 
             CreateNewPackage("alpha", "0.1.0");
-        }
-
-        public string GetRuntimeHome(string flavor, string os, string architecture)
-        {
-            DisposableDir result;
-            if (!_runtimeHomeDirs.TryGetValue(Tuple.Create(flavor, os, architecture), out result))
-            {
-                result = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
-                _runtimeHomeDirs.Add(Tuple.Create(flavor, os, architecture), result);
-            }
-
-            return result.DirPath;
         }
 
         public string PackageSource { get; }
@@ -47,9 +31,9 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
                 throw new InvalidOperationException("Can't find a CLR runtime to pack test packages.");
             }
 
-            var runtimeHomePath = GetRuntimeHome((string)runtimeForPacking[0],
-                                                 (string)runtimeForPacking[1],
-                                                 (string)runtimeForPacking[2]);
+            var runtimeHomePath = base.GetRuntimeHomeDir((string)runtimeForPacking[0],
+                                                         (string)runtimeForPacking[1],
+                                                         (string)runtimeForPacking[2]);
 
             using (var tempdir = TestUtils.CreateTempDir())
             {
@@ -68,12 +52,9 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
             }
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
-            foreach (var each in _runtimeHomeDirs.Values)
-            {
-                each.Dispose();
-            }
+            base.Dispose();
 
             _contextDir.Dispose();
         }


### PR DESCRIPTION
Today, runtime package won't be repeatedly unzip during `build verify`. However it is not the case if the test is run from Visual Studio or run from command line using `dnx . text`. This change leverages the xunit's test collection feature to ensure one fixture is shared in on test assembly among the tests marked in same collection. 

On my machine it reduces the test running time:
```
from:
   Bootstrapper.FunctionalTests  Total: 24, Errors: 0, Failed: 0, Skipped: 0, Time: 99.213s
to:
   Bootstrapper.FunctionalTests  Total: 24, Errors: 0, Failed: 0, Skipped: 0, Time: 58.791s

from:
   Microsoft.Framework.ApplicationHost.FunctionalTests  Total: 20, Errors: 0, Failed: 0, Skipped: 0, Time: 47.367s
to:
   Microsoft.Framework.ApplicationHost.FunctionalTests  Total: 20, Errors: 0, Failed: 0, Skipped: 0, Time: 15.482s

from:
   Microsoft.Framework.PackageManager.FunctionalTests  Total: 82, Errors: 0, Failed: 0, Skipped: 1, Time: 160.156s
to:
   Microsoft.Framework.PackageManager.FunctionalTests  Total: 82, Errors: 0, Failed: 0, Skipped: 1, Time: 121.718s
```

Addressing: https://github.com/aspnet/dnx/issues/1651
