### PR TITLE
"build dev-install" overwrites existing symbol links

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -1138,11 +1138,11 @@ functions @{
         var sourceRuntime= Path.GetFileName(sourceDir);
         var destinationRuntime= sourceRuntime+ ".1.0.0-dev";
         var destinationDir = Path.Combine(FindRuntimePackagesFolder(), destinationRuntime);
-    
+
+        // Overwrite existing symbol link
         if (Directory.Exists(destinationDir)) 
         {
-            // Nothing to do, just return
-            return;
+            Directory.Delete(destinationDir);
         }
     
         // Trim runtime name prefix part from alias to keep it short


### PR DESCRIPTION
This makes it convenient to switch between different local dnx repos

@davidfowl @victorhurdugaci 