### PR TITLE
Print runtime type and architecture in version

### DIFF
--- a/src/Microsoft.Framework.ApplicationHost/Program.cs
+++ b/src/Microsoft.Framework.ApplicationHost/Program.cs
@@ -123,7 +123,9 @@ namespace Microsoft.Framework.ApplicationHost
             var optionCompilationServer = app.Option("--port <PORT>", "The port to the compilation server", CommandOptionType.SingleValue);
             var runCmdExecuted = false;
             app.HelpOption("-?|-h|--help");
-            app.VersionOption("--version", GetVersion);
+
+            var env = (IRuntimeEnvironment)_serviceProvider.GetService(typeof(IRuntimeEnvironment));
+            app.VersionOption("--version", () => env.GetShortVersion(), () => env.GetFullVersion());
             var runCmd = app.Command("run", c =>
             {
                 // We don't actually execute "run" command here
@@ -245,13 +247,6 @@ namespace Microsoft.Framework.ApplicationHost
             throw new InvalidOperationException(
                     string.Format("Unable to load application or execute command '{0}'.",
                     applicationName), innerException);
-        }
-
-        private static string GetVersion()
-        {
-            var assembly = typeof(Program).GetTypeInfo().Assembly;
-            var assemblyInformationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            return assemblyInformationalVersionAttribute.InformationalVersion;
         }
     }
 }

--- a/src/Microsoft.Framework.ApplicationHost/project.json
+++ b/src/Microsoft.Framework.ApplicationHost/project.json
@@ -4,6 +4,7 @@
     "dependencies": {
         "Microsoft.Framework.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime": "1.0.0-*",
+        "Microsoft.Framework.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*"
     },

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Net;
-using System.Reflection;
 using System.Threading;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Common.CommandLine;
@@ -44,7 +43,7 @@ namespace Microsoft.Framework.PackageManager
 
             var optionVerbose = app.Option("-v|--verbose", "Show verbose output", CommandOptionType.NoValue);
             app.HelpOption("-?|-h|--help");
-            app.VersionOption("--version", GetVersion);
+            app.VersionOption("--version", () => _runtimeEnv.GetShortVersion(), () => _runtimeEnv.GetFullVersion());
 
             // Show help information if no subcommand/option was specified
             app.OnExecute(() =>
@@ -66,13 +65,6 @@ namespace Microsoft.Framework.PackageManager
             WrapConsoleCommand.Register(app, reportsFactory);
 
             return app.Execute(args);
-        }
-
-        private static string GetVersion()
-        {
-            var assembly = typeof(Program).GetTypeInfo().Assembly;
-            var assemblyInformationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            return assemblyInformationalVersionAttribute.InformationalVersion;
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/project.json
+++ b/src/Microsoft.Framework.PackageManager/project.json
@@ -7,6 +7,7 @@
         "Microsoft.Framework.Project": "1.0.0-*",
         "Microsoft.Framework.Runtime": "1.0.0-*",
         "Microsoft.Framework.Runtime.Compilation.Sources": { "version": "1.0.0-*", "type": "build" },
+        "Microsoft.Framework.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
         "Newtonsoft.Json": "6.0.6"

--- a/src/Microsoft.Framework.Runtime.Internals/RuntimeEnvironmentExtensions.cs
+++ b/src/Microsoft.Framework.Runtime.Internals/RuntimeEnvironmentExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+
+namespace Microsoft.Framework.Runtime
+{
+    internal static class RuntimeEnvironmentHelper
+    {
+        public static string GetFullVersion(this IRuntimeEnvironment env)
+        {
+            var str = new StringBuilder();
+            str.AppendLine($" Version:      {env.RuntimeVersion}");
+            str.AppendLine($" Type:         {env.RuntimeType}");
+            str.AppendLine($" Architecture: {env.RuntimeArchitecture}");
+            str.AppendLine($" OS Name:      {env.OperatingSystem}");
+
+            if (!string.IsNullOrEmpty(env.OperatingSystemVersion))
+            {
+                str.AppendLine($" OS Version:   {env.OperatingSystemVersion}");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GetShortVersion(this IRuntimeEnvironment env)
+        {
+            return $"{env.RuntimeType}-{env.RuntimeArchitecture}-{env.RuntimeVersion}";
+        }
+    }
+}

--- a/src/Microsoft.Framework.Runtime.Internals/project.json
+++ b/src/Microsoft.Framework.Runtime.Internals/project.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": { "define": [ "TRACE" ], "warningsAsErrors": true },
+    "shared": "**/*.cs",
+    "dependencies": {
+        "Microsoft.Framework.Runtime.Abstractions": ""
+    },
+    "frameworks": {
+        "dnx451": { },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Runtime": "4.0.20-beta-*"
+            }
+        }
+    }
+}

