### PR TITLE
Enabling STL in dnx.dll

### DIFF
--- a/DNX.sln
+++ b/DNX.sln
@@ -64,7 +64,7 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Runtime
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Runtime.FunctionalTests", "test\Microsoft.Framework.Runtime.FunctionalTests\Microsoft.Framework.Runtime.FunctionalTests.xproj", "{5DCA7A59-3B5E-4751-A563-B78201F97AE3}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dnx", "src\dnx\dnx.vcxproj", "{D0E2FB09-0FEA-478A-9068-D6AA420C6DED}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dnx.win32", "src\dnx\dnx.vcxproj", "{D0E2FB09-0FEA-478A-9068-D6AA420C6DED}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dnx.clr", "src\dnx.clr\dnx.clr.vcxproj", "{0E4CB542-5E58-4D24-9CAE-DAC83D932DBE}"
 EndProject
@@ -99,6 +99,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Runtime.Compilation.DesignTime", "src\Microsoft.Framework.Runtime.Compilation.DesignTime\Microsoft.Framework.Runtime.Compilation.DesignTime.xproj", "{19D39312-A4A4-449D-B53F-653F951A11F8}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dnx.host.Tests", "test\dnx.host.Tests\dnx.host.Tests.xproj", "{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dnx.windows", "src\dnx.windows\dnx.windows.vcxproj", "{893A7304-50DB-4053-B864-E10BA3FFAC53}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -726,6 +728,24 @@ Global
 		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|x64.Build.0 = Release|Any CPU
 		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|x86.ActiveCfg = Release|Any CPU
 		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2}.Release|x86.Build.0 = Release|Any CPU
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|Win32.ActiveCfg = Debug|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|Win32.Build.0 = Debug|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|x64.ActiveCfg = Debug|x64
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|x64.Build.0 = Debug|x64
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|x86.ActiveCfg = Debug|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Debug|x86.Build.0 = Debug|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|Any CPU.ActiveCfg = Release|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|Win32.ActiveCfg = Release|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|Win32.Build.0 = Release|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|x64.ActiveCfg = Release|x64
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|x64.Build.0 = Release|x64
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|x86.ActiveCfg = Release|Win32
+		{893A7304-50DB-4053-B864-E10BA3FFAC53}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -770,5 +790,6 @@ Global
 		{333205C2-BE8B-4258-BEA4-4C68D9340986} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 		{19D39312-A4A4-449D-B53F-653F951A11F8} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 		{6F59A0B7-745D-4ADA-A913-6A1AD1AB49C2} = {C43EE429-DE10-4906-BB09-54E6A080948A}
+		{893A7304-50DB-4053-B864-E10BA3FFAC53} = {13ED5001-B871-4BC3-8499-29607F596C7C}
 	EndGlobalSection
 EndGlobal

--- a/build/Dnx.Native.Settings
+++ b/build/Dnx.Native.Settings
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'Win32'">
-    <SDKSubFolder>i386</SDKSubFolder>
+    <LibraryPath Condition="'$(BuildForOneCore)'=='True'">$(VCInstallDir)lib\onecore;$(UniversalCRT_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
-    <SDKSubFolder>amd64</SDKSubFolder>
+    <LibraryPath Condition="'$(BuildForOneCore)'=='True'">$(VCInstallDir)lib\onecore\amd64;$(UniversalCRT_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
   </PropertyGroup>    
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -31,16 +28,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  
-  <ItemDefinitionGroup Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">
-    <ClCompile>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-    </ClCompile>
-    <Link>
-      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
-      <AdditionalDependencies>$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\$(SDKSubFolder)\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\$(SDKSubFolder)\msvcrt.lib</AdditionalDependencies>   
-    </Link>
-  </ItemDefinitionGroup>
 
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
@@ -60,7 +47,29 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
-  </ItemDefinitionGroup> 
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' And $(BuildForOneCore)=='True'">
+    <ClCompile>
+      <!--WINAPI_FAMILY=WINAPI_FAMILY_SERVER; commented due to a bug in Windows SDK that should be fixed by VS 2015 RTM-->
+      <PreprocessorDefinitions><!--WINAPI_FAMILY=WINAPI_FAMILY_SERVER;-->%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+      <AdditionalDependencies>onecore.lib;vcruntimed.lib;ucrtd.lib;msvcrtd.lib;libcpmtd.lib;</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' And $(BuildForOneCore)=='True'">
+    <ClCompile>
+      <!--WINAPI_FAMILY=WINAPI_FAMILY_SERVER; commented due to a bug in Windows SDK that should be fixed by VS 2015 RTM-->
+      <PreprocessorDefinitions><!-- WINAPI_FAMILY=WINAPI_FAMILY_SERVER;-->%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+      <AdditionalDependencies>onecore.lib;vcruntime.lib;ucrt.lib;msvcrt.lib;libcpmt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -85,4 +94,5 @@
       <PreprocessorDefinitions>_WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
+
 </Project>

--- a/build/Dnx.Native.Settings
+++ b/build/Dnx.Native.Settings
@@ -79,7 +79,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>AMD64;_WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 
@@ -91,7 +91,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>AMD64;_WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 

--- a/makefile.shade
+++ b/makefile.shade
@@ -61,7 +61,7 @@ var BOOTSTRAPPER_HOST_NAME = 'dnx.host'
 var PROGRAM_FILES_X86 = '${Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}'
 var MSBUILD = '${Path.Combine(PROGRAM_FILES_X86, "MSBuild", "14.0", "Bin", "MSBuild.exe")}'
 var VS_REDIST_ROOT = '${Path.Combine(PROGRAM_FILES_X86, @"Microsoft Visual Studio 14.0\VC\redist")}'
-var WIN10_SDK = '${Path.Combine(PROGRAM_FILES_X86, @"Windows Kits\10")}'
+var WIN10_SDK_LIB = '${Path.Combine(PROGRAM_FILES_X86, @"Windows Kits\10\Lib")}'
 var CLANG = '${SearchForClang()}'
 
 var MANAGED_PROJECTS = '${FindAllProjects(
@@ -89,6 +89,8 @@ var WIN_MANAGED_PROJECTS = '${FindAllProjects(
 var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_FOLDER_NAME, BOOTSTRAPPER_CLR_NAME, BOOTSTRAPPER_CORECLR_NAME)}'
 
 var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
