### PR TITLE
Work around a Mono issue that makes restore unbearably slow

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -29,6 +29,14 @@ namespace Microsoft.Framework.PackageManager
 #if DNX451
             Thread.GetDomain().SetData(".appDomain", this);
             ServicePointManager.DefaultConnectionLimit = 1024;
+
+            // Work around a Mono issue that makes restore unbearably slow,
+            // due to some form of contention when requests are processed
+            // concurrently. Restoring sequentially is *much* faster in this case.
+            if (PlatformHelper.IsMono)
+            {
+                ServicePointManager.DefaultConnectionLimit = 1;
+            }
 #endif
         }
 


### PR DESCRIPTION
This is due to some form of contention when requests are processed concurrently. Restoring sequentially is *much* faster in this case.

I tested this on a sample project that would take ~70secs to restore before and it now takes 10secs consistently.