### PR TITLE
Prevent help from null refing when the command doesn't exist

### DIFF
--- a/src/Microsoft.Framework.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Framework.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
@@ -332,7 +332,17 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
             else
             {
                 target = Commands.SingleOrDefault(cmd => string.Equals(cmd.Name, commandName, StringComparison.OrdinalIgnoreCase));
-                headerBuilder.AppendFormat(" {0}", commandName);
+
+                if (target != null)
+                {
+                    headerBuilder.AppendFormat(" {0}", commandName);
+                }
+                else
+                {
+                    // The command name is invalid so don't try to show help for something that doesn't exist
+                    target = this;
+                }
+
             }
 
             var optionsBuilder = new StringBuilder();


### PR DESCRIPTION
Fixes https://github.com/aspnet/dnx/issues/1859

cc @moozzyk