### PR TITLE
"dnu publish" puts bundled runtimes to "runtimes" subfolder

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
@@ -3,17 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
-using Microsoft.Framework.PackageManager.Utils;
 using Microsoft.Framework.Runtime;
-using Microsoft.Framework.Runtime.DependencyManagement;
 using Newtonsoft.Json.Linq;
 using NuGet;
 
@@ -466,7 +461,7 @@ namespace Microsoft.Framework.PackageManager.Publish
             var appSettingsElement = GetOrAddElement(parent: xDoc.Root, name: "appSettings");
 
             // Always generate \ since web.config is a IIS thing only
-            var relativePackagesPath = PathUtility.GetRelativePath(wwwRootOutWebConfigFilePath, root.TargetPackagesPath)
+            var relativeRuntimesPath = PathUtility.GetRelativePath(wwwRootOutWebConfigFilePath, root.TargetRuntimesPath)
                                                   .Replace(Path.DirectorySeparatorChar, '\\');
 
             var defaultRuntime = root.Runtimes.FirstOrDefault();
@@ -475,7 +470,7 @@ namespace Microsoft.Framework.PackageManager.Publish
             var keyValuePairs = new Dictionary<string, string>()
             {
                 { Runtime.Constants.WebConfigBootstrapperVersion, GetBootstrapperVersion(root) },
-                { Runtime.Constants.WebConfigRuntimePath, relativePackagesPath },
+                { Runtime.Constants.WebConfigRuntimePath, relativeRuntimesPath },
                 { Runtime.Constants.WebConfigRuntimeVersion, GetRuntimeVersion(defaultRuntime) },
                 { Runtime.Constants.WebConfigRuntimeFlavor, GetRuntimeFlavor(defaultRuntime) },
                 { Runtime.Constants.WebConfigRuntimeAppBase, appBase },

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishRoot.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Framework.Runtime;
@@ -27,12 +26,14 @@ namespace Microsoft.Framework.PackageManager.Publish
             OutputPath = outputPath;
             HostServices = hostServices;
             TargetPackagesPath = Path.Combine(outputPath, AppRootName, "packages");
+            TargetRuntimesPath = Path.Combine(outputPath, AppRootName, "runtimes");
             Operations = new PublishOperations();
             LibraryDependencyContexts = new Dictionary<Library, IList<DependencyContext>>();
         }
 
         public string OutputPath { get; private set; }
         public string TargetPackagesPath { get; private set; }
+        public string TargetRuntimesPath { get; private set; }
         public string SourcePackagesPath { get; set; }
         
         public bool NoSource { get; set; }
@@ -112,7 +113,7 @@ namespace Microsoft.Framework.PackageManager.Publish
                 var runtimeFolder = string.Empty;
                 if (Runtimes.Any())
                 {
-                    runtimeFolder = string.Format(@"%~dp0{0}\packages\{1}\bin\", AppRootName, Runtimes.First().Name);
+                    runtimeFolder = string.Format(@"%~dp0{0}\runtimes\{1}\bin\", AppRootName, Runtimes.First().Name);
                 }
 
                 File.WriteAllText(
@@ -153,7 +154,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                 var runtimeFolder = string.Empty;
                 if (Runtimes.Any())
                 {
-                    runtimeFolder = string.Format(@"$DIR/{0}/packages/{1}/bin/",
+                    runtimeFolder = string.Format(@"$DIR/{0}/runtimes/{1}/bin/",
                         AppRootName, Runtimes.First().Name);
                 }
 

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishRuntime.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishRuntime.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Framework.PackageManager.Publish
             _frameworkName = frameworkName;
             _runtimePath = runtimePath;
             Name = new DirectoryInfo(_runtimePath).Name;
-            TargetPath = Path.Combine(root.TargetPackagesPath, Name);
+            TargetPath = Path.Combine(root.TargetRuntimesPath, Name);
         }
 
         public string Name { get; private set; }

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
@@ -125,7 +125,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 <configuration>
   <appSettings>
     <add key=""{0}"" value="""" />
-    <add key=""{1}"" value=""..\approot\packages"" />
+    <add key=""{1}"" value=""..\approot\runtimes"" />
     <add key=""{2}"" value="""" />
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
@@ -236,7 +236,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
 <configuration>
   <appSettings>
     <add key=""{0}"" value="""" />
-    <add key=""{1}"" value=""..\approot\packages"" />
+    <add key=""{1}"" value=""..\approot\runtimes"" />
     <add key=""{2}"" value="""" />
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
@@ -788,7 +788,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   </nonRelatedElement>
   <appSettings>
     <add key=""{0}"" value="""" />
-    <add key=""{1}"" value=""..\approot\packages"" />
+    <add key=""{1}"" value=""..\approot\runtimes"" />
     <add key=""{2}"" value="""" />
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
@@ -890,7 +890,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   <appSettings>
     <add key=""non-related-key"" value=""OLD_VALUE"" />
     <add key=""{0}"" value="""" />
-    <add key=""{1}"" value=""..\approot\packages"" />
+    <add key=""{1}"" value=""..\approot\runtimes"" />
     <add key=""{2}"" value="""" />
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
@@ -1059,7 +1059,8 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
         '.': ['project.json', 'project.lock.json']
       }
     },
-    'packages': {
+    'packages': {},
+    'runtimes': {
       'RUNTIME_PACKAGE_NAME': {}
     }
   }
@@ -1100,8 +1101,8 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                     .RemoveFile(Path.Combine("bin", "lib", "Microsoft.Framework.PackageManager",
                         "bin", "profile", "startup.prof"));
 
-                var batchFileBinPath = string.Format(@"%~dp0approot\packages\{0}\bin\", runtimeName);
-                var bashScriptBinPath = string.Format("$DIR/approot/packages/{0}/bin/", runtimeName);
+                var batchFileBinPath = string.Format(@"%~dp0approot\runtimes\{0}\bin\", runtimeName);
+                var bashScriptBinPath = string.Format("$DIR/approot/runtimes/{0}/bin/", runtimeName);
 
                 var expectedOutputDir = DirTree.CreateFromJson(expectedOutputStructure)
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
@@ -1137,7 +1138,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                         BashScriptTemplate, EnvironmentNames.AppBase, testEnv.ProjectName, bashScriptBinPath, Constants.BootstrapperExeName, "run")
                     .WithFileContents("kestrel",
                         BashScriptTemplate, EnvironmentNames.AppBase, testEnv.ProjectName, bashScriptBinPath, Constants.BootstrapperExeName, "kestrel")
-                    .WithSubDir(Path.Combine("approot", "packages", runtimeName), runtimeSubDir);
+                    .WithSubDir(Path.Combine("approot", "runtimes", runtimeName), runtimeSubDir);
 
                 Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.PublishOutputDirPath,
                     compareFileContents: true));


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1155

Part of verification can only be done after @davidfowl fixes `dnu publish`.