### PR TITLE
Fix build break on NETCore packages

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Framework.PackageManager.Utils
             {
                 Table =
                 {
-                    { "any", new FrameworkName("Core", new Version(5, 0)) }
+                    { "any", new FrameworkName(VersionUtility.PortableFrameworkIdentifier, new Version(5, 0)) }
                 },
                 Parser = TargetFrameworkName_Parser,
                 OnIsCriteriaSatisfied = TargetFrameworkName_IsCriteriaSatisfied

--- a/src/Microsoft.Framework.Runtime.Compilation.DesignTime/project.json
+++ b/src/Microsoft.Framework.Runtime.Compilation.DesignTime/project.json
@@ -17,10 +17,11 @@
       "dependencies": {
         "System.Collections.Concurrent": "4.0.10-beta-*",
         "System.Dynamic.Runtime": "4.0.10-beta-*",
+        "System.Globalization": "4.0.10-beta-*",
         "System.IO.FileSystem": "4.0.0-beta-*",
+        "System.Net.Primitives": "4.0.10-beta-*",
         "System.Net.Sockets": "4.0.10-beta-*",
-        "System.Threading.Thread": "4.0.0-beta-*",
-        "System.Globalization": "4.0.10-beta-*"
+        "System.Threading.Thread": "4.0.0-beta-*"
       }
     }
   },


### PR DESCRIPTION
If we take NETCore packages, this change is needed to avoid build break.