### PR TITLE
Add dnx-crossgen.cmd

### DIFF
--- a/scripts/dnx-crossgen.cmd
+++ b/scripts/dnx-crossgen.cmd
@@ -1,0 +1,11 @@
+@Echo OFF
+SETLOCAL
+SET ERRORLEVEL=
+
+SET "DNX_RUNTIME_PATH=%~dp0."
+SET "CROSSGEN_PATH=%~dp0crossgen.exe"
+
+"%~dp0dnx" --appbase "%CD%" --lib "%~dp0lib\Microsoft.Framework.Project" "Microsoft.Framework.Project" crossgen --exePath "%CROSSGEN_PATH%" --runtimePath "%DNX_RUNTIME_PATH%" %*
+
+exit /b %ERRORLEVEL%
+ENDLOCAL


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1572

@muratg 

Here is the plan: I am going to add `dnx-crossgen.cmd` without removing `k-crossgen.cmd` and change all other repos to use `dnx-crossgen.cmd`.

Then Coherence-Signed should be able to pass because even some part of our building process is still using the `k-crossgen.cmd`, `k-crossgen.cmd` is available.

After Coherence-Signed passes, I'll merge another PR that removes `k-crossgen.cmd`. This ensures smooth transition without breaking anything.