### PR TITLE
Path.Combine throws "Illegal character in path"

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -1049,16 +1049,19 @@ functions @{
             return CXX;
         }
 
-        foreach(var dir in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator))
+        foreach(var dir in Environment.GetEnvironmentVariable("PATH").Split(new string[] { ";" }, StringSplitOptions.None))
         {
-            if (File.Exists(Path.Combine(dir, "clang++")))
-            {
-                return Path.Combine(dir, "clang++");
-            }
-            else if (File.Exists(Path.Combine(dir, "clang++-3.5")))
-            {
-                return Path.Combine(dir, "clang++-3.5");
-            }
+				    try {
+                if (File.Exists(Path.Combine(dir, "clang++")))
+                {
+                    return Path.Combine(dir, "clang++");
+                }
+                else if (File.Exists(Path.Combine(dir, "clang++-3.5")))
+                {
+                    return Path.Combine(dir, "clang++-3.5");
+                }
+				    }
+				    catch (Exception ex) { }
         }
 
         return null;

--- a/makefile.shade
+++ b/makefile.shade
@@ -1051,7 +1051,7 @@ functions @{
 
         foreach(var dir in Environment.GetEnvironmentVariable("PATH").Split(new string[] { ";" }, StringSplitOptions.None))
         {
-				    try {
+            try {
                 if (File.Exists(Path.Combine(dir, "clang++")))
                 {
                     return Path.Combine(dir, "clang++");
@@ -1060,8 +1060,8 @@ functions @{
                 {
                     return Path.Combine(dir, "clang++-3.5");
                 }
-				    }
-				    catch (Exception ex) { }
+            }
+            catch (Exception ex) { }
         }
 
         return null;


### PR DESCRIPTION
The makefile.shade did throw "Illegal character in path", I assume because there's a path with quotes around.