### PR TITLE
Splitting dnx.coreclr.dll to dnx_win32.coreclr.dll and dnx_onecore.co…

### DIFF
--- a/build/Dnx.Native.Settings
+++ b/build/Dnx.Native.Settings
@@ -79,7 +79,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>AMD64;_WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 
@@ -91,7 +91,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>AMD64;_WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 

--- a/makefile.shade
+++ b/makefile.shade
@@ -61,7 +61,7 @@ var BOOTSTRAPPER_HOST_NAME = 'dnx.host'
 var PROGRAM_FILES_X86 = '${Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}'
 var MSBUILD = '${Path.Combine(PROGRAM_FILES_X86, "MSBuild", "14.0", "Bin", "MSBuild.exe")}'
 var VS_REDIST_ROOT = '${Path.Combine(PROGRAM_FILES_X86, @"Microsoft Visual Studio 14.0\VC\redist")}'
-var WIN10_SDK = '${Path.Combine(PROGRAM_FILES_X86, @"Windows Kits\10")}'
+var WIN10_SDK_LIB = '${Path.Combine(PROGRAM_FILES_X86, @"Windows Kits\10\Lib")}'
 var CLANG = '${SearchForClang()}'
 
 var MANAGED_PROJECTS = '${FindAllProjects(
@@ -89,6 +89,8 @@ var WIN_MANAGED_PROJECTS = '${FindAllProjects(
 var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_FOLDER_NAME, BOOTSTRAPPER_CLR_NAME, BOOTSTRAPPER_CORECLR_NAME)}'
 
 var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
