### PR TITLE
[Proposal] Check global.json sdk version on startup

### DIFF
--- a/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
@@ -32,11 +32,16 @@ namespace Microsoft.Framework.Runtime
             ProjectDirectory = projectDirectory;
             Configuration = configuration;
             RootDirectory = Runtime.ProjectResolver.ResolveRootDirectory(ProjectDirectory);
-            ProjectResolver = new ProjectResolver(ProjectDirectory, RootDirectory);
+
+            GlobalSettings globalSettings;
+            GlobalSettings.TryGetGlobalSettings(RootDirectory, out globalSettings);
+            GlobalSettings = globalSettings;
+
+            ProjectResolver = new ProjectResolver(ProjectDirectory, globalSettings);
             FrameworkReferenceResolver = new FrameworkReferenceResolver();
             _serviceProvider = new ServiceProvider(serviceProvider);
 
-            PackagesDirectory = packagesDirectory ?? NuGetDependencyResolver.ResolveRepositoryPath(RootDirectory);
+            PackagesDirectory = packagesDirectory ?? NuGetDependencyResolver.ResolveRepositoryPath(globalSettings);
 
             var referenceAssemblyDependencyResolver = new ReferenceAssemblyDependencyResolver(FrameworkReferenceResolver);
             NuGetDependencyProvider = new NuGetDependencyResolver(new PackageRepository(PackagesDirectory));
@@ -165,6 +170,8 @@ namespace Microsoft.Framework.Runtime
         public DependencyWalker DependencyWalker { get; private set; }
 
         public FrameworkReferenceResolver FrameworkReferenceResolver { get; private set; }
+        
+        public GlobalSettings GlobalSettings { get; private set; }
 
         public string Configuration { get; private set; }
 

