### PR TITLE
Removing all dnx.clr.managed.dll dependencies

### DIFF
--- a/src/dnx.clr.managed/DomainManager.cs
+++ b/src/dnx.clr.managed/DomainManager.cs
@@ -6,7 +6,6 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 using dnx.clr.managed;
-using dnx.host;
 using Microsoft.Framework.Runtime;
 
 public class DomainManager : AppDomainManager

--- a/src/dnx.clr.managed/EntryPoint.cs
+++ b/src/dnx.clr.managed/EntryPoint.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using dnx.host;
 
 namespace dnx.clr.managed
 {

--- a/src/dnx.clr.managed/RuntimeBootstrapper.cs
+++ b/src/dnx.clr.managed/RuntimeBootstrapper.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace dnx.clr.managed
+{
+    internal class RuntimeBootstrapper
+    {
+        public static int Execute(string[] argv)
+        {
+            var executeMethodInfo = GetBootstrapperType()
+                .GetMethod("Execute", BindingFlags.Static | BindingFlags.Public, null, new[] { argv.GetType() }, null);
+            return (int)executeMethodInfo.Invoke(null, new object[] { argv });
+        }
+
+        public static Task<int> ExecuteAsync(string[] argv)
+        {
+            var executeMethodInfo = GetBootstrapperType()
+                .GetMethod("ExecuteAsync", BindingFlags.Static | BindingFlags.Public, null, new[] { argv.GetType() }, null);
+            return (Task<int>)executeMethodInfo.Invoke(null, new object[] { argv });
+        }
+
+        private static Type GetBootstrapperType()
+        {
+            var dnxHost = Assembly.Load("dnx.host");
+            return dnxHost.GetType("dnx.host.RuntimeBootstrapper");
+        }
+    }
+}

--- a/src/dnx.clr.managed/project.json
+++ b/src/dnx.clr.managed/project.json
@@ -2,13 +2,14 @@
     "version": "1.0.0-*",
     "compilationOptions": { "define": [ "TRACE" ], "allowUnsafe": true, "warningsAsErrors": true },
     "dependencies": {
-        "dnx.host": "1.0.0-*",
-        "Microsoft.Framework.Runtime.Sources": { "version": "1.0.0-*", "type": "build" }
     },
     "frameworks": {
         "dnx451": { }
     },
-
+    "compileFiles": [
+      "../Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs",
+      "../Microsoft.Framework.Runtime.Sources/Impl/Constants.cs"
+    ],
     "scripts": {
         "postbuild": [
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/dnx451/*.* %project:Directory%/../../artifacts/build/dnx-clr-win-x86/bin"


### PR DESCRIPTION
dnx.clr.managed.dll will need to be strong-name signed and therefore cannot depend on any assemblies that don't have a strong name.