### PR TITLE
New lock file format to handle new package conventions.

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -112,15 +112,9 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
 -// Replace repo-initialize with a less greedy restore
 #repo-initialize target='initialize'
     git gitCommand="submodule update --init"
-    for each='var projectFile in Files.Include("src/*/project.json")'
-        exec program='cmd' commandline='/C dnu restore' if='!IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
-        exec program='dnu' commandline='restore' if='IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
-    for each='var projectFile in Files.Include("test/*/project.json")'
-        exec program='cmd' commandline='/C dnu restore' if='!IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
-        exec program='dnu' commandline='restore' if='IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
-    for each='var projectFile in Files.Include("samples/*/project.json")'
-        exec program='cmd' commandline='/C dnu restore' if='!IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
-        exec program='dnu' commandline='restore' if='IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
+    @{
+        DoRestore();
+    }
 
 - // k-standard-goal overrides
 #native-compile
@@ -789,6 +783,24 @@ var CI_DARWIN_DROP_PATH = '${Environment.GetEnvironmentVariable("CI_DARWIN_DROP_
             }
         }
 
+        // We need to run restore with the new runtime (just one of them)
+        // On windows, grab a random windows target, otherwise use mono
+        string path = null;
+        
+        if (CanBuildForWindows)
+        {
+            path = binPaths[RUNTIME_CLR_WIN_x86_NAME];
+        }
+        else
+        {
+            path = binPaths[RUNTIME_MONO_NAME];
+        }
+        
+        ExecuteWithPath(path, () => 
+        {
+            DoRestore();
+        });
+
         // Group by operation system since we only want to run unit tests on a single bitness
         // any = [dnx-mono]
         // win = [dnx-clr-win-x86, dnx-clr-win-x64, dnx-coreclr-win-x86, dnx-coreclr-win-x64]
@@ -883,6 +895,16 @@ var CI_DARWIN_DROP_PATH = '${Environment.GetEnvironmentVariable("CI_DARWIN_DROP_
     }
 
 - // ===================== SHARED UTILITIES ===================== 
