### PR TITLE
"dnu restore" invalidates illegal HTTP cache

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
@@ -181,26 +181,35 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
             return result;
         }
 
+        internal async Task InvalidateCacheFileAsync(string cacheKey)
+        {
+            var cacheFile = GetCacheFilePath(cacheKey);
+
+            // Acquire the lock on a file before we delete it to prevent this process
+            // from deleting a file that just passed existence check in some other processes
+            await ConcurrencyUtilities.ExecuteWithFileLocked(cacheFile, async _ =>
+            {
+                if (File.Exists(cacheFile))
+                {
+                    await Task.Factory.StartNew(() => File.Delete(cacheFile));
+                }
+
+                return 0;
+            });
+        }
+
         private async Task<HttpSourceResult> TryCache(string uri, string cacheKey, TimeSpan cacheAgeLimit)
         {
-            var baseFolderName = RemoveInvalidFileNameChars(ComputeHash(_baseUri));
-            var baseFileName = RemoveInvalidFileNameChars(cacheKey) + ".dat";
-
-#if DNX451
-            var localAppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-#else
-            var localAppDataFolder = Environment.GetEnvironmentVariable("LocalAppData");
-#endif
-            var cacheFolder = Path.Combine(localAppDataFolder, "dnu", "cache", baseFolderName);
-            var cacheFile = Path.Combine(cacheFolder, baseFileName);
+            var cacheFile = GetCacheFilePath(cacheKey);
+            var cacheFolder = Path.GetDirectoryName(cacheFile);
 
             if (!Directory.Exists(cacheFolder) && !cacheAgeLimit.Equals(TimeSpan.Zero))
             {
                 Directory.CreateDirectory(cacheFolder);
             }
 
-            // Acquire the lock on a file before we open it to prevent this process
-            // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
+            // Acquire the lock on a file before we open it to prevent this process from opening
+            // a file deleted by HttpSource.GetAsync()/HttpSource.InvalidateCacheFile() in another process
             return await ConcurrencyUtilities.ExecuteWithFileLocked(cacheFile, _ =>
             {
                 if (File.Exists(cacheFile))
@@ -274,6 +283,19 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
             }
 
             return false;
+        }
+
+        private string GetCacheFilePath(string cacheKey)
+        {
+            var baseFolderName = RemoveInvalidFileNameChars(ComputeHash(_baseUri));
+            var baseFileName = RemoveInvalidFileNameChars(cacheKey) + ".dat";
+
+#if DNX451
+            var localAppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+#else
+            var localAppDataFolder = Environment.GetEnvironmentVariable("LocalAppData");
+#endif
+            return Path.Combine(localAppDataFolder, "dnu", "cache", baseFolderName, baseFileName);
         }
 
         private static FileStream CreateAsyncFileStream(string path, FileMode mode, FileAccess access, FileShare share)


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1746

`dnu restore` can now deal with misbehaving NuGet service servers. It will never cache an error page, even the server mistakenly returns the error page along with 200 status code.

@davidfowl @muratg @anurse 