--- a/src/dnx.host/Bootstrapper.cs
+++ b/src/dnx.host/Bootstrapper.cs
@@ -25,7 +25,7 @@ namespace dnx.host
             _searchPaths = searchPaths;
         }
 
-        public Task<int> RunAsync(List<string> args)
+        public Task<int> RunAsync(List<string> args, IRuntimeEnvironment env)
         {
             var accessor = LoadContextAccessor.Instance;
             var container = new LoaderContainer();
@@ -73,7 +73,7 @@ namespace dnx.host
                 serviceProvider.Add(typeof(IAssemblyLoaderContainer), container);
                 serviceProvider.Add(typeof(IAssemblyLoadContextAccessor), accessor);
                 serviceProvider.Add(typeof(IApplicationEnvironment), applicationEnvironment);
-                serviceProvider.Add(typeof(IRuntimeEnvironment), new RuntimeEnvironment());
+                serviceProvider.Add(typeof(IRuntimeEnvironment), env);
 
                 CallContextServiceLocator.Locator.ServiceProvider = serviceProvider;
 

--- a/src/dnx.host/RuntimeBootstrapper.cs
+++ b/src/dnx.host/RuntimeBootstrapper.cs
@@ -70,8 +70,12 @@ namespace dnx.host
             var optionDebug = app.Option("--debug", "Waits for the debugger to attach before beginning execution.",
                 CommandOptionType.NoValue);
 
+            var env = new RuntimeEnvironment();
+
             app.HelpOption("-?|-h|--help");
-            app.VersionOption("--version", GetVersion);
+            app.VersionOption("--version",
+                              () => env.GetShortVersion(),
+                              () => env.GetFullVersion());
 
             // Options below are only for help info display
             // They will be forwarded to Microsoft.Framework.ApplicationHost
@@ -136,7 +140,7 @@ namespace dnx.host
             IEnumerable<string> searchPaths = ResolveSearchPaths(optionLib.Values, app.RemainingArguments);
 
             var bootstrapper = new Bootstrapper(searchPaths);
-            return bootstrapper.RunAsync(app.RemainingArguments);
+            return bootstrapper.RunAsync(app.RemainingArguments, env);
         }
 
         private static IEnumerable<string> ResolveSearchPaths(List<string> libPaths, List<string> remainingArgs)
@@ -192,17 +196,6 @@ namespace dnx.host
             {
                 searchPaths.Add(libPath);
             }
-        }
-
-        private static string GetVersion()
-        {
-            var assembly = typeof(RuntimeBootstrapper).GetTypeInfo().Assembly;
-            var assemblyInformationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            if (assemblyInformationalVersionAttribute == null)
-            {
-                return assembly.GetName().Version.ToString();
-            }
-            return assemblyInformationalVersionAttribute.InformationalVersion;
         }
     }
 }

--- a/src/dnx.host/project.json
+++ b/src/dnx.host/project.json
@@ -3,6 +3,7 @@
     "compilationOptions": { "define": [ "TRACE" ], "allowUnsafe": true, "warningsAsErrors": true },
     "dependencies": {
         "Microsoft.Framework.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" },
+        "Microsoft.Framework.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Framework.Runtime.Loader": "1.0.0-*"
     },


### PR DESCRIPTION
#1447 

The format of the version is debatable. The current arrangement puts the version at beginning. The other option is `{type}-{architecture}-{version}`, which keeps the output inline with the `dnx` name.

Please share your opinion.

![capture](https://cloud.githubusercontent.com/assets/1329240/7697947/24f1dbae-fdc1-11e4-82a8-92afee7e2756.PNG)