+
+var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles(WIN10_SDK_LIB, "onecore.lib", SearchOption.AllDirectories).Any()}'
 
 @{
     // Always build mono
@@ -239,7 +241,7 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
         Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=False");
         Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=False");
 
-        if(Directory.GetFiles(Path.Combine(WIN10_SDK, "Lib"), "onecore.lib", SearchOption.AllDirectories).Any())
+        if(CAN_BUILD_ONECORE)
         {
             Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=True");
             Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=True");
@@ -259,16 +261,18 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
     var bootstrapperCoreClrProj = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_CORECLR_NAME, BOOTSTRAPPER_CORECLR_NAME + ".vcxproj")}'
 
     @{
-        var environmentRuntimeTargetOS = Environment.GetEnvironmentVariable("RUNTIME_TARGET_OS");
-        var configRuntimeTargetOS = "";
-        
-        if (environmentRuntimeTargetOS == "WIN7_PLUS_CORESYSTEM")
-        {
-            configRuntimeTargetOS = ";RuntimeTargetOS=WIN7_PLUS_CORESYSTEM";
-        }
+        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;BuildForOneCore=False");
+        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;BuildForOneCore=False");
 
-        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32" + configRuntimeTargetOS);
-        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=x64" + configRuntimeTargetOS);
+        if(CAN_BUILD_ONECORE)
+        {
+            Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;BuildForOneCore=True");
+            Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;BuildForOneCore=True");
+        }
+        else
+        {
+            Log.Warn("Windows 10 SDK not installed. Building for One Core skipped.");
+        }
     }
 
     directory delete='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME)}'

--- a/makefile.shade
+++ b/makefile.shade
@@ -49,6 +49,7 @@ var ALL_TARGETS = '${RUNTIME_CLR_TARGETS.Concat(RUNTIME_CORECLR_TARGETS)}'
 
 var RUNTIME_COMMON_NAME = 'DNX'
 var BOOTSTRAPPER_EXE_NAME = 'dnx'
+var BOOTSTRAPPER_DLL_NAME = 'dnx.bootstrapper'
 var BOOTSTRAPPER_CLR_NAME = 'dnx.clr'
 var BOOTSTRAPPER_CORECLR_NAME = 'dnx.coreclr'
 var BOOTSTRAPPER_CLR_MANAGED_NAME = '${BOOTSTRAPPER_CLR_NAME + ".managed"}'
@@ -82,7 +83,7 @@ var MANAGED_PROJECTS = '${FindAllProjects(
 var WIN_MANAGED_PROJECTS = '${FindAllProjects(
     BOOTSTRAPPER_CLR_MANAGED_NAME)}'
 
-var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPER_CLR_NAME, BOOTSTRAPPER_CORECLR_NAME)}'
+var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_DLL_NAME, BOOTSTRAPPER_CLR_NAME, BOOTSTRAPPER_CORECLR_NAME)}'
 
 var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
 
@@ -206,8 +207,30 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
         }
     }
 
