### PR TITLE
Restore performance improvements

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreContext.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Framework.PackageManager
     {
         public RestoreContext()
         {
-            FindLibraryCache = new Dictionary<LibraryRange, Task<GraphItem>>();
+            GraphItemCache = new Dictionary<LibraryRange, Task<GraphItem>>();
+            MatchCache = new Dictionary<LibraryRange, Task<WalkProviderMatch>>();
         }
 
         public FrameworkName FrameworkName { get; set; }
@@ -25,6 +26,7 @@ namespace Microsoft.Framework.PackageManager
         public IList<IWalkProvider> LocalLibraryProviders { get; set; }
         public IList<IWalkProvider> RemoteLibraryProviders { get; set; }
 
-        public Dictionary<LibraryRange, Task<GraphItem>> FindLibraryCache { get; private set; }
+        public Dictionary<LibraryRange, Task<GraphItem>> GraphItemCache { get; private set; }
+        public Dictionary<LibraryRange, Task<WalkProviderMatch>> MatchCache { get; set; }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Framework.PackageManager.Utils
             }
             else
             {
-                lockFileLib.Files = package.GetFiles().Select(p => p.Path.Replace(Path.DirectorySeparatorChar, '/')).ToList();
+                lockFileLib.Files = package.GetFiles().Select(p => p.Path).ToList();
                 var installPath = resolver.GetInstallPath(package.Id, package.Version);
                 foreach (var filePath in lockFileLib.Files)
                 {
@@ -65,9 +65,9 @@ namespace Microsoft.Framework.PackageManager.Utils
             // it has the correct casing that runtime needs during dependency resolution.
             lockFileLib.Name = correctedPackageName ?? package.Id;
             lockFileLib.Version = package.Version;
-
+            var files = library.Files.Select(p => p.Replace(Path.DirectorySeparatorChar, '/'));
             var contentItems = new ContentItemCollection();
-            contentItems.Load(library.Files);
+            contentItems.Load(files);
 
             IEnumerable<PackageDependencySet> dependencySet;
             if (VersionUtility.TryGetCompatibleItems(framework, package.DependencySets, out dependencySet))
@@ -140,7 +140,7 @@ namespace Microsoft.Framework.PackageManager.Utils
 
             // COMPAT: Support lib/contract so older packages can be consumed
             string contractPath = "lib/contract/" + package.Id + ".dll";
-            var hasContract = library.Files.Any(path => path == contractPath);
+            var hasContract = files.Any(path => path == contractPath);
             var hasLib = lockFileLib.RuntimeAssemblies.Any();
 
             if (hasContract && hasLib && !VersionUtility.IsDesktop(framework))

--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Versioning;
-using System.Security.Cryptography;
 using Microsoft.Framework.Runtime.DependencyManagement;
 using NuGet;
 using NuGet.ContentModel;
@@ -15,7 +13,7 @@ namespace Microsoft.Framework.PackageManager.Utils
 {
     internal static class LockFileUtils
     {
-        public static LockFileLibrary CreateLockFileLibrary(IPackagePathResolver resolver, IPackage package, SHA512 sha512, string correctedPackageName = null)
+        public static LockFileLibrary CreateLockFileLibrary(LockFileLibrary previousLibrary, IPackagePathResolver resolver, IPackage package, string correctedPackageName = null)
         {
             var lockFileLib = new LockFileLibrary();
 
@@ -24,34 +22,38 @@ namespace Microsoft.Framework.PackageManager.Utils
             // it has the correct casing that runtime needs during dependency resolution.
             lockFileLib.Name = correctedPackageName ?? package.Id;
             lockFileLib.Version = package.Version;
+            lockFileLib.Sha512 = File.ReadAllText(resolver.GetHashPath(package.Id, package.Version));
 
-            using (var nupkgStream = package.GetStream())
+            // If the shas are equal then do nothing
+            if (previousLibrary?.Sha512 == lockFileLib.Sha512)
             {
-                lockFileLib.Sha512 = Convert.ToBase64String(sha512.ComputeHash(nupkgStream));
+                lockFileLib.Files = previousLibrary.Files;
+                lockFileLib.IsServiceable = previousLibrary.IsServiceable;
             }
-
-            lockFileLib.Files = package.GetFiles().Select(p => p.Path).ToList();
-
-            var installPath = resolver.GetInstallPath(package.Id, package.Version);
-            foreach (var filePath in lockFileLib.Files)
+            else
             {
-                if (!string.Equals(Path.GetExtension(filePath), ".dll"))
+                lockFileLib.Files = package.GetFiles().Select(p => p.Path.Replace(Path.DirectorySeparatorChar, '/')).ToList();
+                var installPath = resolver.GetInstallPath(package.Id, package.Version);
+                foreach (var filePath in lockFileLib.Files)
                 {
-                    continue;
-                }
+                    if (!string.Equals(Path.GetExtension(filePath), ".dll"))
+                    {
+                        continue;
+                    }
 
-                var assemblyPath = Path.Combine(installPath, filePath);
-                if (IsAssemblyServiceable(assemblyPath))
-                {
-                    lockFileLib.IsServiceable = true;
-                    break;
+                    var assemblyPath = Path.Combine(installPath, filePath);
+                    if (IsAssemblyServiceable(assemblyPath))
+                    {
+                        lockFileLib.IsServiceable = true;
+                        break;
+                    }
                 }
             }
 
             return lockFileLib;
         }
 
-        public static LockFileTargetLibrary CreateLockFileTargetLibrary(IPackage package, RestoreContext context, string correctedPackageName)
+        public static LockFileTargetLibrary CreateLockFileTargetLibrary(LockFileLibrary library, IPackage package, RestoreContext context, string correctedPackageName)
         {
             var lockFileLib = new LockFileTargetLibrary();
 
@@ -64,10 +66,8 @@ namespace Microsoft.Framework.PackageManager.Utils
             lockFileLib.Name = correctedPackageName ?? package.Id;
             lockFileLib.Version = package.Version;
 
-            var files = package.GetFiles().Select(p => p.Path.Replace(Path.DirectorySeparatorChar, '/')).ToList();
-
             var contentItems = new ContentItemCollection();
-            contentItems.Load(files);
+            contentItems.Load(library.Files);
 
             IEnumerable<PackageDependencySet> dependencySet;
             if (VersionUtility.TryGetCompatibleItems(framework, package.DependencySets, out dependencySet))
@@ -95,7 +95,7 @@ namespace Microsoft.Framework.PackageManager.Utils
                 AddFrameworkReferences(lockFileLib, framework, package.FrameworkAssemblies.Where(f => !f.SupportedFrameworks.Any()));
             }
 
-            var patterns = new PatternDefinitions();
+            var patterns = PatternDefinitions.DotNetPatterns;
 
             var criteriaBuilderWithTfm = new SelectionCriteriaBuilder(patterns.Properties.Definitions);
             var criteriaBuilderWithoutTfm = new SelectionCriteriaBuilder(patterns.Properties.Definitions);
@@ -140,7 +140,7 @@ namespace Microsoft.Framework.PackageManager.Utils
 
             // COMPAT: Support lib/contract so older packages can be consumed
             string contractPath = "lib/contract/" + package.Id + ".dll";
-            var hasContract = files.Any(path => path == contractPath);
+            var hasContract = library.Files.Any(path => path == contractPath);
             var hasLib = lockFileLib.RuntimeAssemblies.Any();
 
             if (hasContract && hasLib && !VersionUtility.IsDesktop(framework))
@@ -443,6 +443,8 @@ namespace Microsoft.Framework.PackageManager.Utils
 
         public class PatternDefinitions
         {
+            public static PatternDefinitions DotNetPatterns = new PatternDefinitions();
+
             public PropertyDefinitions Properties { get; }
 
             public ContentPatternDefinition CompileTimeAssemblies { get; }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileFormat.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileFormat.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
 
         private JToken WriteFrameworkAssemblyReference(FrameworkAssemblyReference item)
         {
-            return JToken.FromObject(item.AssemblyName);
+            return new JValue(item.AssemblyName);
         }
 
         private PackageReferenceSet ReadPackageReferenceSet(JToken json)


### PR DESCRIPTION
- Cache matches across contexts
- Reuse previous libraries for old lock files if sha didn't change
- Use lock file resolver as local input to speed up
already installed local package walk
- Don't use JToken.FromObject it's slow
- Don't wait for all tasks to complete if there's an
exact match that finished earlier.

/cc @anurse @PradeepKadubandi @pranavkm 