### PR TITLE
Use RuntimeEnvironment to determine current architecture in tests

### DIFF
--- a/test/Microsoft.Framework.ApplicationHost.FunctionalTests/AppHostTests.cs
+++ b/test/Microsoft.Framework.ApplicationHost.FunctionalTests/AppHostTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Framework.ApplicationHost
 
 Current runtime Target Framework: '{runtimeTargetFramework} ({runtimeTargetFrameworkShortName})'
   Type: {runtimeType}
-  Architecture: {architecture ?? TestUtils.GetCurrentRuntimeArchitecture()}
+  Architecture: {architecture ?? TestUtils.CurrentRuntimeEnvironment.RuntimeArchitecture}
   Version: {TestUtils.GetRuntimeVersion()}
 
 Please make sure the runtime matches a framework specified in {Project.ProjectFileName}";

--- a/test/Microsoft.Framework.CommonTestUtils/TestUtils.cs
+++ b/test/Microsoft.Framework.CommonTestUtils/TestUtils.cs
@@ -9,11 +9,21 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Runtime.Infrastructure;
 
 namespace Microsoft.Framework.CommonTestUtils
 {
     public static class TestUtils
     {
+        public static IRuntimeEnvironment CurrentRuntimeEnvironment
+        {
+            get
+            {
+                return CallContextServiceLocator.Locator.ServiceProvider
+                    .GetService(typeof(IRuntimeEnvironment)) as IRuntimeEnvironment;
+            }
+        }
+
         public static DisposableDir CreateTempDir()
         {
             var tempDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -302,19 +312,6 @@ namespace Microsoft.Framework.CommonTestUtils
             {
                 var sha512Bytes = SHA512.Create().ComputeHash(sourceStream);
                 return Convert.ToBase64String(sha512Bytes);
-            }
-        }
-
-        public static string GetCurrentRuntimeArchitecture()
-        {
-            switch (IntPtr.Size)
-            {
-                case 4:
-                    return "x86";
-                case 8:
-                    return "x64";
-                default:
-                    return "Unknown";
             }
         }
 


### PR DESCRIPTION
Making the code DRYer.

@victorhurdugaci  @BrennanConroy 