-#build-dnx-win .ensure-msbuild .update-rc-files target='build-windows'
-    var bootstrapperProj = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPER_EXE_NAME + ".vcxproj")}'
+#build-dnx-win-exe .ensure-msbuild .update-rc-files target='build-windows'
+    var bootstrapperProj = '${Path.Combine(ROOT, @"src\dnx.windows\dnx.windows.vcxproj")}'
+    @{   
+        var environmentRuntimeTargetOS = Environment.GetEnvironmentVariable("RUNTIME_TARGET_OS");
+        var configRuntimeTargetOS = "";
+        
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnx451;RuntimeType=CLR");
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnx451;RuntimeType=CLR");
+
+        if (environmentRuntimeTargetOS == "WIN7_PLUS_CORESYSTEM")
+        {
+            configRuntimeTargetOS = ";RuntimeTargetOS=WIN7_PLUS_CORESYSTEM";
+        }
+            
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN" + configRuntimeTargetOS);
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN" + configRuntimeTargetOS);
+    }
+
+    directory delete='${Path.Combine(BUILD_DIR2, "dnx.windows")}'
+    copy sourceDir='${Path.Combine(ROOT, @"src\dnx.windows")}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, "dnx.windows")}' overwrite='${true}'
+
+
+#build-dnx-win-dll .ensure-msbuild .update-rc-files target='build-windows'
+    var bootstrapperProj = '${Path.Combine(ROOT, @"src\dnx\dnx.vcxproj")}'
     @{
         var environmentRuntimeTargetOS = Environment.GetEnvironmentVariable("RUNTIME_TARGET_OS");
         var configRuntimeTargetOS = "";
@@ -225,7 +248,7 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
     }
 
     directory delete='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME)}'
-    copy sourceDir='${Path.Combine(ROOT, "src", BOOTSTRAPPER_EXE_NAME)}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME)}' overwrite='${true}'
+    copy sourceDir='${Path.Combine(ROOT, @"src\dnx")}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, "dnx")}' overwrite='${true}'
 
 #build-dnx-coreclr-win-bootstrapper .ensure-msbuild .update-tpa .update-rc-files target='build-windows'
     var bootstrapperCoreClrProj = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_CORECLR_NAME, BOOTSTRAPPER_CORECLR_NAME + ".vcxproj")}'
@@ -662,24 +685,28 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
 
 #copy-windows-bits target='package-windows'
     -// Runtime for clr-win-x86
-    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "Win32", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "Win32", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "Win32", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.pdb' overwrite='${true}'
     copy sourceDir='${Path.Combine(ROOT, "src", BOOTSTRAPPER_CLR_MANAGED_NAME)}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.config' overwrite='${true}'
 
     -// Runtime for clr-win-x64
-    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "x64", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "x64", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "x64", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.pdb' overwrite='${true}'
     copy sourceDir='${Path.Combine(ROOT, "src", BOOTSTRAPPER_CLR_MANAGED_NAME)}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.config' overwrite='${true}'
 
     -// Runtime for coreclr-win-x86
-    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "Win32", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "Win32", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "Win32", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.pdb' overwrite='${true}'
 
     -// Runtime for coreclr-win-x64
-    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "x64", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "x64", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "x64", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.pdb' overwrite='${true}'
 

--- a/makefile.shade
+++ b/makefile.shade
@@ -48,8 +48,9 @@ var RUNTIME_CORECLR_TARGETS = '${new [] {RUNTIME_CORECLR_WIN_x86_BIN, RUNTIME_CO
 var ALL_TARGETS = '${RUNTIME_CLR_TARGETS.Concat(RUNTIME_CORECLR_TARGETS)}'
 
 var RUNTIME_COMMON_NAME = 'DNX'
+var BOOTSTRAPPER_FOLDER_NAME = 'dnx'
 var BOOTSTRAPPER_EXE_NAME = 'dnx'
-var BOOTSTRAPPER_DLL_NAME = 'dnx.bootstrapper'
+var BOOTSTRAPPER_WINDOWS_FOLDER_NAME="dnx.windows"
 var BOOTSTRAPPER_CLR_NAME = 'dnx.clr'
 var BOOTSTRAPPER_CORECLR_NAME = 'dnx.coreclr'
 var BOOTSTRAPPER_CLR_MANAGED_NAME = '${BOOTSTRAPPER_CLR_NAME + ".managed"}'
@@ -59,6 +60,8 @@ var BOOTSTRAPPER_HOST_NAME = 'dnx.host'
 
 var PROGRAM_FILES_X86 = '${Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}'
 var MSBUILD = '${Path.Combine(PROGRAM_FILES_X86, "MSBuild", "14.0", "Bin", "MSBuild.exe")}'
+var VS_REDIST_ROOT = '${Path.Combine(PROGRAM_FILES_X86, @"Microsoft Visual Studio 14.0\VC\redist")}'
+var WIN10_SDK = '${Path.Combine(PROGRAM_FILES_X86, @"Windows Kits\10")}'
 var CLANG = '${SearchForClang()}'
 
 var MANAGED_PROJECTS = '${FindAllProjects(
@@ -83,7 +86,7 @@ var MANAGED_PROJECTS = '${FindAllProjects(
 var WIN_MANAGED_PROJECTS = '${FindAllProjects(
     BOOTSTRAPPER_CLR_MANAGED_NAME)}'
 
-var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_DLL_NAME, BOOTSTRAPPER_CLR_NAME, BOOTSTRAPPER_CORECLR_NAME)}'
+var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_FOLDER_NAME, BOOTSTRAPPER_CLR_NAME, BOOTSTRAPPER_CORECLR_NAME)}'
 
 var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
 
@@ -208,29 +211,7 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
     }
 
 #build-dnx-win-exe .ensure-msbuild .update-rc-files target='build-windows'
