### PR TITLE
Not everyone has installed bash in /bin

### DIFF
--- a/scripts/dnu.sh
+++ b/scripts/dnu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/scripts/dnx.sh
+++ b/scripts/dnx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink


### PR DESCRIPTION
Some operating systems (like OpenBSD) don't install `bash` in /bin. `env` will use the first occurrence in `PATH`. 