### PR TITLE
Fix #876, Correct handling of quotation marks in commands

### DIFF
--- a/src/Microsoft.Framework.ApplicationHost/Program.cs
+++ b/src/Microsoft.Framework.ApplicationHost/Program.cs
@@ -50,9 +50,11 @@ namespace Microsoft.Framework.ApplicationHost
             string replacementCommand;
             if (host.Project.Commands.TryGetValue(lookupCommand, out replacementCommand))
             {
-                var replacementArgs = CommandGrammar.Process(
-                    replacementCommand,
-                    GetVariable).ToArray();
+                // preserveSurroundingQuotes: false to imitate a shell. Shells remove quotation marks before calling
+                // Main methods. Here however we are invoking Main() without involving a shell.
+                var replacementArgs = CommandGrammar
+                    .Process(replacementCommand, GetVariable, preserveSurroundingQuotes: false)
+                    .ToArray();
                 options.ApplicationName = replacementArgs.First();
                 programArgs = replacementArgs.Skip(1).Concat(programArgs).ToArray();
             }

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuRestoreTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuRestoreTests.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Framework.CommonTestUtils;
+using Microsoft.Framework.PackageManager.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Framework.PackageManager
+{
+    [Collection(nameof(PackageManagerFunctionalTestCollection))]
+    public class DnuRestoreTests
+    {
+        private readonly PackageManagerFunctionalTestFixture _fixture;
+
+        public DnuRestoreTests(PackageManagerFunctionalTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public static IEnumerable<object[]> RuntimeComponents
+        {
+            get
+            {
+                return TestUtils.GetRuntimeComponentsCombinations();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuRestore_ExecutesScripts(string flavor, string os, string architecture)
+        {
+            bool isWindows = TestUtils.CurrentRuntimeEnvironment.OperatingSystem == "Windows";
+            var environment = new Dictionary<string, string>
+            {
+                { "DNX_TRACE", "0" },
+            };
+
+            var expectedPreContent =
+@"""one""
+""two""
+"">three""
+""four""
+";
+            var expectedPostContent =
+@"""five""
+""six""
+""argument seven""
+""argument eight""
+";
+
+            string projectJsonContent;
+            string scriptContent;
+            string scriptName;
+            if (isWindows)
+            {
+                projectJsonContent =
+@"{
+  ""frameworks"": {
+    ""dnx451"": { }
+  },
+  ""scripts"": {
+    ""prerestore"": [
+      ""script.cmd one two > pre"",
+      ""script.cmd ^>three >> pre && script.cmd ^ four >> pre""
+    ],
+    ""postrestore"": [
+      ""\""%project:Directory%/script.cmd\"" five six > post"",
+      ""\""%project:Directory%/script.cmd\"" \""argument seven\"" \""argument eight\"" >> post""
+    ]
+  }
+}";
+                scriptContent =
+@"@echo off
+
+:argumentStart
+if ""%~1""=="""" goto argumentEnd
+echo ""%~1""
+shift
+goto argumentStart
+:argumentEnd";
+                scriptName = "script.cmd";
+            }
+            else
+            {
+                projectJsonContent =
+@"{
+  ""frameworks"": {
+    ""dnx451"": { }
+  },
+  ""scripts"": {
+    ""prerestore"": [
+      ""script one two > pre"",
+      ""script.sh \\>three >> pre; ./script.sh four >> pre""
+    ],
+    ""postrestore"": [
+      ""\""%project:Directory%/script\"" five six > post"",
+      ""\""%project:Directory%/script.sh\"" \""argument seven\"" \""argument eight\"" >> post""
+    ]
+  }
+}";
+                scriptContent =
+@"#!/bin/bash --restricted
+set -o errexit
+
+for arg in ""$@""; do
+  printf ""\""%s\""\n"" ""$arg""
+done";
+                scriptName = "script.sh";
+            }
+
+            var projectStructure =
+$@"{{
+  '.': ['project.json', '{ scriptName }']
+}}";
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
+            using (var testEnv = new DnuTestEnvironment(runtimeHomePath, projectName: "Project Name"))
+            {
+                var projectPath = testEnv.ProjectPath;
+                DirTree.CreateFromJson(projectStructure)
+                    .WithFileContents("project.json", projectJsonContent)
+                    .WithFileContents(scriptName, scriptContent)
+                    .WriteTo(projectPath);
+                FileOperationUtils.MarkExecutable(Path.Combine(projectPath, scriptName));
+
+                string output;
+                string error;
+                var exitCode = DnuTestUtils.ExecDnu(
+                    runtimeHomePath,
+                    subcommand: "restore",
+                    arguments: null,
+                    stdOut: out output,
+                    stdErr: out error,
+                    environment: environment,
+                    workingDir: projectPath);
+
+                Assert.Equal(0, exitCode);
+                Assert.Empty(error);
+                Assert.Contains("Executing script 'prerestore' in project.json", output);
+                Assert.Contains("Executing script 'postrestore' in project.json", output);
+
+                var preContent = File.ReadAllText(Path.Combine(projectPath, "pre"));
+                Assert.Equal(expectedPreContent, preContent);
+                var postContent = File.ReadAllText(Path.Combine(projectPath, "post"));
+                Assert.Equal(expectedPostContent, postContent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- don't strip quotes surrounding command-line arguments when used in `scripts`
 - prevented command paths and grouping arguments containing spaces
 - pass `preserveSurroundingQuotes` into `CommandGrammar` to control stripping
- support expected shell capabilities such as quoting command and redirections
 - use `cmd /s /c` when executing `scripts` on Windows
 - use `/bin/bash -c` when executing `scripts` on Linux
- add functional tests of commands and scripts (together with `dnu restore`)
 - no `dnu restore` for .NET Core due to extra time required

note:
- `CommandGrammar` may need additional generalizations
 - e.g. unquoted term can't contain more than one escape sequence
 - but it's probably good enough for now
- _not_ adding quotes around variables replacements inserted into commands
 - no way of determining if replacement is already quoted
 - basically, leave it to project.json author to perform appropriate quoting for their platform

nits:
- ~~let VS do its thing with test services~~
- make `CommandGrammar` constructor private; used only in `Process()` method
- update a few `ScriptExecutor` comments, long lines, et cetera