### PR TITLE
"dnu restore" shouldn't stop on invalid root

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -134,7 +134,10 @@ namespace Microsoft.Framework.PackageManager
                 }
                 else
                 {
-                    throw new InvalidOperationException($"The given root {restoreDirectory} is invalid.");
+                    var errorMessage = $"The given root {restoreDirectory.Red().Bold()} is invalid.";
+                    ErrorMessages.GetOrAdd(restoreDirectory, _ => new List<string>()).Add(errorMessage);
+                    Reports.Error.WriteLine(errorMessage);
+                    return false;
                 }
 
                 var rootDirectory = ProjectResolver.ResolveRootDirectory(restoreDirectory);


### PR DESCRIPTION
Reaction to https://github.com/aspnet/dnx/commit/4bb7649793806ea0296c108fcc19b7816d14e850#commitcomment-11318212

@davidfowl , invalid root error is also shown at the very end of `dnu restore` output, just like other kinds of restore errors. This makes sure it is not lost in a long output:
![capture](https://cloud.githubusercontent.com/assets/1383883/7761668/6b9af766-ffdd-11e4-9174-851bc4c9dc3f.PNG)

