### PR TITLE
rename DNX_PACKAGES to NUGET_PACKAGES

### DIFF
--- a/src/Microsoft.Framework.Runtime.Hosting/RuntimeHostBuilder.cs
+++ b/src/Microsoft.Framework.Runtime.Hosting/RuntimeHostBuilder.cs
@@ -112,6 +112,11 @@ namespace Microsoft.Framework.Runtime
 
             var runtimePackages = Environment.GetEnvironmentVariable(EnvironmentNames.Packages);
 
+            if(string.IsNullOrEmpty(runtimePackages))
+            {
+                runtimePackages = Environment.GetEnvironmentVariable(EnvironmentNames.DnxPackages);
+            }
+
             if (!string.IsNullOrEmpty(runtimePackages))
             {
                 return runtimePackages;

--- a/src/Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs
+++ b/src/Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs
@@ -6,7 +6,8 @@ namespace Microsoft.Framework.Runtime
     internal static class EnvironmentNames
     {
         public static readonly string CommonPrefix = Constants.RuntimeShortName.ToUpper() + "_";
-        public static readonly string Packages = CommonPrefix + "PACKAGES";
+        public static readonly string Packages = "NUGET_PACKAGES";
+        public static readonly string DnxPackages = CommonPrefix + "PACKAGES";
         public static readonly string PackagesCache = CommonPrefix + "PACKAGES_CACHE";
         public static readonly string Servicing = CommonPrefix + "SERVICING";
         public static readonly string Trace = CommonPrefix + "TRACE";

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -457,6 +457,11 @@ namespace Microsoft.Framework.Runtime
 
             var runtimePackages = Environment.GetEnvironmentVariable(EnvironmentNames.Packages);
 
+            if(string.IsNullOrEmpty(runtimePackages))
+            {
+                runtimePackages = Environment.GetEnvironmentVariable(EnvironmentNames.DnxPackages);
+            }
+
             if (!string.IsNullOrEmpty(runtimePackages))
             {
                 return runtimePackages;


### PR DESCRIPTION
Renames DNX_PACKAGES to NUGET_PACKAGES, but still supports the old one as a fallback for now.

/cc @yishaigalatzer @davidfowl @emgarten

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/aspnet/dnx/1851)
<!-- Reviewable:end -->
