### PR TITLE
Include System.Runtime.Serialization.Primitives in runtime

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -510,7 +510,8 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
                 {
                     "System.Private.DataContractSerialization.dll",
                     "System.Private.Networking.dll",
-                    "System.Private.ServiceModel.dll"
+                    "System.Private.ServiceModel.dll",
+                    "System.Runtime.Serialization.Primitives.dll"
                 };
 
                 if (target.OS != "win")


### PR DESCRIPTION
Since the removal of `Newtonsoft.Json` dependency, the `System.Runtime.Serialization.Primitives` is not included. 

/cc @davidfowl 