+
+var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles(WIN10_SDK_LIB, "onecore.lib", SearchOption.AllDirectories).Any()}'
 
 @{
     // Always build mono
@@ -239,7 +241,7 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
         Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=False");
         Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnxcore50;RuntimeType=CORECLR_WIN;BuildForOneCore=False");
 
-        if(Directory.GetFiles(Path.Combine(WIN10_SDK, "Lib"), "onecore.lib", SearchOption.AllDirectories).Any())
+        if(CAN_BUILD_ONECORE)
         {
             Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=True");
             Exec(MSBUILD, bootstrapperProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;TargetFramework=dnx451;RuntimeType=CLR;BuildForOneCore=True");
@@ -259,16 +261,18 @@ var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
     var bootstrapperCoreClrProj = '${Path.Combine(ROOT, "src", BOOTSTRAPPER_CORECLR_NAME, BOOTSTRAPPER_CORECLR_NAME + ".vcxproj")}'
 
     @{
-        var environmentRuntimeTargetOS = Environment.GetEnvironmentVariable("RUNTIME_TARGET_OS");
-        var configRuntimeTargetOS = "";
-        
-        if (environmentRuntimeTargetOS == "WIN7_PLUS_CORESYSTEM")
-        {
-            configRuntimeTargetOS = ";RuntimeTargetOS=WIN7_PLUS_CORESYSTEM";
-        }
+        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;BuildForOneCore=False");
+        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;BuildForOneCore=False");
 
-        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32" + configRuntimeTargetOS);
-        Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=x64" + configRuntimeTargetOS);
+        if(CAN_BUILD_ONECORE)
+        {
+            Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=Win32;BuildForOneCore=True");
+            Exec(MSBUILD, bootstrapperCoreClrProj + " /p:Configuration=" + Configuration2 + ";Platform=x64;BuildForOneCore=True");
+        }
+        else
+        {
+            Log.Warn("Windows 10 SDK not installed. Building for One Core skipped.");
+        }
     }
 
     directory delete='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME)}'

--- a/src/dnx.coreclr/dllmain.cpp
+++ b/src/dnx.coreclr/dllmain.cpp
@@ -3,10 +3,9 @@
 
 #include "stdafx.h"
 
-BOOL APIENTRY DllMain( HMODULE hModule,
+BOOL APIENTRY DllMain( HMODULE /* hModule */,
                       DWORD  ul_reason_for_call,
-                      LPVOID lpReserved
-                      )
+                      LPVOID /* lpReserved */)
 {
     switch (ul_reason_for_call)
     {

--- a/src/dnx.coreclr/dnx.coreclr.cpp
+++ b/src/dnx.coreclr/dnx.coreclr.cpp
@@ -260,7 +260,6 @@ bool Win32KDisable()
     bool fSuccess = true;
     TCHAR szWin32KDisable[2] = {};
     LPWSTR lpwszModuleFileName = L"api-ms-win-core-processthreads-l1-1-1.dll";
-    DWORD dwModuleFileName = 0;
     HMODULE hProcessThreadsModule = nullptr;
     // Note: Need to keep as ASCII as GetProcAddress function takes ASCII params
     LPCSTR pszSetProcessMitigationPolicy = "SetProcessMitigationPolicy";
@@ -322,7 +321,7 @@ Finished:
     return fSuccess;
 }
 
-extern "C" __declspec(dllexport) HRESULT __stdcall CallApplicationMain(PCALL_APPLICATION_MAIN_DATA data)
+extern "C" HRESULT __stdcall CallApplicationMain(PCALL_APPLICATION_MAIN_DATA data)
 {
     HRESULT hr = S_OK;
     errno_t errno = 0;

--- a/src/dnx.coreclr/dnx.coreclr.vcxproj
+++ b/src/dnx.coreclr/dnx.coreclr.vcxproj
@@ -1,180 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Config.Definitions.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1F31D08E-DE21-48F6-ADE3-315EA6268DD1}</ProjectGuid>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
     <Keyword>Win32Proj</Keyword>
+    <BuildForOneCore Condition="'$(BuildForOneCore)' == ''">False</BuildForOneCore>
     <RootNamespace>KSys</RootNamespace>
-    <ProjectName>dnx.coreclr</ProjectName>
+    <ProjectName>dnx.win32.coreclr</ProjectName>
+    <ProjectName Condition="'$(BuildForOneCore)' == 'True'">dnx.onecore.coreclr</ProjectName>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
+    <IntDir>bin\$(ProjectName)\$(Platform)\$(Configuration)\$(TargetFramework)\</IntDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Dnx.Native.Settings" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>bin\$(Platform)\$(Configuration)\</IntDir>
-    <IncludePath Condition="'$(RuntimeTargetOS)' == 'WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\inc\crt;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PreprocessorDefinitions>_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Subsystem>Windows</Subsystem>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
     </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>AMD64;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
-    </Link>
-    <ProjectReference>
-      <LinkLibraryDependencies>false</LinkLibraryDependencies>
-    </ProjectReference>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\i386\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>AMD64;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\mincore_fw.lib;$(ProgramFiles)\Windows Kits\Win8CoreSystem\sdk\lib\mincore\amd64\msvcrt.lib</AdditionalDependencies>
-      <IgnoreAllDefaultLibraries Condition="'$(RuntimeTargetOS)'=='WIN7_PLUS_CORESYSTEM'">true</IgnoreAllDefaultLibraries>
-    </Link>
-    <ProjectReference>
-      <LinkLibraryDependencies>false</LinkLibraryDependencies>
-    </ProjectReference>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
@@ -184,25 +39,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dnx.coreclr.cpp" />
-    <ClCompile Include="dllmain.cpp">
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </PrecompiledHeader>
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
-      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-      </PrecompiledHeader>
-    </ClCompile>
+    <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="stdafx.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="tpa.cpp" />
   </ItemGroup>
@@ -216,9 +55,9 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
     <Target Name="CopyManagedForDebuggingLocally" AfterTargets="Build" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\dnx.coreclr.dll"
+        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(ProjectName).dll"
               DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
-        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\dnx.coreclr.pdb"
+        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(ProjectName).pdb"
               DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
     </Target>
 </Project>

--- a/src/dnx.coreclr/exports.def
+++ b/src/dnx.coreclr/exports.def
@@ -1,3 +1,3 @@
-LIBRARY   dnx.coreclr.dll 
+LIBRARY 
 EXPORTS
     CallApplicationMain   @1

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -235,7 +235,11 @@ int CallApplicationProcessMain(int argc, LPTSTR argv[])
     bool fSuccess = true;
     HMODULE m_hHostModule = nullptr;
 #if CORECLR_WIN
-    LPCTSTR pwzHostModuleName = _T("dnx.coreclr.dll");
+#if ONECORE
+        LPCTSTR pwzHostModuleName = _T("dnx.onecore.coreclr.dll");
+#else
+        LPCTSTR pwzHostModuleName = _T("dnx.win32.coreclr.dll");
+#endif
 #elif CORECLR_DARWIN
     LPCTSTR pwzHostModuleName = _T("dnx.coreclr.dylib");
 #elif CORECLR_LINUX

--- a/src/dnx/dnx.vcxproj
+++ b/src/dnx/dnx.vcxproj
@@ -21,6 +21,9 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\Build\Dnx.Native.Settings" />
   <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(BuildForOneCore)' == 'True'">ONECORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <Link>
       <Subsystem>Console</Subsystem>
       <ModuleDefinitionFile>dnx.def</ModuleDefinitionFile>


### PR DESCRIPTION
…reclr.dll

Note that the difference between dnx_win32.coreclr.dll and dnx_onecore.coreclr.dll is only how we build the code and the code itself should remain the same.

- Enables using STL in the dnx_xxx.coreclr.dll
- Opens a way to compile for arm (onecore)

Bonus: Fixing some warnings and errors that started appearing after Warning Level was changed to 4