### PR TITLE
Add IPlugin protocol to PluginHandler.

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost.Abstractions/IPlugin.cs
+++ b/src/Microsoft.Framework.DesignTimeHost.Abstractions/IPlugin.cs
@@ -9,5 +9,7 @@ namespace Microsoft.Framework.DesignTimeHost
     public interface IPlugin
     {
         void ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext);
+
+        int Protocol { get; set; }
     }
 }

--- a/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/RegisterPluginResponseMessage.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/RegisterPluginResponseMessage.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.DesignTimeHost.Models.OutgoingMessages
+{
+    public class RegisterPluginResponseMessage : PluginResponseMessage
+    {
+        public int Protocol { get; set; }
+    }
+}


### PR DESCRIPTION
- When a plugin is registered with the system a client protocol can now be provided. This protocol is then cross checked with the created IPlugin's protocol and the result of Register returns the Protocol that will be used when communicating with the registered Plugin.
- Added tests to validate error conditions and protocol resolutions.

#1905