### PR TITLE
Use lowercase "id" querystring param when calling FindPackagesById()

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 
                 try
                 {
-                    var uri = _baseUri + "FindPackagesById()?Id='" + id + "'";
+                    var uri = _baseUri + "FindPackagesById()?id='" + id + "'";
                     var results = new List<PackageInfo>();
                     var page = 1;
                     while (true)


### PR DESCRIPTION
The `id` querystring parameter to the `FindPackagesById()` request should be all lower case, as opposed to `Id`.

The [metadata](https://www.nuget.org/api/v2/$metadata) for the nuget feed methods specifies lower case parameters, and requests should follow suit.

Normally, this isn't an issue as NuGet.org (and MyGet I assume) are both _not_ case-sensitive. However, TeamCity running on Linux is, and using `Id` instead of `id` causes a `204 No Content` response, which `dnu` doesn't like at all.

Since the metadata specifies a lower case parameter, this should be adhered to to avoid any possible compatibility issues with custom NuGet package feeds.