--- a/src/Microsoft.Framework.Runtime/DefaultHost.cs
+++ b/src/Microsoft.Framework.Runtime/DefaultHost.cs
@@ -137,6 +137,7 @@ Please make sure the runtime matches a framework specified in {Project.ProjectFi
             var cacheContextAccessor = new CacheContextAccessor();
             var cache = new Cache(cacheContextAccessor);
             var namedCacheDependencyProvider = new NamedCacheDependencyProvider();
+            var runtimeEnvironment = (IRuntimeEnvironment)hostServices.GetService(typeof(IRuntimeEnvironment));
 
             _applicationHostContext = new ApplicationHostContext(
                 hostServices,
@@ -151,6 +152,18 @@ Please make sure the runtime matches a framework specified in {Project.ProjectFi
             Logger.TraceInformation("[{0}]: Project path: {1}", GetType().Name, _projectDirectory);
             Logger.TraceInformation("[{0}]: Project root: {1}", GetType().Name, _applicationHostContext.RootDirectory);
             Logger.TraceInformation("[{0}]: Packages path: {1}", GetType().Name, _applicationHostContext.PackagesDirectory);
+            
+            if (_applicationHostContext.GlobalSettings?.SdkVersion != null)
+            {
+                Logger.TraceInformation("[{0}]: Required SDK version {1}", GetType().Name, _applicationHostContext.GlobalSettings.SdkVersion);
+
+                var runtimeVersion = SemanticVersion.Parse(runtimeEnvironment.RuntimeVersion);
+                
+                if (runtimeVersion != _applicationHostContext.GlobalSettings.SdkVersion)
+                {
+                    throw new InvalidOperationException($@"The runtime version specified by '{_applicationHostContext.GlobalSettings.FilePath}' is {_applicationHostContext.GlobalSettings.SdkVersion} but the current runtime version is {runtimeVersion}.");
+                }
+            }
 
             _project = _applicationHostContext.Project;
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -449,6 +449,13 @@ namespace Microsoft.Framework.Runtime
 
         public static string ResolveRepositoryPath(string rootDirectory)
         {
+            GlobalSettings globalSettings;
+            GlobalSettings.TryGetGlobalSettings(rootDirectory, out globalSettings);
+            return ResolveRepositoryPath(globalSettings);
+        }
+
+        internal static string ResolveRepositoryPath(GlobalSettings globalSettings)
+        {
             // Order
             // 1. EnvironmentNames.Packages environment variable
             // 2. global.json { "packages": "..." }
@@ -462,11 +469,9 @@ namespace Microsoft.Framework.Runtime
                 return runtimePackages;
             }
 
-            GlobalSettings settings;
-            if (GlobalSettings.TryGetGlobalSettings(rootDirectory, out settings) &&
-                !string.IsNullOrEmpty(settings.PackagesPath))
+            if (!string.IsNullOrEmpty(globalSettings?.PackagesPath))
             {
-                return Path.Combine(rootDirectory, settings.PackagesPath);
+                return Path.Combine(globalSettings.Directory, globalSettings.PackagesPath);
             }
 
             var profileDirectory = Environment.GetEnvironmentVariable("USERPROFILE");

--- a/src/Microsoft.Framework.Runtime/GlobalSettings.cs
+++ b/src/Microsoft.Framework.Runtime/GlobalSettings.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet;
 
 namespace Microsoft.Framework.Runtime
 {
@@ -15,6 +16,8 @@ namespace Microsoft.Framework.Runtime
         public IList<string> ProjectSearchPaths { get; private set; }
         public string PackagesPath { get; private set; }
         public string FilePath { get; private set; }
+        public string Directory { get; private set; }
+        public SemanticVersion SdkVersion { get; private set; }
 
         public static bool TryGetGlobalSettings(string path, out GlobalSettings globalSettings)
         {
@@ -51,12 +54,21 @@ namespace Microsoft.Framework.Runtime
 
             // TODO: Remove sources
             var projectSearchPaths = settings["projects"] ?? settings["sources"];
+            var sdkValue = settings["sdk"]?["version"]?.Value<string>();
 
             globalSettings.ProjectSearchPaths = projectSearchPaths == null ?
                 new string[] { } :
                 projectSearchPaths.ValueAsArray<string>();
             globalSettings.PackagesPath = settings.Value<string>("packages");
             globalSettings.FilePath = globalJsonPath;
+            globalSettings.Directory = Path.GetDirectoryName(globalJsonPath);
+
+            // If there's an exact version specified, parse it
+            SemanticVersion sdkVersion;
+            if (SemanticVersion.TryParse(sdkValue, out sdkVersion))
+            {
+                globalSettings.SdkVersion = sdkVersion;
+            }
 
             return true;
         }

--- a/src/Microsoft.Framework.Runtime/ProjectResolver.cs
+++ b/src/Microsoft.Framework.Runtime/ProjectResolver.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 
 namespace Microsoft.Framework.Runtime
@@ -17,12 +15,14 @@ namespace Microsoft.Framework.Runtime
         public ProjectResolver(string projectPath)
         {
             var rootPath = ResolveRootDirectory(projectPath);
-            Initialize(projectPath, rootPath);
+            GlobalSettings global;
+            GlobalSettings.TryGetGlobalSettings(rootPath, out global);
+            Initialize(projectPath, global);
         }
 
-        public ProjectResolver(string projectPath, string rootPath)
+        public ProjectResolver(string projectPath, GlobalSettings global)
         {
-            Initialize(projectPath, rootPath);
+            Initialize(projectPath, global);
         }
 
         public IEnumerable<string> SearchPaths
@@ -47,17 +47,15 @@ namespace Microsoft.Framework.Runtime
             return false;
         }
 
-        private void Initialize(string projectPath, string rootPath)
+        private void Initialize(string projectPath, GlobalSettings global)
         {
             _searchPaths.Add(new DirectoryInfo(projectPath).Parent.FullName);
 
-            GlobalSettings global;
-
-            if (GlobalSettings.TryGetGlobalSettings(rootPath, out global))
+            if (global != null)
             {
                 foreach (var sourcePath in global.ProjectSearchPaths)
                 {
-                    _searchPaths.Add(Path.Combine(rootPath, sourcePath));
+                    _searchPaths.Add(Path.Combine(global.Directory, sourcePath));
                 }
             }
 


### PR DESCRIPTION
- If there's a specific version in global.json it must match the runtime version
exactly. Show a nice error message if this isn't the case.

/cc @loudej @glennc @muratg 