-    var bootstrapperProj = '${Path.Combine(ROOT, @"src\dnx.windows\dnx.windows.vcxproj")}'
-    @{   
-        var environmentRuntimeTargetOS = Environment.GetEnvironmentVariable("RUNTIME_TARGET_OS");
-        var configRuntimeTargetOS = "";
-        
-        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnx451;RuntimeType=CLR");
-        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnx451;RuntimeType=CLR");
-
-        if (environmentRuntimeTargetOS == "WIN7_PLUS_CORESYSTEM")
-        {
-            configRuntimeTargetOS = ";RuntimeTargetOS=WIN7_PLUS_CORESYSTEM";
-        }
-            
-        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN" + configRuntimeTargetOS);
-        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN" + configRuntimeTargetOS);
-    }
-
-    directory delete='${Path.Combine(BUILD_DIR2, "dnx.windows")}'
-    copy sourceDir='${Path.Combine(ROOT, @"src\dnx.windows")}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, "dnx.windows")}' overwrite='${true}'
-
-
-#build-dnx-win-dll .ensure-msbuild .update-rc-files target='build-windows'
-    var bootstrapperProj = '${Path.Combine(ROOT, @"src\dnx\dnx.vcxproj")}'
+    var bootstrapperProj = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_WINDOWS_FOLDER_NAME, "dnx.windows.vcxproj")}'
     @{
         var environmentRuntimeTargetOS = Environment.GetEnvironmentVariable("RUNTIME_TARGET_OS");
         var configRuntimeTargetOS = "";
@@ -247,8 +228,32 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
         Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN" + configRuntimeTargetOS);
     }
 
-    directory delete='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME)}'
-    copy sourceDir='${Path.Combine(ROOT, @"src\dnx")}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, "dnx")}' overwrite='${true}'
+    directory delete='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_WINDOWS_FOLDER_NAME)}'
+    copy sourceDir='${Path.Combine(ROOT, "src", BOOTSTRAPPER_WINDOWS_FOLDER_NAME)}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_WINDOWS_FOLDER_NAME)}' overwrite='${true}'
+
+#build-dnx-win-dll .ensure-msbuild .update-rc-files target='build-windows'
+    var bootstrapperProj = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_FOLDER_NAME, "dnx.vcxproj")}'
+    @{
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=False");
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=False");
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=False");
+        Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=False");
+
+        if(Directory.GetFiles(Path.Combine(WIN10_SDK, "Lib"), "onecore.lib", SearchOption.AllDirectories).Any())
+        {
+            Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=True");
+            Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=True");
+            Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=True");
+            Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=True");
+        }
+        else
+        {
+            Log.Warn("Windows 10 SDK not installed. Building for One Core skipped.");
+        }
+    }
+
+    directory delete='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME)}'
+    copy sourceDir='${Path.Combine(ROOT, "src", BOOTSTRAPPER_FOLDER_NAME)}' include='bin/**/' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME)}' overwrite='${true}'
 
 #build-dnx-coreclr-win-bootstrapper .ensure-msbuild .update-tpa .update-rc-files target='build-windows'
     var bootstrapperCoreClrProj = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_CORECLR_NAME, BOOTSTRAPPER_CORECLR_NAME + ".vcxproj")}'
@@ -323,15 +328,15 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
     copy sourceDir='${soOutputDir}' include='*.so' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME + ".unix")}' overwrite='${true}'
 
 #build-dnx-linux-bootstrapper .ensure-clang target='build-linux'
-    var soOutputDir = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_EXE_NAME, "bin", "x64")}'
+    var soOutputDir = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_FOLDER_NAME, "bin", "x64")}'
     var soOutputPath = '${Path.Combine(soOutputDir, BOOTSTRAPPER_EXE_NAME)}'
     @{
         var sourceFiles = new string[] 
         {
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPER_EXE_NAME + ".cpp"),
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, "pal.unix.cpp"),
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, "pal.linux.cpp"),
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, "tchar.cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, BOOTSTRAPPER_EXE_NAME + ".cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.unix.cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.linux.cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "tchar.cpp"),
         };
 
         Directory.CreateDirectory(soOutputDir);
@@ -339,7 +344,7 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
         Exec(CLANG, string.Format("{0} -g -o {1} -DCORECLR_LINUX -DPLATFORM_UNIX -std=c++11 -ldl", string.Join(" ", sourceFiles), soOutputPath));
     }
 
-    copy sourceDir='${soOutputDir}' include='*' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "linux", "x64")}' overwrite='${true}'
+    copy sourceDir='${soOutputDir}' include='*' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "linux", "x64")}' overwrite='${true}'
 
 
 - // ===================== DARWIN (OSX) ===================== 
@@ -362,15 +367,15 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
     copy sourceDir='${soOutputDir}' include='*.dylib' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME + ".unix")}' overwrite='${true}'
 
 #build-dnx-darwin-bootstrapper .ensure-clang target='build-darwin'
