### PR TITLE
Fix "dnu wrap" help information

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -483,9 +483,9 @@ namespace Microsoft.Framework.PackageManager
 
             app.Command("wrap", c =>
             {
-                c.Description = "Wrap a csproj into a project.json, which can be referenced by project.json files";
+                c.Description = "Wrap a csproj/assembly into a project.json, which can be referenced by project.json files";
 
-                var argPath = c.Argument("[path]", "Path to csproj to be wrapped");
+                var argPath = c.Argument("[path]", "Path to csproj/assembly to be wrapped");
                 var optConfiguration = c.Option("--configuration <CONFIGURATION>",
                     "Configuration of wrapped project, default is 'debug'", CommandOptionType.SingleValue);
                 var optMsBuildPath = c.Option("--msbuild <PATH>",


### PR DESCRIPTION
`dnu wrap` can wrap dlls. Fix the help information to make users aware of this.

@davidfowl @muratg 