+macro name='DoRestore'
+    for each='var projectFile in Files.Include("src/*/project.json")'
+        exec program='cmd' commandline='/C dnu restore' if='!IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
+        exec program='dnu' commandline='restore' if='IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
+    for each='var projectFile in Files.Include("test/*/project.json")'
+        exec program='cmd' commandline='/C dnu restore' if='!IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
+        exec program='dnu' commandline='restore' if='IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
+    for each='var projectFile in Files.Include("samples/*/project.json")'
+        exec program='cmd' commandline='/C dnu restore' if='!IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
+        exec program='dnu' commandline='restore' if='IsMono' workingdir="${Path.GetDirectoryName(projectFile)}"
 
 #update-tpa .copy-coreclr
     @{
@@ -964,16 +986,6 @@ functions @{
     void KTest(string projectFolder)
     {
         projectFolder = Path.GetDirectoryName(projectFolder);
-
-        // Make sure we use the newly built runtime to generate lock file for tests
-        if (IsMono)
-        {
-            Exec("dnu", string.Format("restore {0}", projectFolder));
-        }
-        else
-        {
-            Exec("cmd", string.Format("/C dnu restore {0}", projectFolder));
-        }
 
         var testArgs = IsMono ? " -parallel none" : "";
         K(("test" + testArgs), projectFolder, "");

--- a/src/Microsoft.Framework.PackageManager/FeedOptions.cs
+++ b/src/Microsoft.Framework.PackageManager/FeedOptions.cs
@@ -8,58 +8,28 @@ namespace Microsoft.Framework.PackageManager
 {
     public class FeedOptions
     {
-        public IList<string> FallbackSources
-        {
-            get
-            {
-                return FallbackSourceOptions.Values;
-            }
-        }
+        public IList<string> FallbackSources { get; set; } = new List<string>();
 
-        public bool IgnoreFailedSources
-        {
-            get
-            {
-                return IgnoreFailedSourcesOptions.HasValue();
-            }
-        }
-        public bool NoCache
-        {
-            get
-            {
-                return NoCacheOptions.HasValue();
-            }
-        }
-        public string TargetPackagesFolder
-        {
-            get
-            {
-                return TargetPackagesFolderOptions.Value();
-            }
-        }
-        public string Proxy
-        {
-            get
-            {
-                return ProxyOptions.Value();
-            }
-        }
-        public IList<string> Sources
-        {
-            get
-            {
-                return SourceOptions.Values;
-            }
-        }
+        public bool IgnoreFailedSources { get; set; }
 
-        public bool Quiet
-        {
-            get
-            {
-                return QuietOptions.HasValue();
-            }
-        }
+        public bool NoCache { get; set; }
 
+        public string TargetPackagesFolder { get; set; }
+
+        public string Proxy { get; set; }
+
+        public IList<string> Sources { get; set; } = new List<string>();
+
+        public bool Quiet { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag that determines if restore is performed on multiple project.json files in parallel.
+        /// </summary>
+        public bool Parallel { get; set; }
+    }
+
+    public class FeedCommandLineOptions
+    {
         internal CommandOption FallbackSourceOptions { get; private set; }
         internal CommandOption IgnoreFailedSourcesOptions { get; private set; }
         internal CommandOption NoCacheOptions { get; private set; }
@@ -67,44 +37,65 @@ namespace Microsoft.Framework.PackageManager
         internal CommandOption ProxyOptions { get; private set; }
         internal CommandOption SourceOptions { get; private set; }
         internal CommandOption QuietOptions { get; private set; }
+        internal CommandOption ParallelOptions { get; private set; }
 
-        internal static FeedOptions Add(CommandLineApplication c)
+        internal static FeedCommandLineOptions Add(CommandLineApplication app)
         {
-            var options = new FeedOptions();
+            var options = new FeedCommandLineOptions();
 
-            options.SourceOptions = c.Option(
+            options.SourceOptions = app.Option(
                 "-s|--source <FEED>",
                 "A list of packages sources to use for this command",
                 CommandOptionType.MultipleValue);
 
-            options.FallbackSourceOptions = c.Option(
+            options.FallbackSourceOptions = app.Option(
                 "-f|--fallbacksource <FEED>",
                 "A list of packages sources to use as a fallback",
                 CommandOptionType.MultipleValue);
 
-            options.ProxyOptions = c.Option(
+            options.ProxyOptions = app.Option(
                 "-p|--proxy <ADDRESS>",
                 "The HTTP proxy to use when retrieving packages",
                 CommandOptionType.SingleValue);
 
-            options.NoCacheOptions = c.Option(
+            options.NoCacheOptions = app.Option(
                 "--no-cache",
                 "Do not use local cache",
                 CommandOptionType.NoValue);
 
-            options.TargetPackagesFolderOptions = c.Option(
+            options.TargetPackagesFolderOptions = app.Option(
                 "--packages",
                 "Path to restore packages",
                 CommandOptionType.SingleValue);
 
-            options.IgnoreFailedSourcesOptions = c.Option(
+            options.IgnoreFailedSourcesOptions = app.Option(
                 "--ignore-failed-sources",
                 "Ignore failed remote sources if there are local packages meeting version requirements",
                 CommandOptionType.NoValue);
 
-            options.QuietOptions = c.Option(
+            options.QuietOptions = app.Option(
                 "--quiet", "Do not show output such as HTTP request/cache information",
                 CommandOptionType.NoValue);
+
+            options.ParallelOptions = app.Option("--parallel",
+                "Restores in parallel when more than one project.json is discovered.",
+                CommandOptionType.NoValue);
+
+            return options;
+        }
+
+        public FeedOptions GetOptions()
+        {
+            var options = new FeedOptions();
+
+            options.FallbackSources = FallbackSourceOptions.Values ?? options.FallbackSources;
+            options.Sources = SourceOptions.Values ?? options.Sources;
+            options.IgnoreFailedSources = IgnoreFailedSourcesOptions.HasValue();
+            options.NoCache = NoCacheOptions.HasValue();
+            options.Parallel = ParallelOptions.HasValue();
+            options.Quiet = QuietOptions.HasValue();
+            options.Proxy = ProxyOptions.Value();
+            options.TargetPackagesFolder = TargetPackagesFolderOptions.Value();
 
             return options;
         }

--- a/src/Microsoft.Framework.PackageManager/Install/InstallGlobalCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Install/InstallGlobalCommand.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Framework.PackageManager
 
             if (string.IsNullOrEmpty(FeedOptions.TargetPackagesFolder))
             {
-                FeedOptions.TargetPackagesFolderOptions.Values.Add(_commandsRepository.PackagesRoot.Root);
+                FeedOptions.Sources.Add(_commandsRepository.PackagesRoot.Root);
             }
 
             var temporaryProjectFileFullPath = CreateTemporaryProject(FeedOptions.TargetPackagesFolder, packageId, packageVersion);
@@ -130,7 +130,7 @@ namespace Microsoft.Framework.PackageManager
                 var packagePath = Path.GetFullPath(packageId);
                 var packageDirectory = Path.GetDirectoryName(packagePath);
                 var zipPackage = new NuGet.ZipPackage(packagePath);
-                FeedOptions.FallbackSourceOptions.Values.Add(packageDirectory);
+                FeedOptions.FallbackSources.Add(packageDirectory);
 
                 return new Tuple<string, string>(
                     zipPackage.Id,

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/Asset.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/Asset.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace NuGet.ContentModel
+{
+    public class Asset
+    {
+        public string Path { get; set; }
+        public string Link { get; set; }
+
+        public override string ToString()
+        {
+            return Path;
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentItem.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentItem.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NuGet.ContentModel
+{
+    public class ContentItem
+    {
+        public string Path { get; set; }
+        public string PhysicalPath { get; set; }
+        public IDictionary<string, object> Properties { get; set; }
+
+        public ContentItem()
+        {
+            Properties = new Dictionary<string, object>();
+        }
+
+        public override string ToString()
+        {
+            return Path + " -> " + PhysicalPath;
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentItemCollection.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentItemCollection.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.ContentModel
+{
+    public class ContentItemCollection
+    {
+        private IEnumerable<Asset> _assets;
+
+        public void Load(IEnumerable<string> paths)
+        {
+            _assets = paths.Select(path => new Asset { Path = path }).ToList();
+        }
+
+        public IEnumerable<ContentItem> FindItems(ContentPatternDefinition definition)
+        {
+            return FindItemsImplementation(definition, _assets);
+        }
+
+        public IEnumerable<ContentItemGroup> FindItemGroups(ContentPatternDefinition definition)
+        {
+            var groupPatterns = definition.GroupPatterns
+                .Select(pattern => new Infrastructure.PatternExpression(pattern))
+                .ToList();
+
+            var groupAssets = new List<Tuple<ContentItem, Asset>>();
+            foreach (var asset in _assets)
+            {
+                foreach (var groupParser in groupPatterns)
+                {
+                    ContentItem item = groupParser.Match(asset.Path, definition.PropertyDefinitions);
+                    if (item != null)
+                    {
+                        groupAssets.Add(Tuple.Create(item, asset));
+                    }
+                }
+            }
+
+            foreach (var grouping in groupAssets.GroupBy(key => key.Item1, new GroupComparer()))
+            {
+                var group = new ContentItemGroup();
+
+                foreach (var property in grouping.Key.Properties)
+                {
+                    group.Properties.Add(property.Key, property.Value);
+                }
+
+                foreach (var item in FindItemsImplementation(definition, grouping.Select(match => match.Item2)))
+                {
+                    group.Items.Add(item);
+                }
+
+                yield return group;
+            }
+        }
+
+        public ContentItemGroup FindBestItemGroup(SelectionCriteria criteria, params ContentPatternDefinition[] definitions)
+        {
+            foreach (var definition in definitions)
+            {
+                var itemGroups = FindItemGroups(definition).ToList();
+                foreach (var criteriaEntry in criteria.Entries)
+                {
+                    ContentItemGroup bestGroup = null;
+                    var bestAmbiguity = false;
+
+                    foreach (var itemGroup in itemGroups)
+                    {
+                        var groupIsValid = true;
+                        foreach (var criteriaProperty in criteriaEntry.Properties)
+                        {
+                            if (criteriaProperty.Value == null)
+                            {
+                                if (itemGroup.Properties.ContainsKey(criteriaProperty.Key))
+                                {
+                                    groupIsValid = false;
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                object itemProperty;
+                                if (!itemGroup.Properties.TryGetValue(criteriaProperty.Key, out itemProperty))
+                                {
+                                    groupIsValid = false;
+                                    break;
+                                }
+                                ContentPropertyDefinition propertyDefinition;
+                                if (!definition.PropertyDefinitions.TryGetValue(criteriaProperty.Key, out propertyDefinition))
+                                {
+                                    groupIsValid = false;
+                                    break;
+                                }
+                                if (!propertyDefinition.IsCriteriaSatisfied(criteriaProperty.Value, itemProperty))
+                                {
+                                    groupIsValid = false;
+                                    break;
+                                }
+                            }
+                        }
+                        if (groupIsValid)
+                        {
+                            if (bestGroup == null)
+                            {
+                                bestGroup = itemGroup;
+                            }
+                            else
+                            {
+                                var groupComparison = 0;
+                                foreach (var criteriaProperty in criteriaEntry.Properties)
+                                {
+                                    if (criteriaProperty.Value == null)
+                                    {
+                                        continue;
+                                    }
+                                    else
+                                    {
+                                        var bestGroupValue = bestGroup.Properties[criteriaProperty.Key];
+                                        var itemGroupValue = itemGroup.Properties[criteriaProperty.Key];
+                                        var propertyDefinition = definition.PropertyDefinitions[criteriaProperty.Key];
+                                        groupComparison = propertyDefinition.Compare(criteriaProperty.Value, bestGroupValue, itemGroupValue);
+                                        if (groupComparison != 0)
+                                        {
+                                            break;
+                                        }
+                                    }
+                                }
+                                if (groupComparison > 0)
+                                {
+                                    bestGroup = itemGroup;
+                                    bestAmbiguity = false;
+                                }
+                                else if (groupComparison == 0)
+                                {
+                                    bestAmbiguity = true;
+                                }
+                            }
+                        }
+
+                    }
+                    if (bestGroup != null)
+                    {
+                        if (bestAmbiguity)
+                        {
+                            // TODO: Something
+                        }
+                        return bestGroup;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private IEnumerable<ContentItem> FindItemsImplementation(ContentPatternDefinition definition, IEnumerable<Asset> assets)
+        {
+            var pathPatterns = definition.PathPatterns
+                .Select(pattern => new Infrastructure.PatternExpression(pattern))
+                .ToList();
+
+            foreach (var asset in assets)
+            {
+                foreach (var pathPattern in pathPatterns)
+                {
+                    ContentItem contentItem = pathPattern.Match(asset.Path, definition.PropertyDefinitions);
+                    if (contentItem != null)
+                    {
+                        yield return contentItem;
+                        break;
+                    }
+                }
+            }
+        }
+
+        private class GroupComparer : IEqualityComparer<ContentItem>
+        {
+            public int GetHashCode(ContentItem obj)
+            {
+                var hashCode = 0;
+                foreach (var property in obj.Properties)
+                {
+                    hashCode ^= property.Key.GetHashCode();
+                    hashCode ^= property.Value.GetHashCode();
+                }
+                return hashCode;
+            }
+
+            public bool Equals(ContentItem x, ContentItem y)
+            {
+                foreach (var xProperty in x.Properties)
+                {
+                    object yValue;
+                    if (!y.Properties.TryGetValue(xProperty.Key, out yValue))
+                    {
+                        return false;
+                    }
+                    if (!Equals(xProperty.Value, yValue))
+                    {
+                        return false;
+                    }
+                }
+
+                foreach (var yProperty in y.Properties)
+                {
+                    object xValue;
+                    if (!x.Properties.TryGetValue(yProperty.Key, out xValue))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentItemGroup.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentItemGroup.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace NuGet.ContentModel
+{
+    public class ContentItemGroup
+    {
+        public ContentItemGroup()
+        {
+            Properties = new Dictionary<string, object>();
+            Items = new List<ContentItem>();
+        }
+
+        public IDictionary<string, object> Properties { get;  }
+
+        public IList<ContentItem> Items { get;  }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentPropertyDefinition.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentPropertyDefinition.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.ContentModel
+{
+    public class ContentPropertyDefinition
+    {
+        public ContentPropertyDefinition()
+        {
+            Table = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            FileExtensions = new List<string>();
+        }
+
+        public IDictionary<string, object> Table { get; set; }
+
+        public List<string> FileExtensions { get; set; }
+
+        public bool FileExtensionAllowSubFolders { get; set; }
+
+        public Func<string, object> Parser { get; set; }
+
+        public virtual bool TryLookup(string name, out object value)
+        {
+            if (name == null)
+            {
+                value = null;
+                return false;
+            }
+
+            if (Table != null && Table.TryGetValue(name, out value))
+            {
+                return true;
+            }
+
+            if (FileExtensions != null && FileExtensions.Any())
+            {
+                if (FileExtensionAllowSubFolders == true || name.IndexOfAny(new[] { '/', '\\' }) == -1)
+                {
+                    foreach (var fileExtension in FileExtensions)
+                    {
+                        if (name.EndsWith(fileExtension, StringComparison.OrdinalIgnoreCase))
+                        {
+
+                            value = name;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            if (Parser != null)
+            {
+                value = Parser.Invoke(name);
+                if (value != null)
+                {
+                    return true;
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        public Func<object, object, bool> OnIsCriteriaSatisfied { get; set; } = Object.Equals;
+        public Func<object, object, object, int> OnCompare { get; set; }
+
+        public virtual bool IsCriteriaSatisfied(object critieriaValue, object candidateValue)
+        {
+            return OnIsCriteriaSatisfied.Invoke(critieriaValue, candidateValue);
+        }
+
+        public virtual int Compare(object criteriaValue, object candidateValue1, object candidateValue2)
+        {
+            if (OnCompare != null)
+            {
+                return OnCompare(criteriaValue, candidateValue1, candidateValue2);
+            }
+
+            var betterCoverageFromValue1 = IsCriteriaSatisfied(candidateValue1, candidateValue2);
+            var betterCoverageFromValue2 = IsCriteriaSatisfied(candidateValue2, candidateValue1);
+            if (betterCoverageFromValue1 && !betterCoverageFromValue2)
+            {
+                return -1;
+            }
+            if (betterCoverageFromValue2 && !betterCoverageFromValue1)
+            {
+                return 1;
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentQueryDefinition.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/ContentQueryDefinition.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NuGet.ContentModel
+{
+    public class ContentPatternDefinition
+    {
+        public ContentPatternDefinition()
+        {
+            GroupPatterns = new List<string>();
+            PathPatterns = new List<string>();
+            PropertyDefinitions = new Dictionary<string, ContentPropertyDefinition>();
+        }
+        public IList<string> GroupPatterns { get; set; }
+
+        public IList<string> PathPatterns { get; set; }
+
+        public IDictionary<string, ContentPropertyDefinition> PropertyDefinitions { get; set; }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/Infrastructure/Parser.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/Infrastructure/Parser.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NuGet.ContentModel.Infrastructure
+{
+    public class PatternExpression
+    {
+        private List<Segment> _segments = new List<Segment>();
+
+        public PatternExpression(string pattern)
+        {
+            Initialize(pattern);
+        }
+
+        private void Initialize(string pattern)
+        {
+            for (var scanIndex = 0; scanIndex < pattern.Length;)
+            {
+                var beginToken = (pattern + '{').IndexOf('{', scanIndex);
+                var endToken = (pattern + '}').IndexOf('}', beginToken);
+                if (scanIndex != beginToken)
+                {
+                    var literal = pattern.Substring(scanIndex, beginToken - scanIndex);
+                    _segments.Add(new LiteralSegment(literal));
+                }
+                if (beginToken != endToken)
+                {
+                    var delimiter = (pattern + '\0')[endToken + 1];
+                    var matchOnly = pattern[endToken - 1] == '?';
+
+                    var beginName = beginToken + 1;
+                    var endName = endToken - (matchOnly ? 1 : 0);
+
+                    var tokenName = pattern.Substring(beginName, endName - beginName);
+                    _segments.Add(new TokenSegment(tokenName, delimiter, matchOnly));
+                }
+                scanIndex = endToken + 1;
+            }
+        }
+
+        public ContentItem Match(string path, IDictionary<string, ContentPropertyDefinition> propertyDefinitions)
+        {
+            var item = new ContentItem
+            {
+                Path = path
+            };
+            var startIndex = 0;
+            foreach (var segment in _segments)
+            {
+                int endIndex;
+                if (segment.TryMatch(item, propertyDefinitions, startIndex, out endIndex))
+                {
+                    startIndex = endIndex;
+                    continue;
+                }
+                return null;
+            }
+            return startIndex == path.Length ? item : null;
+        }
+
+        private abstract class Segment
+        {
+            internal abstract bool TryMatch(ContentItem item, IDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
+        }
+
+        private class LiteralSegment : Segment
+        {
+            private readonly string _literal;
+
+            public LiteralSegment(string literal)
+            {
+                _literal = literal;
+            }
+
+            internal override bool TryMatch(
+                ContentItem item,
+                IDictionary<string, ContentPropertyDefinition> propertyDefinitions,
+                int startIndex,
+                out int endIndex)
+            {
+                if (item.Path.Length >= startIndex + _literal.Length)
+                {
+                    var substring = item.Path.Substring(startIndex, _literal.Length);
+                    if (string.Equals(_literal, substring, StringComparison.OrdinalIgnoreCase))
+                    {
+                        endIndex = startIndex + _literal.Length;
+                        return true;
+                    }
+                }
+                endIndex = startIndex;
+                return false;
+            }
+        }
+
+        private class TokenSegment : Segment
+        {
+            private readonly string _token;
+            private readonly char _delimiter;
+            private readonly bool _matchOnly;
+
+            public TokenSegment(string token, char delimiter, bool matchOnly)
+            {
+                _token = token;
+                _delimiter = delimiter;
+                _matchOnly = matchOnly;
+            }
+
+            internal override bool TryMatch(ContentItem item, IDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex)
+            {
+                ContentPropertyDefinition propertyDefinition;
+                if (!propertyDefinitions.TryGetValue(_token, out propertyDefinition))
+                {
+                    throw new Exception(string.Format("Unable to find property definition for {{{0}}}", _token));
+                }
+                for (var scanIndex = startIndex; scanIndex != item.Path.Length;)
+                {
+                    var delimiterIndex = (item.Path + _delimiter).IndexOf(_delimiter, scanIndex + 1);
+                    if (delimiterIndex == item.Path.Length && _delimiter != '\0')
+                    {
+                        break;
+                    }
+                    var substring = item.Path.Substring(startIndex, delimiterIndex - startIndex);
+                    object value;
+                    if (propertyDefinition.TryLookup(substring, out value))
+                    {
+                        if (!_matchOnly)
+                        {
+                            item.Properties.Add(_token, value);
+                        }
+                        endIndex = delimiterIndex;
+                        return true;
+                    }
+                    scanIndex = delimiterIndex;
+                }
+                endIndex = startIndex;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/SelectionCriteria.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/ContentModel/SelectionCriteria.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace NuGet.ContentModel
+{
+    public class SelectionCriteria
+    {
+        public SelectionCriteria()
+        {
+            Entries = new List<SelectionCriteriaEntry>();
+        }
+
+        public IList<SelectionCriteriaEntry> Entries { get; set; }
+    }
+
+    public class SelectionCriteriaEntry
+    {
+        public SelectionCriteriaEntry()
+        {
+            Properties = new Dictionary<string, object>();
+        }
+
+        public IDictionary<string, object> Properties { get; set; }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -52,29 +52,27 @@ namespace Microsoft.Framework.PackageManager
                 c.Description = "Restore packages";
 
                 var argRoot = c.Argument("[root]", "Root of all projects to restore. It can be a directory, a project.json, or a global.json.");
-                var feedOptions = FeedOptions.Add(c);
+                var feedCommandLineOptions = FeedCommandLineOptions.Add(c);
                 var optLock = c.Option("--lock",
                     "Creates dependencies file with locked property set to true. Overwrites file if it exists.",
                     CommandOptionType.NoValue);
                 var optUnlock = c.Option("--unlock",
                     "Creates dependencies file with locked property set to false. Overwrites file if it exists.",
                     CommandOptionType.NoValue);
-                var optParallel = c.Option("--parallel",
-                    "Restores in parallel when more than one project.json is discovered.",
-                    CommandOptionType.NoValue);
+
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(async () =>
                 {
+                    var feedOptions = feedCommandLineOptions.GetOptions();
                     var command = new RestoreCommand(_environment);
                     command.Reports = CreateReports(optionVerbose.HasValue(), feedOptions.Quiet);
                     command.RestoreDirectory = argRoot.Value;
                     command.FeedOptions = feedOptions;
                     command.Lock = optLock.HasValue();
                     command.Unlock = optUnlock.HasValue();
-                    command.Parallel = optParallel.HasValue();
 
-                    if (feedOptions.ProxyOptions.HasValue())
+                    if (!string.IsNullOrEmpty(feedOptions.Proxy))
                     {
                         Environment.SetEnvironmentVariable("http_proxy", feedOptions.Proxy);
                     }
@@ -212,12 +210,13 @@ namespace Microsoft.Framework.PackageManager
                 var argVersion = c.Argument("[version]", "Version of the dependency to add, default is the latest version.");
                 var argProject = c.Argument("[project]", "Path to project, default is current directory");
 
-                var feedOptions = FeedOptions.Add(c);
+                var feedCommandLineOptions = FeedCommandLineOptions.Add(c);
 
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(async () =>
                 {
+                    var feedOptions = feedCommandLineOptions.GetOptions();
                     var reports = CreateReports(optionVerbose.HasValue(), feedOptions.Quiet);
 
                     var addCmd = new AddCommand();
@@ -232,7 +231,7 @@ namespace Microsoft.Framework.PackageManager
 
                     restoreCmd.RestoreDirectory = argProject.Value;
 
-                    if (feedOptions.ProxyOptions.HasValue())
+                    if (!string.IsNullOrEmpty(feedOptions.Proxy))
                     {
                         Environment.SetEnvironmentVariable("http_proxy", feedOptions.Proxy);
                     }
@@ -426,12 +425,13 @@ namespace Microsoft.Framework.PackageManager
 
                     var optOverwrite = c.Option("-o|--overwrite", "Overwrites conflicting commands", CommandOptionType.NoValue);
 
-                    var feedOptions = FeedOptions.Add(c);
+                    var feedCommandLineOptions = FeedCommandLineOptions.Add(c);
 
                     c.HelpOption("-?|-h|--help");
 
                     c.OnExecute(async () =>
                     {
+                        var feedOptions = feedCommandLineOptions.GetOptions();
                         var command = new InstallGlobalCommand(
                                 _environment,
                                 string.IsNullOrEmpty(feedOptions.TargetPackagesFolder) ?

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishOperations.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishOperations.cs
@@ -18,6 +18,24 @@ namespace Microsoft.Framework.PackageManager.Publish
             FileOperationUtils.DeleteFolder(folderPath);
         }
 
+        public void DeleteEmptyFolders(string packageDir)
+        {
+            DeleteEmptyFolders(new DirectoryInfo(packageDir));
+        }
+
+        private void DeleteEmptyFolders(DirectoryInfo directoryInfo)
+        {
+            foreach (var directory in directoryInfo.EnumerateDirectories())
+            {
+                DeleteEmptyFolders(directory);
+            }
+
+            if (!directoryInfo.EnumerateFileSystemInfos().Any())
+            {
+                directoryInfo.Delete();
+            }
+        }
+
         public void Copy(IEnumerable<string> sourceFiles, string sourceDirectory, string targetDirectory)
         {
             if (sourceFiles == null)
@@ -55,7 +73,7 @@ namespace Microsoft.Framework.PackageManager.Publish
                 }
             }
         }
-        
+
         public void Copy(string sourcePath, string targetPath)
         {
             sourcePath = PathUtility.EnsureTrailingSlash(sourcePath);
@@ -95,8 +113,8 @@ namespace Microsoft.Framework.PackageManager.Publish
         public void ExtractNupkg(ZipArchive archive, string targetPath)
         {
             ExtractFiles(
-                archive, 
-                targetPath, 
+                archive,
+                targetPath,
                 shouldInclude: NupkgFilter);
         }
 
@@ -173,9 +191,9 @@ namespace Microsoft.Framework.PackageManager.Publish
         public void AddFiles(ZipArchive archive, string sourcePath, string targetPath, Func<string, string, bool> shouldInclude)
         {
             AddFilesRecursive(
-                archive, 
-                sourcePath, 
-                "", 
+                archive,
+                sourcePath,
+                "",
                 targetPath,
                 shouldInclude);
         }

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishRoot.cs
@@ -68,12 +68,14 @@ namespace Microsoft.Framework.PackageManager.Publish
 
             foreach (var deploymentRuntime in Runtimes)
             {
-                deploymentRuntime.Emit(this);
+                success &= deploymentRuntime.Emit(this);
             }
 
-            mainProject.PostProcess(this);
-
+            // Order matters here, we write out the global.json first
+            // so that post process can find things
             WriteGlobalJson();
+
+            success &= mainProject.PostProcess(this);
 
             // Generate .cmd files
             GenerateBatchFiles();

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishRuntime.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishRuntime.cs
@@ -24,14 +24,16 @@ namespace Microsoft.Framework.PackageManager.Publish
         public string TargetPath { get; private set; }
         public FrameworkName Framework { get { return _frameworkName; } }
 
-        public void Emit(PublishRoot root)
+        public bool Emit(PublishRoot root)
         {
             root.Reports.Quiet.WriteLine("Bundling runtime {0}", Name);
 
             if (Directory.Exists(TargetPath))
             {
                 root.Reports.Quiet.WriteLine("  {0} already exists.", TargetPath);
-                return;
+
+                // REVIEW: IS this correct?
+                return true;
             }
 
             if (!Directory.Exists(TargetPath))
@@ -50,6 +52,8 @@ namespace Microsoft.Framework.PackageManager.Publish
                     root.Reports.Information.WriteLine("Failed to mark {0} as executable".Yellow(), dnxPath);
                 }
             }
+
+            return true;
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -1,25 +1,21 @@
 ﻿using System;
-using System.Security.Cryptography;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Versioning;
-using NuGet;
+using System.Security.Cryptography;
 using Microsoft.Framework.Runtime.DependencyManagement;
+using NuGet;
+using NuGet.ContentModel;
 
 namespace Microsoft.Framework.PackageManager.Utils
 {
     internal static class LockFileUtils
     {
-        public static LockFileLibrary CreateLockFileLibraryForProject(
-            Runtime.Project project,
-            IPackage package,
-            SHA512 sha512,
-            IEnumerable<FrameworkName> frameworks,
-            IPackagePathResolver resolver,
-            string correctedPackageName = null)
+        public static LockFileLibrary CreateLockFileLibrary(IPackagePathResolver resolver, IPackage package, SHA512 sha512, string correctedPackageName = null)
         {
             var lockFileLib = new LockFileLibrary();
 
@@ -31,76 +27,20 @@ namespace Microsoft.Framework.PackageManager.Utils
 
             using (var nupkgStream = package.GetStream())
             {
-                lockFileLib.Sha = Convert.ToBase64String(sha512.ComputeHash(nupkgStream));
+                lockFileLib.Sha512 = Convert.ToBase64String(sha512.ComputeHash(nupkgStream));
             }
+
             lockFileLib.Files = package.GetFiles().Select(p => p.Path).ToList();
 
-            foreach (var framework in frameworks)
-            {
-                var group = new LockFileFrameworkGroup();
-                group.TargetFramework = framework;
-
-                IEnumerable<PackageDependencySet> dependencySet;
-                if (VersionUtility.TryGetCompatibleItems(framework, package.DependencySets, out dependencySet))
-                {
-                    var set = dependencySet.FirstOrDefault()?.Dependencies?.ToList();
-
-                    if (set != null)
-                    {
-                        group.Dependencies = set;
-                    }
-                }
-
-                // TODO: Remove this when we do #596
-                // ASP.NET Core isn't compatible with generic PCL profiles
-                if (!string.Equals(framework.Identifier, VersionUtility.AspNetCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(framework.Identifier, VersionUtility.DnxCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase))
-                {
-                    IEnumerable<FrameworkAssemblyReference> frameworkAssemblies;
-                    if (VersionUtility.TryGetCompatibleItems(framework, package.FrameworkAssemblies, out frameworkAssemblies))
-                    {
-                        foreach (var assemblyReference in frameworkAssemblies)
-                        {
-                            if (!assemblyReference.SupportedFrameworks.Any() &&
-                                !VersionUtility.IsDesktop(framework))
-                            {
-                                // REVIEW: This isn't 100% correct since none *can* mean 
-                                // any in theory, but in practice it means .NET full reference assembly
-                                // If there's no supported target frameworks and we're not targeting
-                                // the desktop framework then skip it.
-
-                                // To do this properly we'll need all reference assemblies supported
-                                // by each supported target framework which isn't always available.
-                                continue;
-                            }
-
-                            group.FrameworkAssemblies.Add(assemblyReference);
-                        }
-                    }
-                }
-
-                group.RuntimeAssemblies = GetPackageAssemblies(package, framework);
-
-                string contractPath = Path.Combine("lib", "contract", package.Id + ".dll");
-                var hasContract = lockFileLib.Files.Any(path => path == contractPath);
-                var hasLib = group.RuntimeAssemblies.Any();
-
-                if (hasContract && hasLib && !VersionUtility.IsDesktop(framework))
-                {
-                    group.CompileTimeAssemblies.Add(contractPath);
-                }
-                else if (hasLib)
-                {
-                    group.CompileTimeAssemblies.AddRange(group.RuntimeAssemblies);
-                }
-
-                lockFileLib.FrameworkGroups.Add(group);
-            }
-
             var installPath = resolver.GetInstallPath(package.Id, package.Version);
-            foreach (var assembly in lockFileLib.FrameworkGroups.SelectMany(f => f.RuntimeAssemblies))
+            foreach (var filePath in lockFileLib.Files)
             {
-                var assemblyPath = Path.Combine(installPath, assembly);
+                if (!string.Equals(Path.GetExtension(filePath), ".dll"))
+                {
+                    continue;
+                }
+
+                var assemblyPath = Path.Combine(installPath, filePath);
                 if (IsAssemblyServiceable(assemblyPath))
                 {
                     lockFileLib.IsServiceable = true;
@@ -109,6 +49,128 @@ namespace Microsoft.Framework.PackageManager.Utils
             }
 
             return lockFileLib;
+        }
+
+        public static LockFileTargetLibrary CreateLockFileTargetLibrary(IPackage package, RestoreContext context, string correctedPackageName)
+        {
+            var lockFileLib = new LockFileTargetLibrary();
+
+            var framework = context.FrameworkName;
+            var runtimeIdentifier = context.RuntimeName;
+
+            // package.Id is read from nuspec and it might be in wrong casing.
+            // correctedPackageName should be the package name used by dependency graph and
+            // it has the correct casing that runtime needs during dependency resolution.
+            lockFileLib.Name = correctedPackageName ?? package.Id;
+            lockFileLib.Version = package.Version;
+
+            var files = package.GetFiles().Select(p => p.Path.Replace(Path.DirectorySeparatorChar, '/')).ToList();
+
+            var contentItems = new ContentItemCollection();
+            contentItems.Load(files);
+
+            IEnumerable<PackageDependencySet> dependencySet;
+            if (VersionUtility.TryGetCompatibleItems(framework, package.DependencySets, out dependencySet))
+            {
+                var set = dependencySet.FirstOrDefault()?.Dependencies?.ToList();
+
+                if (set != null)
+                {
+                    lockFileLib.Dependencies = set;
+                }
+            }
+
+            // TODO: Remove this when we do #596
+            // ASP.NET Core isn't compatible with generic PCL profiles
+            if (!string.Equals(framework.Identifier, VersionUtility.AspNetCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(framework.Identifier, VersionUtility.DnxCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                IEnumerable<FrameworkAssemblyReference> frameworkAssemblies;
+                if (VersionUtility.TryGetCompatibleItems(framework, package.FrameworkAssemblies, out frameworkAssemblies))
+                {
+                    AddFrameworkReferences(lockFileLib, framework, frameworkAssemblies);
+                }
+
+                // Add framework assemblies with empty supported frameworks
+                AddFrameworkReferences(lockFileLib, framework, package.FrameworkAssemblies.Where(f => !f.SupportedFrameworks.Any()));
+            }
+
+            var patterns = new PatternDefinitions();
+
+            var criteriaBuilderWithTfm = new SelectionCriteriaBuilder(patterns.Properties.Definitions);
+            var criteriaBuilderWithoutTfm = new SelectionCriteriaBuilder(patterns.Properties.Definitions);
+
+            if (context.RuntimeSpecs != null)
+            {
+                foreach (var runtimeSpec in context.RuntimeSpecs)
+                {
+                    criteriaBuilderWithTfm = criteriaBuilderWithTfm
+                    .Add["tfm", framework]["rid", runtimeSpec.Name]
+                    .Add["tfm", new FrameworkName("Core", new Version(5, 0))]["rid", runtimeSpec.Name];
+
+                    criteriaBuilderWithoutTfm = criteriaBuilderWithoutTfm
+                        .Add["rid", runtimeSpec.Name];
+                }
+            }
+
+            criteriaBuilderWithTfm = criteriaBuilderWithTfm
+                .Add["tfm", framework]
+                .Add["tfm", new FrameworkName("Core", new Version(5, 0))];
+
+            var criteria = criteriaBuilderWithTfm.Criteria;
+
+            var compileGroup = contentItems.FindBestItemGroup(criteria, patterns.CompileTimeAssemblies, patterns.ManagedAssemblies);
+
+            if (compileGroup != null)
+            {
+                lockFileLib.CompileTimeAssemblies = compileGroup.Items.Select(t => t.Path).ToList();
+            }
+
+            var runtimeGroup = contentItems.FindBestItemGroup(criteria, patterns.ManagedAssemblies);
+            if (runtimeGroup != null)
+            {
+                lockFileLib.RuntimeAssemblies = runtimeGroup.Items.Select(p => p.Path).ToList();
+            }
+
+            var nativeGroup = contentItems.FindBestItemGroup(criteriaBuilderWithoutTfm.Criteria, patterns.NativeLibraries);
+            if (nativeGroup != null)
+            {
+                lockFileLib.NativeLibraries = nativeGroup.Items.Select(p => p.Path).ToList();
+            }
+
+            // COMPAT: Support lib/contract so older packages can be consumed
+            string contractPath = "lib/contract/" + package.Id + ".dll";
+            var hasContract = files.Any(path => path == contractPath);
+            var hasLib = lockFileLib.RuntimeAssemblies.Any();
+
+            if (hasContract && hasLib && !VersionUtility.IsDesktop(framework))
+            {
+                lockFileLib.CompileTimeAssemblies.Clear();
+                lockFileLib.CompileTimeAssemblies.Add(contractPath);
+            }
+
+            return lockFileLib;
+        }
+
+        private static void AddFrameworkReferences(LockFileTargetLibrary lockFileLib, FrameworkName framework, IEnumerable<FrameworkAssemblyReference> frameworkAssemblies)
+        {
+            foreach (var assemblyReference in frameworkAssemblies)
+            {
+                if (!assemblyReference.SupportedFrameworks.Any() &&
+                    !VersionUtility.IsDesktop(framework))
+                {
+                    // REVIEW: This isn't 100% correct since none *can* mean 
+                    // any in theory, but in practice it means .NET full reference assembly
+                    // If there's no supported target frameworks and we're not targeting
+                    // the desktop framework then skip it.
+
+                    // To do this properly we'll need all reference assemblies supported
+                    // by each supported target framework which isn't always available.
+                    continue;
+                }
+
+                lockFileLib.FrameworkAssemblies.Add(assemblyReference);
+            }
         }
 
         private static List<string> GetPackageAssemblies(IPackage package, FrameworkName targetFramework)
@@ -161,6 +223,11 @@ namespace Microsoft.Framework.PackageManager.Utils
             using (var stream = File.OpenRead(assemblyPath))
             using (var peReader = new PEReader(stream))
             {
+                if (!peReader.HasMetadata)
+                {
+                    return false;
+                }
+
                 var mdReader = peReader.GetMetadataReader();
                 var attrs = mdReader.GetAssemblyDefinition().GetCustomAttributes()
                     .Select(ah => mdReader.GetCustomAttribute(ah));
@@ -247,6 +314,262 @@ namespace Microsoft.Framework.PackageManager.Utils
             }
 
             return arguments;
+        }
+
+        public class PropertyDefinitions
+        {
+            public PropertyDefinitions()
+            {
+                Definitions = new Dictionary<string, ContentPropertyDefinition>
+                {
+                    { "language", _language },
+                    { "tfm", _targetFramework },
+                    { "rid", _rid },
+                    { "assembly", _assembly },
+                    { "dynamicLibrary", _dynamicLibrary },
+                    { "resources", _resources },
+                    { "locale", _locale },
+                    { "any", _any },
+                };
+            }
+
+            public IDictionary<string, ContentPropertyDefinition> Definitions { get; }
+
+            ContentPropertyDefinition _language = new ContentPropertyDefinition
+            {
+                Table =
+                {
+                    { "cs", "CSharp" },
+                    { "vb", "Visual Basic" },
+                    { "fs", "FSharp" },
+                }
+            };
+
+            ContentPropertyDefinition _targetFramework = new ContentPropertyDefinition
+            {
+                Table =
+                {
+                    { "any", new FrameworkName("Core", new Version(5, 0)) }
+                },
+                Parser = TargetFrameworkName_Parser,
+                OnIsCriteriaSatisfied = TargetFrameworkName_IsCriteriaSatisfied
+            };
+
+            ContentPropertyDefinition _rid = new ContentPropertyDefinition
+            {
+                Parser = name => name
+            };
+
+            ContentPropertyDefinition _assembly = new ContentPropertyDefinition
+            {
+                FileExtensions = { ".dll" }
+            };
+
+            ContentPropertyDefinition _dynamicLibrary = new ContentPropertyDefinition
+            {
+                FileExtensions = { ".dll", ".dylib", ".so" }
+            };
+
+            ContentPropertyDefinition _resources = new ContentPropertyDefinition
+            {
+                FileExtensions = { ".resources.dll" }
+            };
+
+            ContentPropertyDefinition _locale = new ContentPropertyDefinition
+            {
+                Parser = Locale_Parser,
+            };
+
+            ContentPropertyDefinition _any = new ContentPropertyDefinition
+            {
+                Parser = name => name
+            };
+
+
+            internal static object Locale_Parser(string name)
+            {
+                if (name.Length == 2)
+                {
+                    return name;
+                }
+                else if (name.Length >= 4 && name[2] == '-')
+                {
+                    return name;
+                }
+
+                return null;
+            }
+
+            internal static object TargetFrameworkName_Parser(string name)
+            {
+                var result = VersionUtility.ParseFrameworkName(name);
+
+                if (result != VersionUtility.UnsupportedFrameworkName)
+                {
+                    return result;
+                }
+
+                return new FrameworkName(name, new Version(0, 0));
+            }
+
+            internal static bool TargetFrameworkName_IsCriteriaSatisfied(object criteria, object available)
+            {
+                var criteriaFrameworkName = criteria as FrameworkName;
+                var availableFrameworkName = available as FrameworkName;
+
+                if (criteriaFrameworkName != null && availableFrameworkName != null)
+                {
+                    return VersionUtility.IsCompatible(criteriaFrameworkName, availableFrameworkName);
+                }
+
+                return false;
+            }
+        }
+
+        public class PatternDefinitions
+        {
+            public PropertyDefinitions Properties { get; }
+
+            public ContentPatternDefinition CompileTimeAssemblies { get; }
+            public ContentPatternDefinition ManagedAssemblies { get; }
+            public ContentPatternDefinition NativeLibraries { get; }
+
+            public PatternDefinitions()
+            {
+                Properties = new PropertyDefinitions();
+
+                ManagedAssemblies = new ContentPatternDefinition
+                {
+                    GroupPatterns =
+                    {
+                        "runtimes/{rid}/lib/{tfm}/{any?}",
+                        "lib/{tfm}/{any?}",
+                    },
+                    PathPatterns =
+                    {
+                        "runtimes/{rid}/lib/{tfm}/{assembly}",
+                        "lib/{tfm}/{assembly}",
+                    },
+                    PropertyDefinitions = Properties.Definitions,
+                };
+
+                CompileTimeAssemblies = new ContentPatternDefinition
+                {
+                    GroupPatterns =
+                    {
+                        "ref/{tfm}/{any?}",
+                    },
+                    PathPatterns =
+                    {
+                        "ref/{tfm}/{assembly}",
+                    },
+                    PropertyDefinitions = Properties.Definitions,
+                };
+
+                NativeLibraries = new ContentPatternDefinition
+                {
+                    GroupPatterns =
+                    {
+                        "runtimes/{rid}/native/{any?}",
+                        "native/{any?}",
+                    },
+                    PathPatterns =
+                    {
+                        "runtimes/{rid}/native/{any}",
+                        "native/{any}",
+                    },
+                    PropertyDefinitions = Properties.Definitions,
+                };
+            }
+        }
+
+        private class SelectionCriteriaBuilder
+        {
+            private IDictionary<string, ContentPropertyDefinition> propertyDefinitions;
+
+            public SelectionCriteriaBuilder(IDictionary<string, ContentPropertyDefinition> propertyDefinitions)
+            {
+                this.propertyDefinitions = propertyDefinitions;
+            }
+
+            public virtual SelectionCriteria Criteria { get; } = new SelectionCriteria();
+
+            internal virtual SelectionCriteriaEntryBuilder Add
+            {
+                get
+                {
+                    var entry = new SelectionCriteriaEntry();
+                    Criteria.Entries.Add(entry);
+                    return new SelectionCriteriaEntryBuilder(this, entry);
+                }
+            }
+
+            internal class SelectionCriteriaEntryBuilder : SelectionCriteriaBuilder
+            {
+                public SelectionCriteriaEntry Entry { get; }
+                public SelectionCriteriaBuilder Builder { get; }
+
+                public SelectionCriteriaEntryBuilder(SelectionCriteriaBuilder builder, SelectionCriteriaEntry entry) : base(builder.propertyDefinitions)
+                {
+                    Builder = builder;
+                    Entry = entry;
+                }
+                public SelectionCriteriaEntryBuilder this[string key, string value]
+                {
+                    get
+                    {
+                        ContentPropertyDefinition propertyDefinition;
+                        if (!propertyDefinitions.TryGetValue(key, out propertyDefinition))
+                        {
+                            throw new Exception("Undefined property used for criteria");
+                        }
+                        if (value == null)
+                        {
+                            Entry.Properties[key] = null;
+                        }
+                        else
+                        {
+                            object valueLookup;
+                            if (propertyDefinition.TryLookup(value, out valueLookup))
+                            {
+                                Entry.Properties[key] = valueLookup;
+                            }
+                            else
+                            {
+                                throw new Exception("Undefined value used for criteria");
+                            }
+                        }
+                        return this;
+                    }
+                }
+                public SelectionCriteriaEntryBuilder this[string key, object value]
+                {
+                    get
+                    {
+                        ContentPropertyDefinition propertyDefinition;
+                        if (!propertyDefinitions.TryGetValue(key, out propertyDefinition))
+                        {
+                            throw new Exception("Undefined property used for criteria");
+                        }
+                        Entry.Properties[key] = value;
+                        return this;
+                    }
+                }
+                internal override SelectionCriteriaEntryBuilder Add
+                {
+                    get
+                    {
+                        return Builder.Add;
+                    }
+                }
+                public override SelectionCriteria Criteria
+                {
+                    get
+                    {
+                        return Builder.Criteria;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Framework.Runtime
             return null;
         }
 
-        public void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework)
+        public void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework, string runtimeIdentifier)
         {
             foreach (var d in dependencies)
             {

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/IDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/IDependencyProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.Runtime
     {
         LibraryDescription GetDescription(LibraryRange libraryRange, FrameworkName targetFramework);
 
-        void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework);
+        void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework, string runtimeIdentifier);
 
         IEnumerable<string> GetAttemptedPaths(FrameworkName targetFramework);
     }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFile.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFile.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
     {
         public bool Islocked { get; set; }
         public int Version { get; set; }
-        public IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get; set; } =
-            new List<ProjectFileDependencyGroup>();
+        public IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get; set; } = new List<ProjectFileDependencyGroup>();
         public IList<LockFileLibrary> Libraries { get; set; } = new List<LockFileLibrary>();
+        public IList<LockFileTarget> Targets { get; set; } = new List<LockFileTarget>();
 
         public bool IsValidForProject(Project project)
         {

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileLibrary.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileLibrary.cs
@@ -16,16 +16,25 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
 
         public bool IsServiceable { get; set; }
 
-        public string Sha { get; set; }
-
-        public IList<LockFileFrameworkGroup> FrameworkGroups { get; set; } = new List<LockFileFrameworkGroup>();
+        public string Sha512 { get; set; }
 
         public IList<string> Files { get; set; } = new List<string>();
     }
 
-    public class LockFileFrameworkGroup
+    public class LockFileTarget
     {
         public FrameworkName TargetFramework { get; set; }
+
+        public string RuntimeIdentifier { get; set; }
+
+        public IList<LockFileTargetLibrary> Libraries { get; set; } = new List<LockFileTargetLibrary>();
+    }
+
+    public class LockFileTargetLibrary
+    {
+        public string Name { get; set; }
+
+        public SemanticVersion Version { get; set; }
 
         public IList<PackageDependency> Dependencies { get; set; } = new List<PackageDependency>();
 
@@ -34,5 +43,7 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
         public IList<string> RuntimeAssemblies { get; set; } = new List<string>();
 
         public IList<string> CompileTimeAssemblies { get; set; } = new List<string>();
+
+        public IList<string> NativeLibraries { get; set; } = new List<string>();
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Framework.Runtime
             };
         }
 
-        public virtual void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework)
+        public virtual void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework, string runtimeIdentifier)
         {
             Dependencies = dependencies;
         }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Framework.Runtime
             return null;
         }
 
-        public void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework)
+        public void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework, string runtimeIdentifier)
         {
             foreach (var d in dependencies)
             {

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Framework.Runtime
             };
         }
 
-        public void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework)
+        public void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework, string runtimeIdentifier)
         {
         }
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Framework.Runtime
                     };
                 }).ToList();
 
-                resolver.Initialize(descriptions, frameworkName);
+                resolver.Initialize(descriptions, frameworkName, runtimeIdentifier: null);
                 libraries.AddRange(descriptions);
             }
 

--- a/src/Microsoft.Framework.Runtime/ExportProviders/ProjectExportProviderHelper.cs
+++ b/src/Microsoft.Framework.Runtime/ExportProviders/ProjectExportProviderHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Framework.Runtime
             var sourceReferences = new Dictionary<string, ISourceReference>(StringComparer.OrdinalIgnoreCase);
 
             // Walk the dependency tree and resolve the library export for all references to this project
-            var stack = new Queue<Node>();
+            var queue = new Queue<Node>();
             var processed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             var rootNode = new Node
@@ -52,11 +52,11 @@ namespace Microsoft.Framework.Runtime
                 Library = manager.GetLibraryInformation(target.Name, target.Aspect)
             };
 
-            stack.Enqueue(rootNode);
+            queue.Enqueue(rootNode);
 
-            while (stack.Count > 0)
+            while (queue.Count > 0)
             {
-                var node = stack.Dequeue();
+                var node = queue.Dequeue();
 
                 // Skip it if we've already seen it
                 if (!processed.Add(node.Library.Name))
@@ -93,7 +93,7 @@ namespace Microsoft.Framework.Runtime
                         Parent = node
                     };
 
-                    stack.Enqueue(childNode);
+                    queue.Enqueue(childNode);
                 }
             }
 

--- a/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.xproj
+++ b/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.xproj
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.xproj
+++ b/src/Microsoft.Framework.Runtime/Microsoft.Framework.Runtime.xproj
@@ -13,8 +13,5 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
-  </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
@@ -30,6 +30,8 @@ namespace NuGet
                 caseSensitivePackagesName ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
         }
 
+        public bool CheckHashFile { get; set; }
+
         public IFileSystem RepositoryRoot
         {
             get
@@ -106,7 +108,7 @@ namespace NuGet
                         continue;
                     }
 
-                    if (!_repositoryRoot.GetFiles(versionDir, "*" + Constants.HashFileExtension).Any())
+                    if (CheckHashFile && !_repositoryRoot.GetFiles(versionDir, "*" + Constants.HashFileExtension).Any())
                     {
                         // Writing the marker file is the last operation performed by NuGetPackageUtils.InstallFromStream. We'll use the
                         // presence of the file to denote the package was successfully installed.

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -22,6 +22,7 @@ namespace NuGet
     {
         public static readonly string AspNetCoreFrameworkIdentifier = "Asp.NetCore";
         public static readonly string DnxCoreFrameworkIdentifier = "DNXCore";
+        public static readonly string CoreFrameworkIdentifier = "Core";
 
         internal const string NetFrameworkIdentifier = ".NETFramework";
         private const string NetCoreFrameworkIdentifier = ".NETCore";
@@ -781,7 +782,7 @@ namespace NuGet
         /// </summary>
         /// <param name="frameworkName">The project's framework</param>
         /// <param name="targetFrameworkName">The package's target framework</param>
-        internal static bool IsCompatible(FrameworkName frameworkName, FrameworkName targetFrameworkName)
+        public static bool IsCompatible(FrameworkName frameworkName, FrameworkName targetFrameworkName)
         {
             if (frameworkName == null)
             {
@@ -797,7 +798,7 @@ namespace NuGet
             targetFrameworkName = NormalizeFrameworkName(targetFrameworkName);
             frameworkName = NormalizeFrameworkName(frameworkName);
 
-            check:
+        check:
 
             if (!frameworkName.Identifier.Equals(targetFrameworkName.Identifier, StringComparison.OrdinalIgnoreCase))
             {
@@ -1176,6 +1177,7 @@ namespace NuGet
                 { "asp.net", AspNetFrameworkIdentifier },
                 { "aspnetcore", AspNetCoreFrameworkIdentifier },
                 { "asp.netcore", AspNetCoreFrameworkIdentifier },
+                { "core", CoreFrameworkIdentifier },
 
                 { "NET", NetFrameworkIdentifier },
                 { ".NET", NetFrameworkIdentifier },

--- a/test/Microsoft.Framework.CommonTestUtils/DnuTestUtils.cs
+++ b/test/Microsoft.Framework.CommonTestUtils/DnuTestUtils.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -19,8 +20,20 @@ namespace Microsoft.Framework.PackageManager
                                   IDictionary<string, string> environment = null,
                                   string workingDir = null)
         {
-            string program, commandLine;
-            var runtimeRoot = Directory.EnumerateDirectories(Path.Combine(runtimeHomePath, "runtimes"), Constants.RuntimeNamePrefix + "*").First();
+            string program;
+            string commandLine;
+            string runtimeRoot;
+
+            var dnxDev = Environment.GetEnvironmentVariable("DNX_DEV");
+            if (string.Equals(dnxDev, "1"))
+            {
+                runtimeRoot = runtimeHomePath;
+            }
+            else
+            {
+                runtimeRoot = Directory.EnumerateDirectories(Path.Combine(runtimeHomePath, "runtimes"), Constants.RuntimeNamePrefix + "*").First();
+            }
+
             if (PlatformHelper.IsMono)
             {
                 program = Path.Combine(runtimeRoot, "bin", "dnu");

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
@@ -37,10 +37,14 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         private static readonly string BasicLockFile = @"{
   ""locked"": false,
   ""version"": LOCKFILEFORMAT_VERSION,
-  ""projectFileDependencyGroups"": {
-    """": []
+  ""targets"": {
+    ""DNX,Version=v4.5.1"": {}
   },
-  ""libraries"": {}
+  ""libraries"": {},
+  ""projectFileDependencyGroups"": {
+    """": [],
+    ""DNX,Version=v4.5.1"": []
+  }
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString());
 
         public static IEnumerable<object[]> RuntimeComponents
@@ -131,7 +135,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
   ""publishExclude"": ""**.bconfig"",
-  ""webroot"": ""to_be_overridden""
+  ""webroot"": ""to_be_overridden"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WriteTo(testEnv.ProjectPath);
 
@@ -152,13 +159,19 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
   ""publishExclude"": ""**.bconfig"",
-  ""webroot"": ""../../../wwwroot""
+  ""webroot"": ""../../../wwwroot"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"),
                         BasicLockFile)
                     .WithFileContents(Path.Combine("wwwroot", "project.json"), @"{
   ""publishExclude"": ""**.bconfig"",
-  ""webroot"": ""to_be_overridden""
+  ""webroot"": ""to_be_overridden"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
   ""packages"": ""packages""
@@ -231,7 +244,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
   ""publishExclude"": ""**.useless"",
-  ""webroot"": ""public""
+  ""webroot"": ""public"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WriteTo(testEnv.ProjectPath);
 
@@ -252,7 +268,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
   ""publishExclude"": ""**.useless"",
-  ""webroot"": ""../../../wwwroot""
+  ""webroot"": ""../../../wwwroot"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"),
                         BasicLockFile)
@@ -297,7 +316,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             {
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
-  ""publishExclude"": ""Data/Backup/**""
+  ""publishExclude"": ""Data/Backup/**"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WriteTo(testEnv.ProjectPath);
 
@@ -317,7 +339,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
-  ""publishExclude"": ""Data/Backup/**""
+  ""publishExclude"": ""Data/Backup/**"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"),
                         BasicLockFile)
@@ -380,6 +405,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                 // We need a good strategy to test \\ and / on windows and / on *nix and osx
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  },
   ""publishExclude"": [
     ""FileWithoutExtension"",
     ""UselessFolder1"",
@@ -415,6 +443,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  },
   ""publishExclude"": [
     ""FileWithoutExtension"",
     ""UselessFolder1"",
@@ -495,6 +526,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             {
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  },
   ""publishExclude"": [
     ""UselessFolder1\\**"",
     ""UselessFolder2/**/*"",
@@ -519,6 +553,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  },
   ""publishExclude"": [
     ""UselessFolder1\\**"",
     ""UselessFolder2/**/*"",
@@ -598,6 +635,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             {
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WriteTo(testEnv.ProjectPath);
 
@@ -617,6 +657,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"),
                         BasicLockFile)
@@ -668,6 +711,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             {
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WriteTo(testEnv.ProjectPath);
 
@@ -687,6 +733,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"),
                         BasicLockFile)
@@ -746,7 +795,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             {
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
-  ""webroot"": ""public""
+  ""webroot"": ""public"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("public", "web.config"), originalWebConfigContents)
                     .WriteTo(testEnv.ProjectPath);
@@ -767,7 +819,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
-  ""webroot"": ""../../../wwwroot""
+  ""webroot"": ""../../../wwwroot"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"),
                         BasicLockFile)
@@ -842,7 +897,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             {
                 DirTree.CreateFromJson(projectStructure)
                     .WithFileContents("project.json", @"{
-  ""webroot"": ""../../../wwwroot""
+  ""webroot"": ""../../../wwwroot"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("public", "web.config"), originalWebConfigContents)
                     .WriteTo(testEnv.ProjectPath);
@@ -863,7 +921,10 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
-  ""webroot"": ""../../../wwwroot""
+  ""webroot"": ""../../../wwwroot"",
+  ""frameworks"": {
+    ""dnx451"": {}
+  }
 }")
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"),
                         BasicLockFile)
@@ -941,12 +1002,16 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"), @"{
   ""locked"": false,
   ""version"": LOCKFILEFORMAT_VERSION,
+  ""targets"": {
+    ""DNX,Version=v4.5.1"": {},
+    ""DNXCore,Version=v5.0"": {}
+  },
+  ""libraries"": {},
   ""projectFileDependencyGroups"": {
     """": [],
     ""DNX,Version=v4.5.1"": [],
     ""DNXCore,Version=v5.0"": []
-  },
-  ""libraries"": {}
+  }
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString()))
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
   ""packages"": ""packages""
@@ -1044,13 +1109,17 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.lock.json"), @"{
   ""locked"": false,
   ""version"": LOCKFILEFORMAT_VERSION,
+  ""targets"": {
+    ""RUNTIME_TARGET"": {}
+  },
+  ""libraries"": {},
   ""projectFileDependencyGroups"": {
     """": [],
     ""DNX,Version=v4.5.1"": [],
     ""DNXCore,Version=v5.0"": []
-  },
-  ""libraries"": {}
-}".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString()))
+  }
+}".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString())
+  .Replace("RUNTIME_TARGET", flavor == "coreclr" ? "DNXCore,Version=v5.0" : "DNX,Version=v4.5.1"))
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
   ""packages"": ""packages""
 }")
@@ -1093,33 +1162,27 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             string expectedLockFileContents = @"{
   ""locked"": false,
   ""version"": LOCKFILEFORMAT_VERSION,
-  ""projectFileDependencyGroups"": {
-    ""DNX,Version=v4.5.1"": [],
-    """": [
-      ""NoDependencies >= 1.0.0""
-    ]
+  ""targets"": {
+    ""DNX,Version=v4.5.1"": {
+      ""NoDependencies/1.0.0"": {
+        ""frameworkAssemblies"": [
+          ""mscorlib"",
+          ""System"",
+          ""System.Core"",
+          ""Microsoft.CSharp""
+        ],
+        ""compile"": [
+          ""lib/dnx451/NoDependencies.dll""
+        ],
+        ""runtime"": [
+          ""lib/dnx451/NoDependencies.dll""
+        ]
+      }
+    }
   },
   ""libraries"": {
     ""NoDependencies/1.0.0"": {
-      ""serviceable"": false,
-      ""sha"": ""NUPKG_SHA_VALUE"",
-      ""frameworks"": {
-        ""DNX,Version=v4.5.1"": {
-          ""dependencies"": {},
-          ""frameworkAssemblies"": [
-            ""mscorlib"",
-            ""System"",
-            ""System.Core"",
-            ""Microsoft.CSharp""
-          ],
-          ""runtimeAssemblies"": [
-            ""lib/dnx451/NoDependencies.dll""
-          ],
-          ""compileAssemblies"": [
-            ""lib/dnx451/NoDependencies.dll""
-          ]
-        }
-      },
+      ""sha512"": ""NUPKG_SHA_VALUE"",
       ""files"": [
         ""NoDependencies.1.0.0.nupkg"",
         ""NoDependencies.1.0.0.nupkg.sha512"",
@@ -1132,6 +1195,12 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         ""root/project.json""
       ]
     }
+  },
+  ""projectFileDependencyGroups"": {
+    """": [
+      ""NoDependencies >= 1.0.0""
+    ],
+    ""DNX,Version=v4.5.1"": []
   }
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString());
 
@@ -1196,33 +1265,27 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
             var expectedLockFileContents = @"{
   ""locked"": false,
   ""version"": LOCKFILEFORMAT_VERSION,
-  ""projectFileDependencyGroups"": {
-    ""DNX,Version=v4.5.1"": [],
-    """": [
-      ""NoDependencies >= 1.0.0""
-    ]
+  ""targets"": {
+    ""DNX,Version=v4.5.1"": {
+      ""NoDependencies/1.0.0"": {
+        ""frameworkAssemblies"": [
+          ""mscorlib"",
+          ""System"",
+          ""System.Core"",
+          ""Microsoft.CSharp""
+        ],
+        ""compile"": [
+          ""lib/dnx451/NoDependencies.dll""
+        ],
+        ""runtime"": [
+          ""lib/dnx451/NoDependencies.dll""
+        ]
+      }
+    }
   },
   ""libraries"": {
     ""NoDependencies/1.0.0"": {
-      ""serviceable"": false,
-      ""sha"": ""NUPKG_SHA_VALUE"",
-      ""frameworks"": {
-        ""DNX,Version=v4.5.1"": {
-          ""dependencies"": {},
-          ""frameworkAssemblies"": [
-            ""mscorlib"",
-            ""System"",
-            ""System.Core"",
-            ""Microsoft.CSharp""
-          ],
-          ""runtimeAssemblies"": [
-            ""lib/dnx451/NoDependencies.dll""
-          ],
-          ""compileAssemblies"": [
-            ""lib/dnx451/NoDependencies.dll""
-          ]
-        }
-      },
+      ""sha512"": ""NUPKG_SHA_VALUE"",
       ""files"": [
         ""NoDependencies.1.0.0.nupkg"",
         ""NoDependencies.1.0.0.nupkg.sha512"",
@@ -1233,9 +1296,15 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         ""lib/dnx451/NoDependencies.dll"",
         ""lib/dnx451/NoDependencies.xml"",
         ""root/project.json"",
-        ""root/LOCKFILE_NAME""
+        ""root/project.lock.json""
       ]
     }
+  },
+  ""projectFileDependencyGroups"": {
+    """": [
+      ""NoDependencies >= 1.0.0""
+    ],
+    ""DNX,Version=v4.5.1"": []
   }
 }".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString())
 .Replace("LOCKFILE_NAME", LockFileFormat.LockFileName);

--- a/test/Microsoft.Framework.Runtime.Tests/DependencyWalkerFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/DependencyWalkerFacts.cs
@@ -204,11 +204,11 @@ namespace Loader.Tests
             };
         }
 
-        public void Initialize(IEnumerable<LibraryDescription> packages, FrameworkName frameworkName)
+        public void Initialize(IEnumerable<LibraryDescription> packages, FrameworkName frameworkName, string runtimeIdentifier)
         {
             var d = packages.Select(CreateDependency).ToArray();
 
-            Logger.TraceInformation("StubAssemblyLoader.Initialize {0} {1}", d.Aggregate("", (a, b) => a + " " + b), frameworkName);
+            Logger.TraceInformation("StubAssemblyLoader.Initialize {0} {1} {2}", d.Aggregate("", (a, b) => a + " " + b), frameworkName, runtimeIdentifier);
 
             Dependencies = d;
             FrameworkName = frameworkName;


### PR DESCRIPTION
- Added NuGet conventions for compile (ref), and native.
- Updated to lock file format to take runtime ids into account.
- Made things work end to end with the old runtime and new lock file
- Changed how compiled dependencies work (do it properly). Look at the
closure relative to that project for compilation.
Make publish work with new lock file layout
- Make publish run restore after to generate the correct
lock file.
- Prune package content after creating the final layout with correct
lock file on disk.
- Fix the servicable flag generation.
- Refactored feed options so it could be used outside of command
line arguments.
- Reuse dnu packages add command PublishProject and PublishPackage
- Updated tests


Most of this code is also being moved to NuGet but we need to get enough working so that we can start consuming the new CLR packages. I won't be making any changes to the NuGet/* code unless it's  functional fix as it's temporary.