### PR TITLE
Fixing parsing coreclr package version

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -455,20 +455,30 @@ var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPE
     var CoreCLR_DIR='${""}'
     @{
         Func<string, long> getVersion = version => {
-        var dash = version.LastIndexOf('-');
+            var dash = version.LastIndexOf('-');
+            var parsedVersion = Int64.MaxValue;
 
             if(dash != -1)
             {
                 var lastToken = version.Substring(dash + 1);
+                var flag = false;
 
                 if(lastToken.StartsWith("t"))
                 {
-                    return Int64.Parse(lastToken.Substring(1));
+                    flag = Int64.TryParse(lastToken.Substring(1), out parsedVersion);
+                }
+                else
+                {
+                    flag = Int64.TryParse(lastToken, out parsedVersion);
                 }
 
-                return Int64.Parse(lastToken);
+                if(!flag)
+                {
+                    Log.Info(string.Format("Version does not have build number: {0}", version));
+                }
             }
-            return Int64.MaxValue;
+            
+            return parsedVersion;
         };
 
         string packagesDir = Path.Combine(Directory.GetCurrentDirectory(), "packages");


### PR DESCRIPTION
@davidfowl @BrennanConroy 

Issue: When building dnx, the copy-coreclr is trying to extract the version number of the core clr package. It is expecting it to be in the form `X.0.0-pre-buildNumber` and extracting the `buildNumber` value. The current version is `1.0.0-beta4` so this is failing with a parse exception. 

Fix: Adding the `TryParse` to see if it can be parsed., Rest functionality is unchanged

Also the fix needs to be in release since we are merging that again. I'll port it to dev once approved