### PR TITLE
Include native resource files for CoreCLR Linux

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -555,6 +555,24 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
                     Log.Info("Copying " + file + " to " + targetFilePath);
                     File.Copy(file, targetFilePath, true);
                 }
+
+                // Copy the managed resources the runtime needs for Linux
+                if (target.OS == "linux")
+                {
+                    foreach (var file in Files.BasePath(coreclrFolder).Include("**/*.mo"))
+                    {
+                        var sourceFile = Path.Combine(coreclrFolder, file);
+                        var outputFile = Path.Combine(target.TargetFolder, file);
+
+                        if (!Directory.Exists(Path.GetDirectoryName(outputFile)))
+                        {
+                            Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
+                        }
+
+                        Log.Info("Copying " + sourceFile + " to " + outputFile);
+                        File.Copy(sourceFile, outputFile, true);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
We should include the compiled message files as part of the package so
we can put them in DNX.  These are used when the runtime throws an
exception internally and are useful for debugging (e.g. it makes
FileNotFound exceptions actually have the text of the file that was not
found).

They are not produced for OSX yet (see dotnet/coreclr#678) so we can
only include the Linux versions.