### PR TITLE
Sync the breadcrumbs writer 

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
@@ -11,6 +11,7 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Framework.Runtime.Internal;
 
 namespace Microsoft.Framework.PackageManager.Restore.NuGet
 {

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using Microsoft.Framework.Runtime.Internal;
 using NuGet;
 
 namespace Microsoft.Framework.PackageManager.Restore.NuGet

--- a/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Framework.PackageManager.Publish;
 using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Runtime.Internal;
 using NuGet;
 
 namespace Microsoft.Framework.PackageManager

--- a/src/Microsoft.Framework.Runtime/Internal/ConcurrencyUtilities.cs
+++ b/src/Microsoft.Framework.Runtime/Internal/ConcurrencyUtilities.cs
@@ -6,9 +6,9 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Framework.PackageManager
+namespace Microsoft.Framework.Runtime.Internal
 {
-    internal static class ConcurrencyUtilities
+    public static class ConcurrencyUtilities
     {
         internal static string FilePathToLockName(string filePath)
         {
@@ -19,7 +19,7 @@ namespace Microsoft.Framework.PackageManager
             return filePath.Replace(Path.DirectorySeparatorChar, '_');
         }
 
-        internal async static Task<T> ExecuteWithFileLocked<T>(string filePath, Func<bool, Task<T>> action)
+        public async static Task<T> ExecuteWithFileLocked<T>(string filePath, Func<bool, Task<T>> action)
         {
             var createdNew = false;
             var fileLock = new Semaphore(initialCount: 0, maximumCount: 1, name: FilePathToLockName(filePath),


### PR DESCRIPTION
Fixes: https://github.com/aspnet/dnx/issues/1733 and https://github.com/aspnet/dnx/issues/1771

The root cause is this change: https://github.com/aspnet/dnx/blob/be5bb7b77550bc2297b1827687206341c3fb0ec2/src/Microsoft.Framework.Runtime/ExportProviders/ProjectLibraryExportProvider.cs#L102 . We write the breadcrumbs during the dependency graph walking. That code was called only once before and it happened before breadcrumb writing.

Now that is it called multiple times, it can happen to run at the same time as the breadcrumb writing that that's running on a different thread. 

This change will allow `Add` to be called at anytime and only throw if you try to add a new breadcrumb (one that didn't exists when `write` was called). 

Also, the change includes a lock for multi-process breadcrumb writing. It locks the breadcrumb file and doesn't allow other processes to access it while writing.

Please review: @davidfowl @pranavkm 