### PR TITLE
"dnu restore" uses correct HTTP request option to avoid memory explosion

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
             {
                 HttpStatusCode statusCode;
 
-                using (var response = await _client.SendAsync(request))
+                using (var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
                 {
                     response.EnsureSuccessStatusCode();
                     statusCode = response.StatusCode;


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1849

@Tratcher 

The goal is to have a seekable stream containing HTTP response content. However, we don't want to have the whole response content into memory.

Use `HttpCompletionOption.ResponseHeadersRead` and copy `response.Content` to a temp file, then open a stream to the temp file. This can meet the goal above.