-    var soOutputDir = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_EXE_NAME, "bin", "x64")}'
+    var soOutputDir = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_FOLDER_NAME, "bin", "x64")}'
     var soOutputPath = '${Path.Combine(soOutputDir, BOOTSTRAPPER_EXE_NAME)}'
     @{
         var sourceFiles = new string[]
         {
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPER_EXE_NAME + ".cpp"),
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, "pal.unix.cpp"),
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, "pal.darwin.cpp"),
-            Path.Combine("src", BOOTSTRAPPER_EXE_NAME, "tchar.cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, BOOTSTRAPPER_EXE_NAME + ".cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.unix.cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.darwin.cpp"),
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "tchar.cpp"),
         };
 
         Directory.CreateDirectory(soOutputDir);
@@ -378,7 +383,7 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
         Exec(CLANG, string.Format("{0} -g -o {1} -DCORECLR_DARWIN -DPLATFORM_UNIX -std=c++11 -ldl", string.Join(" ", sourceFiles), soOutputPath));
     }
 
-    copy sourceDir='${soOutputDir}' include='*' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "darwin", "x64")}' overwrite='${true}'
+    copy sourceDir='${soOutputDir}' include='*' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "darwin", "x64")}' overwrite='${true}'
 
 - // ===================== PACKAGE ===================== 
 
@@ -683,32 +688,36 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
         }
     }
 
-#copy-windows-bits target='package-windows'
+#copy-windows-bits .ensure-vs-redist target='package-windows'
     -// Runtime for clr-win-x86
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "Win32", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "Win32", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "Win32", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_WINDOWS_FOLDER_NAME, "bin", "Win32", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.pdb' overwrite='${true}'
     copy sourceDir='${Path.Combine(ROOT, "src", BOOTSTRAPPER_CLR_MANAGED_NAME)}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='*.config' overwrite='${true}'
 
     -// Runtime for clr-win-x64
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "x64", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "x64", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "x64", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_WINDOWS_FOLDER_NAME, "bin", "x64", Configuration2, "dnx451")}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.pdb' overwrite='${true}'
     copy sourceDir='${Path.Combine(ROOT, "src", BOOTSTRAPPER_CLR_MANAGED_NAME)}' outputDir='${RUNTIME_CLR_WIN_x64_BIN}' include='*.config' overwrite='${true}'
 
     -// Runtime for coreclr-win-x86
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "Win32", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "Win32", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "Win32", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_WINDOWS_FOLDER_NAME, "bin", "Win32", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "Win32", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x86_BIN}' include='*.pdb' overwrite='${true}'
+    -// Since we can't build debug versions of some native binaries for CoreClr/OneCore we only copy ret version of vcruntime dll
+    copy sourceDir='${Path.Combine(VS_REDIST_ROOT, @"onecore\x86\Microsoft.VC140.CRT")}' outputDir='${RUNTIME_CLR_WIN_x86_BIN}' include='vcruntime140.dll' overwrite='${true}' if='Configuration2 == "Release"'
 
     -// Runtime for coreclr-win-x64
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx", "bin", "x64", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, "dnx.windows", "bin", "x64", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "x64", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_WINDOWS_FOLDER_NAME, "bin", "x64", Configuration2, "dnxcore50")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.exe' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.dll' overwrite='${true}'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME, "bin", "x64", Configuration2)}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='*.pdb' overwrite='${true}'
+    -// Since we can't build debug versions of some native binaries for CoreClr/OneCore we only copy ret version of vcruntime dll
+    copy sourceDir='${Path.Combine(VS_REDIST_ROOT, @"onecore\x64\Microsoft.VC140.CRT")}' outputDir='${RUNTIME_CORECLR_WIN_x64_BIN}' include='vcruntime140.dll' overwrite='${true}' if='Configuration2 == "Release"'
 
     -// Copy cmd files
     copy sourceDir='${SCRIPTS_DIR}' include='*.cmd' exclude='k-crossgen.cmd' overwrite='${true}' each='var outputDir in new[]{ RUNTIME_CLR_WIN_x86_BIN, RUNTIME_CLR_WIN_x64_BIN}'
@@ -716,7 +725,7 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
 
 #copy-linux-bits target='package-linux'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME + ".unix")}' include='*.so' outputDir='${RUNTIME_CORECLR_LINUX_x64_BIN}' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "linux", "x64")}' include='dnx' outputDir='${RUNTIME_CORECLR_LINUX_x64_BIN}' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "linux", "x64")}' include='dnx' outputDir='${RUNTIME_CORECLR_LINUX_x64_BIN}' overwrite='${true}'
     copy sourceDir='${SCRIPTS_DIR}' include='dnu.sh' outputDir='${RUNTIME_CORECLR_LINUX_x64_BIN}' overwrite='${true}'
     @{
         FixShFiles(RUNTIME_CORECLR_LINUX_x64_BIN);
@@ -746,7 +755,7 @@ var CI_LINUX_DROP_PATH = '${Environment.GetEnvironmentVariable("CI_LINUX_DROP_PA
 
 #copy-darwin-bits target='package-darwin'
     copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME + ".unix")}' include='*.dylib' outputDir='${RUNTIME_CORECLR_DARWIN_x64_BIN}' overwrite='${true}'
