### PR TITLE
Teach dnx/dnu/dth about netportable50

### DIFF
--- a/misc/XreTestApps/FrameworkReferences/Program.cs
+++ b/misc/XreTestApps/FrameworkReferences/Program.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+
+public class Program 
+{
+    public void Main(string[] args) 
+    {
+        if (args.Length != 1) 
+        {
+            Console.Error.WriteLine("Required argument: file path");
+            return;
+        }
+
+        foreach (var line in File.ReadAllLines(args[0])) 
+        {
+            Console.WriteLine(line);
+        }
+    }
+}

--- a/misc/XreTestApps/FrameworkReferences/project.json
+++ b/misc/XreTestApps/FrameworkReferences/project.json
@@ -1,6 +1,6 @@
 {
     "frameworks": {
-        "dnx451": {
+        "dnx46": {
             "frameworkAssemblies": {
                 "System.IO": ""
             }

--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -105,8 +105,7 @@ namespace Microsoft.Framework.PackageManager.Utils
                 foreach (var runtimeSpec in context.RuntimeSpecs)
                 {
                     criteriaBuilderWithTfm = criteriaBuilderWithTfm
-                    .Add["tfm", framework]["rid", runtimeSpec.Name]
-                    .Add["tfm", new FrameworkName("Core", new Version(5, 0))]["rid", runtimeSpec.Name];
+                        .Add["tfm", framework]["rid", runtimeSpec.Name];
 
                     criteriaBuilderWithoutTfm = criteriaBuilderWithoutTfm
                         .Add["rid", runtimeSpec.Name];
@@ -114,8 +113,7 @@ namespace Microsoft.Framework.PackageManager.Utils
             }
 
             criteriaBuilderWithTfm = criteriaBuilderWithTfm
-                .Add["tfm", framework]
-                .Add["tfm", new FrameworkName("Core", new Version(5, 0))];
+                .Add["tfm", framework];
 
             var criteria = criteriaBuilderWithTfm.Criteria;
 

--- a/src/Microsoft.Framework.Runtime/FrameworkReferenceResolver.cs
+++ b/src/Microsoft.Framework.Runtime/FrameworkReferenceResolver.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Framework.Runtime
             { new FrameworkName(VersionUtility.DnxFrameworkIdentifier, new Version(4, 5, 1)), new List<FrameworkName> {
                     new FrameworkName(VersionUtility.NetFrameworkIdentifier, new Version(4, 5, 1))
                 }
+            },
+            { new FrameworkName(VersionUtility.DnxFrameworkIdentifier, new Version(4, 6)), new List<FrameworkName> {
+                    new FrameworkName(VersionUtility.NetFrameworkIdentifier, new Version(4, 6))
+                }
             }
         };
 
@@ -95,6 +99,10 @@ namespace Microsoft.Framework.Runtime
             {
                 return "DNX " + targetFramework.Version.ToString();
             }
+            else if (string.Equals(targetFramework.Identifier, VersionUtility.PortableFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) && targetFramework.Version >= new Version(5, 0))
+            {
+                return ".NET Portable " + targetFramework.Version.ToString();
+            }
 
             var information = _cache.GetOrAdd(targetFramework, GetFrameworkInformation);
 
@@ -132,7 +140,7 @@ namespace Microsoft.Framework.Runtime
 
         public static string GetReferenceAssembliesPath()
         {
-#if DNX451            
+#if DNX451
             if (PlatformHelper.IsMono)
             {
                 var mscorlibLocationOnThisRunningMonoInstance = typeof(object).GetTypeInfo().Assembly.Location;
@@ -141,7 +149,7 @@ namespace Microsoft.Framework.Runtime
 
                 return Path.Combine(libPath, "xbuild-frameworks");
             }
-#endif 
+#endif
 
             // References assemblies are in %ProgramFiles(x86)% on
             // 64 bit machines
@@ -163,7 +171,7 @@ namespace Microsoft.Framework.Runtime
                     programFiles,
                     "Reference Assemblies", "Microsoft", "Framework");
         }
-        
+
         private static FrameworkInformation GetFrameworkInformation(FrameworkName targetFramework)
         {
             string referenceAssembliesPath = GetReferenceAssembliesPath();

--- a/test/Microsoft.Framework.Runtime.Tests/VersionUtilityFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/VersionUtilityFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using NuGet;
 using Xunit;
 
@@ -47,8 +48,8 @@ namespace Microsoft.Framework.Runtime.Tests
 
         [InlineData("dnxcore50", "aspnetcore50", true)]
         [InlineData("aspnetcore50", "dnxcore50", false)]
-        
         // Portable stuff?
+
         [InlineData("dnxcore50", "portable-net40+win8+dnxcore50", true)]
         [InlineData("dnxcore50", "portable-net40+win8+aspnetcore50", true)]
         [InlineData("dnxcore50", "portable-net45+win8", true)]
@@ -57,14 +58,51 @@ namespace Microsoft.Framework.Runtime.Tests
         [InlineData("dnxcore50", "portable-net45+win8", true)]
         [InlineData("dnxcore50", "portable-net451+win81", true)]
         [InlineData("dnxcore50", "portable-net40+sl5+win8", false)]
-        public void FrameworksAreCompatible(string projectTargetFramework, string packageTargetFramework, bool compatible)
+
+        // NetPortable50
+        [InlineData("netportable50", "netportable50", true)]
+        [InlineData("dnxcore50", "netportable50", true)]
+        [InlineData("aspnetcore50", "netportable50", true)]
+        [InlineData("dnx451", "netportable50", true)]
+        [InlineData("dnx46", "netportable50", true)]
+        [InlineData("net451", "netportable50", false)]
+        [InlineData("net40", "netportable50", false)]
+        [InlineData("net46", "netportable50", true)]
+        [InlineData("sl20", "netportable50", false)]
+        [InlineData("netportable50", "portable-net40+sl5+win8", false)]
+        [InlineData("netportable50", "portable-net45+win8", true)]
+        [InlineData("netportable50", "portable-net451+win81", true)]
+        [InlineData("netportable50", "portable-net451+win8+core50", true)]
+        [InlineData("netportable50", "portable-net451+win8+dnxcore50", true)]
+        [InlineData("netportable50", "portable-net451+win8+aspnetcore50", true)]
+
+        // Old-world Portable doesn't support netportable50
+        [InlineData("portable-net40+sl5+win8", "netportable50", false)]
+        [InlineData("portable-net45+win8", "netportable50", false)]
+        [InlineData("portable-net451+win81", "netportable50", false)]
+        [InlineData("portable-net451+win8+core50", "netportable50", false)]
+        [InlineData("portable-net451+win8+dnxcore50", "netportable50", false)]
+        [InlineData("portable-net451+win8+aspnetcore50", "netportable50", false)]
+        public void FrameworksAreCompatible(string project, string package, bool compatible)
         {
-            var frameworkName1 = VersionUtility.ParseFrameworkName(projectTargetFramework);
-            var frameworkName2 = VersionUtility.ParseFrameworkName(packageTargetFramework);
+            var frameworkName1 = VersionUtility.ParseFrameworkName(project);
+            var frameworkName2 = VersionUtility.ParseFrameworkName(package);
 
             var result = VersionUtility.IsCompatible(frameworkName1, frameworkName2);
 
             Assert.Equal(compatible, result);
+        }
+
+        [Theory]
+        [InlineData(".NETPortable", "0.0", "net45+win8", "portable-net45+win80")]
+        [InlineData(".NETPortable", "4.2", "net45", "portable-net45")] // Portable version numbers < 5.0 didn't matter
+        [InlineData(".NETPortable", "5.0", null, "netportable50")]
+        [InlineData(".NETPortable", "5.1", null, "netportable51")]
+        [InlineData(".NETPortable", "6.0", null, "netportable60")]
+        public void ShortFrameworkNamesAreCorrect(string longName, string version, string profile, string shortName)
+        {
+            var fx = new FrameworkName(longName, Version.Parse(version), profile);
+            Assert.Equal(shortName, VersionUtility.GetShortFrameworkName(fx));
         }
     }
 }


### PR DESCRIPTION
This PR teaches the various parts of the DNX system about the new `netportable50` identifier. This maps to the full name `.NETPortable, Version=v5.0` and the friendly name `.NET Portable 5.0`.

Support exists throughout DNX. DNX apps can consume `netportable50` packages and DNU can produce `netportable50` assemblies.

Integration with VS is included:
![image](https://cloud.githubusercontent.com/assets/7574/7760900/b110533a-ffd4-11e4-9839-b88fa4f22170.png)

A `core50` package can be installed into: `net451` (and higher), `dnx451` (and higher), `netportable50` and `netcore50` projects. A `core50` project can reference packages targeting: `netportable50` and PCL profiles including `net45` and/or `win8` (same rules as `dnxcore50`).

Of course, the current problem is that there aren't any packages out there that include `netportable50`. I've got a local test app with some hacked up packages that support it if anyone wants to try it out.

/cc @lodejard @davidfowl @ericstj @yishaigalatzer @emgarten