### PR TITLE
Fixing dnx.coreclr.vcxproj so that it builds correctly in VS

### DIFF
--- a/src/dnx.coreclr/dnx.coreclr.vcxproj
+++ b/src/dnx.coreclr/dnx.coreclr.vcxproj
@@ -55,9 +55,9 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
     <Target Name="CopyManagedForDebuggingLocally" AfterTargets="Build" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(ProjectName).dll"
+        <Copy SourceFiles="bin\$(Platform)\$(Configuration)\$(ProjectName).dll"
               DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
-        <Copy SourceFiles="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(ProjectName).pdb"
+        <Copy SourceFiles="bin\$(Platform)\$(Configuration)\$(ProjectName).pdb"
               DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
     </Target>
 </Project>


### PR DESCRIPTION
The issue was that the post build step used an absolute path while we started bin placing binaries using a relative path.