-    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_EXE_NAME, "bin", "darwin", "x64")}' include='dnx' outputDir='${RUNTIME_CORECLR_DARWIN_x64_BIN}' overwrite='${true}'
+    copy sourceDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "darwin", "x64")}' include='dnx' outputDir='${RUNTIME_CORECLR_DARWIN_x64_BIN}' overwrite='${true}'
     copy sourceDir='${SCRIPTS_DIR}' include='dnu.sh' outputDir='${RUNTIME_CORECLR_DARWIN_x64_BIN}' overwrite='${true}'
     @{
         FixShFiles(RUNTIME_CORECLR_DARWIN_x64_BIN);
@@ -995,6 +1004,15 @@ macro name='DoRestore'
         if (!File.Exists(MSBUILD))
         {
             Log.Warn("msbuild version 14 not found. Please ensure you have the VS 2015 C++ SDK installed.");
+            Environment.Exit(1);
+        }
+    }
+
+#ensure-vs-redist
+    @{
+        if (!Directory.Exists(VS_REDIST_ROOT))
+        {
+            Log.Warn("Visual Studio C++ Redistributable not found. Please ensure you have the VS 2015 C++ SDK installed.");
             Environment.Exit(1);
         }
     }

--- a/src/dnx.coreclr/dllmain.cpp
+++ b/src/dnx.coreclr/dllmain.cpp
@@ -3,10 +3,9 @@
 
 #include "stdafx.h"
 
