### PR TITLE
[Design] Add no-op support for IPlugins.

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost.Abstractions/IPlugin.cs
+++ b/src/Microsoft.Framework.DesignTimeHost.Abstractions/IPlugin.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Framework.DesignTimeHost
 {
     public interface IPlugin
     {
-        void ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext);
+        bool ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext);
 
         int Protocol { get; set; }
     }

--- a/src/Microsoft.Framework.DesignTimeHost/Models/IncomingMessages/PluginMessage.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Models/IncomingMessages/PluginMessage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Framework.DesignTimeHost.Models.IncomingMessages
     public class PluginMessage
     {
         public string PluginId { get; set; }
+        public string MessageId { get; set; }
         public string MessageName { get; set; }
         public JObject Data { get; set; }
     }

--- a/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/NoopPluginResponseMessage.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/NoopPluginResponseMessage.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.DesignTimeHost.Models.OutgoingMessages
+{
+    public class NoopPluginResponseMessage : PluginResponseMessage
+    {
+        public bool Unhandled { get; } = true;
+    }
+}

--- a/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/PluginResponseMessage.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/PluginResponseMessage.cs
@@ -1,14 +1,27 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+using Newtonsoft.Json;
 
 namespace Microsoft.Framework.DesignTimeHost.Models.OutgoingMessages
 {
     public class PluginResponseMessage
     {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string MessageId { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string MessageName { get; set; }
-        public bool Success { get; set; }
+
+        public bool Success
+        {
+            get
+            {
+                return Error == null;
+            }
+        }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Error { get; set; }
     }
 }

--- a/src/Microsoft.Framework.DesignTimeHost/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Properties/Resources.Designer.cs
@@ -43,6 +43,38 @@ namespace Microsoft.Framework.DesignTimeHost
         }
 
         /// <summary>
+        /// Plugin '{0}' could not handle message '{1}'.
+        /// </summary>
+        internal static string Plugin_PluginCouldNotHandleMessage
+        {
+            get { return GetString("Plugin_PluginCouldNotHandleMessage"); }
+        }
+
+        /// <summary>
+        /// Plugin '{0}' could not handle message '{1}'.
+        /// </summary>
+        internal static string FormatPlugin_PluginCouldNotHandleMessage(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Plugin_PluginCouldNotHandleMessage"), p0, p1);
+        }
+
+        /// <summary>
+        /// Plugin handler could not handle message '{0}' for plugin '{1}'.
+        /// </summary>
+        internal static string Plugin_PluginHandlerCouldNotHandleMessage
+        {
+            get { return GetString("Plugin_PluginHandlerCouldNotHandleMessage"); }
+        }
+
+        /// <summary>
+        /// Plugin handler could not handle message '{0}' for plugin '{1}'.
+        /// </summary>
+        internal static string FormatPlugin_PluginHandlerCouldNotHandleMessage(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Plugin_PluginHandlerCouldNotHandleMessage"), p0, p1);
+        }
+
+        /// <summary>
         /// Could not locate plugin id '{0}' of type '{1}' in assembly '{2}'.
         /// </summary>
         internal static string Plugin_TypeCouldNotBeLocatedInAssembly

--- a/src/Microsoft.Framework.DesignTimeHost/Resources.resx
+++ b/src/Microsoft.Framework.DesignTimeHost/Resources.resx
@@ -123,6 +123,12 @@
   <data name="Plugin_EncounteredExceptionWhenProcessingPluginMessage" xml:space="preserve">
     <value>Plugin '{0}' encountered an exception when processing a message. Exception message: '{1}'</value>
   </data>
+  <data name="Plugin_PluginCouldNotHandleMessage" xml:space="preserve">
+    <value>Plugin '{0}' could not handle message '{1}'.</value>
+  </data>
+  <data name="Plugin_PluginHandlerCouldNotHandleMessage" xml:space="preserve">
+    <value>Plugin handler could not handle message '{0}' for plugin '{1}'.</value>
+  </data>
   <data name="Plugin_TypeCouldNotBeLocatedInAssembly" xml:space="preserve">
     <value>Could not locate plugin id '{0}' of type '{1}' in assembly '{2}'.</value>
   </data>

--- a/test/Microsoft.Framework.DesignTimeHost.Tests/PluginHandlerFacts.cs
+++ b/test/Microsoft.Framework.DesignTimeHost.Tests/PluginHandlerFacts.cs
@@ -810,9 +810,11 @@ namespace Microsoft.Framework.DesignTimeHost
 
             public int Protocol { get; set; } = 1;
 
-            public void ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
+            public bool ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
             {
                 _messageBroker.SendMessage(data["Data"].ToString() + "!");
+
+                return true;
             }
         }
 
@@ -820,8 +822,9 @@ namespace Microsoft.Framework.DesignTimeHost
         {
             public int Protocol { get; set; } = 3;
 
-            public virtual void ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
+            public virtual bool ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
             {
+                return true;
             }
         }
 
@@ -838,7 +841,7 @@ namespace Microsoft.Framework.DesignTimeHost
 
             public int Protocol { get; set; } = 1;
 
-            public virtual void ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
+            public virtual bool ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
             {
                 throw new InvalidOperationException("Cannot process messages.");
             }
@@ -856,9 +859,11 @@ namespace Microsoft.Framework.DesignTimeHost
                 _messageBroker = messageBroker;
             }
 
-            public override void ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
+            public override bool ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
             {
                 _messageBroker.SendMessage("Created");
+
+                return true;
             }
         }
 
@@ -872,9 +877,11 @@ namespace Microsoft.Framework.DesignTimeHost
                 _messageBroker = messageBroker;
             }
 
-            public override void ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
+            public override bool ProcessMessage(JObject data, IAssemblyLoadContext assemblyLoadContext)
             {
                 _messageBroker.SendMessage(assemblyLoadContext);
+
+                return true;
             }
         }
 


### PR DESCRIPTION
Running this through design prior to adding tests.

- In the case that the PluginHandler cannot handle a message a no-op is returned.
- In the case that a Plugin cannot handle a message a no-op is returned. Handling a message is determined by the result of the ProcessMessages call to the invoked Plugin.

#1906