-BOOL APIENTRY DllMain( HMODULE hModule,
+BOOL APIENTRY DllMain( HMODULE /* hModule */,
                       DWORD  ul_reason_for_call,
-                      LPVOID lpReserved
-                      )
+                      LPVOID /* lpReserved */)
 {
     switch (ul_reason_for_call)
     {

--- a/src/dnx.coreclr/dnx.coreclr.cpp
+++ b/src/dnx.coreclr/dnx.coreclr.cpp
@@ -260,7 +260,6 @@ bool Win32KDisable()
     bool fSuccess = true;
     TCHAR szWin32KDisable[2] = {};
     LPWSTR lpwszModuleFileName = L"api-ms-win-core-processthreads-l1-1-1.dll";
-    DWORD dwModuleFileName = 0;
     HMODULE hProcessThreadsModule = nullptr;
     // Note: Need to keep as ASCII as GetProcAddress function takes ASCII params
     LPCSTR pszSetProcessMitigationPolicy = "SetProcessMitigationPolicy";
@@ -322,7 +321,7 @@ Finished:
     return fSuccess;
 }
 
-extern "C" __declspec(dllexport) HRESULT __stdcall CallApplicationMain(PCALL_APPLICATION_MAIN_DATA data)
+extern "C" HRESULT __stdcall CallApplicationMain(PCALL_APPLICATION_MAIN_DATA data)
 {
     HRESULT hr = S_OK;
     errno_t errno = 0;

--- a/src/dnx.coreclr/dnx.coreclr.vcxproj
+++ b/src/dnx.coreclr/dnx.coreclr.vcxproj
@@ -1,180 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Config.Definitions.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1F31D08E-DE21-48F6-ADE3-315EA6268DD1}</ProjectGuid>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
     <Keyword>Win32Proj</Keyword>
+    <BuildForOneCore Condition="'$(BuildForOneCore)' == ''">False</BuildForOneCore>
     <RootNamespace>KSys</RootNamespace>
-    <ProjectName>dnx.coreclr</ProjectName>
+    <ProjectName>dnx.win32.coreclr</ProjectName>
+    <ProjectName Condition="'$(BuildForOneCore)' == 'True'">dnx.onecore.coreclr</ProjectName>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
+    <IntDir>bin\$(ProjectName)\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Dnx.Native.Settings" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PreprocessorDefinitions>_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Subsystem>Windows</Subsystem>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
     </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>AMD64;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
-    </Link>
-    <ProjectReference>
-      <LinkLibraryDependencies>false</LinkLibraryDependencies>
-    </ProjectReference>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>AMD64;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
-    </Link>
-    <ProjectReference>
-      <LinkLibraryDependencies>false</LinkLibraryDependencies>
-    </ProjectReference>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
@@ -184,25 +39,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dnx.coreclr.cpp" />
-    <ClCompile Include="dllmain.cpp">
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </PrecompiledHeader>
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-      </PrecompiledHeader>
-    </ClCompile>
+    <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="stdafx.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="tpa.cpp" />
   </ItemGroup>
@@ -216,9 +55,9 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
     <Target Name="CopyManagedForDebuggingLocally" AfterTargets="Build" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\dnx.coreclr.dll"
+        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(ProjectName).dll"
               DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
-        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\dnx.coreclr.pdb"
+        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(ProjectName).pdb"
               DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
     </Target>
 </Project>

--- a/src/dnx.coreclr/exports.def
+++ b/src/dnx.coreclr/exports.def
@@ -1,3 +1,3 @@
-LIBRARY   dnx.coreclr.dll 
+LIBRARY 
 EXPORTS
     CallApplicationMain   @1

--- a/src/dnx.windows/dnx.cpp
+++ b/src/dnx.windows/dnx.cpp
@@ -3,7 +3,7 @@
 
 #include "stdafx.h"
 
-int _tmain(int /*argc*/, _TCHAR* /*argv[]*/)
+int _tmain(int argc, _TCHAR* argv[])
 {
     OSVERSIONINFO version_info;
     ZeroMemory(&version_info, sizeof(OSVERSIONINFO));
@@ -15,7 +15,22 @@ int _tmain(int /*argc*/, _TCHAR* /*argv[]*/)
 
     bool is_oneCore = version_info.dwMajorVersion >= 6 && version_info.dwMinorVersion >= 2;
 
-    _tprintf(L"is one core %d: ", is_oneCore);
+    // TODO: temporarily using the same name until we have necessary versions of the bootstrapper dll
+    auto dnx_dll_name = is_oneCore ? L"dnx.bootstrapper.dll" : L"dnx.bootstrapper.dll";
 
-    return 0;
+    auto dnx_dll = LoadLibraryEx(dnx_dll_name, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    if (!dnx_dll)
+    {
+        auto last_error = GetLastError();
+        _tprintf(L"%s could not be loaded. Last error: %d\n", dnx_dll_name, last_error);
+        return -1;
+    }
+
+    auto entry_point = (int (STDAPICALLTYPE*)(int, wchar_t **))GetProcAddress(dnx_dll, "DnxMain");
+    if (!entry_point)
+    {
+        _tprintf(L"Getting entry point failed\n");
+    }
+
+    return entry_point(argc, argv);
 }

--- a/src/dnx.windows/dnx.cpp
+++ b/src/dnx.windows/dnx.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+
+int _tmain(int /*argc*/, _TCHAR* /*argv[]*/)
+{
+    OSVERSIONINFO version_info;
+    ZeroMemory(&version_info, sizeof(OSVERSIONINFO));
+    version_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+
+#pragma warning(disable:4996)
+    GetVersionEx(&version_info);
+#pragma warning(default:4996)
+
+    bool is_oneCore = version_info.dwMajorVersion >= 6 && version_info.dwMinorVersion >= 2;
+
+    _tprintf(L"is one core %d: ", is_oneCore);
+
+    return 0;
+}

--- a/src/dnx.windows/dnx.cpp
+++ b/src/dnx.windows/dnx.cpp
@@ -13,10 +13,9 @@ int _tmain(int argc, _TCHAR* argv[])
     GetVersionEx(&version_info);
 #pragma warning(default:4996)
 
-    bool is_oneCore = version_info.dwMajorVersion >= 6 && version_info.dwMinorVersion >= 2;
+    bool is_oneCore = version_info.dwMajorVersion >= 10;
 
-    // TODO: temporarily using the same name until we have necessary versions of the bootstrapper dll
-    auto dnx_dll_name = is_oneCore ? L"dnx.bootstrapper.dll" : L"dnx.bootstrapper.dll";
+    auto dnx_dll_name = is_oneCore ? L"dnx.onecore.dll" : L"dnx.win32.dll";
 
     auto dnx_dll = LoadLibraryEx(dnx_dll_name, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
     if (!dnx_dll)
@@ -30,6 +29,7 @@ int _tmain(int argc, _TCHAR* argv[])
     if (!entry_point)
     {
         _tprintf(L"Getting entry point failed\n");
+        return -1;
     }
 
     return entry_point(argc, argv);

--- a/src/dnx.windows/dnx.windows.vcxproj
+++ b/src/dnx.windows/dnx.windows.vcxproj
@@ -15,10 +15,42 @@
     <Defines Condition="$(RuntimeType) == 'CORECLR_WIN'">CORECLR_WIN</Defines>
     <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
     <IntDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
+    <BuildForOneCore>False</BuildForOneCore>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'Win32'">
+    <SDKSubFolder>i386</SDKSubFolder>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'x64'">
+    <SDKSubFolder>amd64</SDKSubFolder>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Dnx.Native.Settings" />
+  <PropertyGroup>
+    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">
+    <ClCompile>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
+    <Link>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+      <AdditionalDependencies>$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\$(SDKSubFolder)\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\$(SDKSubFolder)\msvcrt.lib</AdditionalDependencies>   
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
   <ItemDefinitionGroup>
     <Link>
       <Subsystem>Console</Subsystem>

--- a/src/dnx.windows/dnx.windows.vcxproj
+++ b/src/dnx.windows/dnx.windows.vcxproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Config.Definitions.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{893A7304-50DB-4053-B864-E10BA3FFAC53}</ProjectGuid>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>dnx</RootNamespace>
+    <ProjectName>dnx.windows</ProjectName>
+    <TargetName>dnx</TargetName>
+    <ConfigurationType>Application</ConfigurationType>
+    <Defines Condition="$(RuntimeType) == 'CORECLR_WIN'">CORECLR_WIN</Defines>
+    <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
+    <IntDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Dnx.Native.Settings" />
+  <ItemDefinitionGroup>
+    <Link>
+      <Subsystem>Console</Subsystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dnx.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/dnx.windows/dnx.windows.vcxproj.filters
+++ b/src/dnx.windows/dnx.windows.vcxproj.filters
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="dnx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/src/dnx.windows/stdafx.cpp
+++ b/src/dnx.windows/stdafx.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+

--- a/src/dnx.windows/stdafx.h
+++ b/src/dnx.windows/stdafx.h
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include "targetver.h"
+
+#include <stdio.h>
+#include <tchar.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>

--- a/src/dnx.windows/targetver.h
+++ b/src/dnx.windows/targetver.h
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/src/dnx/dllmain.cpp
+++ b/src/dnx/dllmain.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+
+BOOL APIENTRY DllMain(HMODULE /*hModule*/, DWORD  ul_reason_for_call, LPVOID /*lpReserved*/)
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -375,7 +375,7 @@ Finished:
 #if PLATFORM_UNIX
 int main(int argc, char* argv[])
 #else
-int wmain(int argc, wchar_t* argv[])
+extern "C" int __stdcall DnxMain(int argc, wchar_t* argv[])
 #endif
 {
     // Check for the debug flag before doing anything else

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -235,7 +235,11 @@ int CallApplicationProcessMain(int argc, LPTSTR argv[])
     bool fSuccess = true;
     HMODULE m_hHostModule = nullptr;
 #if CORECLR_WIN
-    LPCTSTR pwzHostModuleName = _T("dnx.coreclr.dll");
+#if ONECORE
+        LPCTSTR pwzHostModuleName = _T("dnx.onecore.coreclr.dll");
+#else
+        LPCTSTR pwzHostModuleName = _T("dnx.win32.coreclr.dll");
+#endif
 #elif CORECLR_DARWIN
     LPCTSTR pwzHostModuleName = _T("dnx.coreclr.dylib");
 #elif CORECLR_LINUX

--- a/src/dnx/dnx.def
+++ b/src/dnx/dnx.def
@@ -1,0 +1,3 @@
+LIBRARY
+EXPORTS
+DnxMain

--- a/src/dnx/dnx.vcxproj
+++ b/src/dnx/dnx.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Config.Definitions.props" />
   <PropertyGroup Label="Globals">
@@ -6,11 +6,11 @@
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>          
+    <CharacterSet>Unicode</CharacterSet>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dnx</RootNamespace>
-    <ProjectName>dnx</ProjectName>
-    <ConfigurationType>Application</ConfigurationType>
+    <ProjectName>dnx.bootstrapper</ProjectName>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <Defines Condition="$(RuntimeType) == 'CORECLR_WIN'">CORECLR_WIN</Defines>
     <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
     <IntDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
@@ -21,6 +21,7 @@
   <ItemDefinitionGroup>
     <Link>
       <Subsystem>Console</Subsystem>
+      <ModuleDefinitionFile>dnx.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ImportGroup Label="ExtensionSettings">
@@ -30,9 +31,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClInclude Include="dnx.h" />
     <ClInclude Include="pal.h" />
     <ClInclude Include="resource.h" />
@@ -40,6 +38,7 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="dnx.cpp" />
     <ClCompile Include="pal.win32.cpp" />
     <ClCompile Include="stdafx.cpp">
@@ -48,6 +47,9 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="dnx.def" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <PropertyGroup>

--- a/src/dnx/dnx.vcxproj
+++ b/src/dnx/dnx.vcxproj
@@ -8,12 +8,14 @@
     <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <Keyword>Win32Proj</Keyword>
+    <BuildForOneCore Condition="'$(BuildForOneCore)' == ''">False</BuildForOneCore>
     <RootNamespace>dnx</RootNamespace>
-    <ProjectName>dnx.bootstrapper</ProjectName>
+    <ProjectName>dnx.win32</ProjectName>
+    <ProjectName Condition="'$(BuildForOneCore)' == 'True'">dnx.onecore</ProjectName>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <Defines Condition="$(RuntimeType) == 'CORECLR_WIN'">CORECLR_WIN</Defines>
     <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
-    <IntDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
+    <IntDir>bin\$(ProjectName)\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/dnx/dnx.vcxproj
+++ b/src/dnx/dnx.vcxproj
@@ -21,6 +21,9 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Dnx.Native.Settings" />
   <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(BuildForOneCore)' == 'True'">ONECORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <Link>
       <Subsystem>Console</Subsystem>
       <ModuleDefinitionFile>dnx.def</ModuleDefinitionFile>


### PR DESCRIPTION
With this change I am introducing a new dnx.exe for Windows whose only purpose is to load the right version of the dnx_xxx.dll. The old dnx.exe is compiled as dnx_win32.dll and dnx_onecore.dll. The only difference between dnx_win32.dll and dnx_onecore.dll is how they are built. The result of this change is that it enables using STL in the dnx_xxx.dll. We may need/want to do similar split to dnx.coreclr.dll in the future if we needed to use STL there. 