### PR TITLE
Skip validation portable part of the framework when the version >= 5

### DIFF
--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -259,7 +259,7 @@ namespace NuGet
             }
 
             // if this is a .NET Portable framework name, validate the profile part to ensure it is valid
-            if (identifierPart.Equals(PortableFrameworkIdentifier, StringComparison.OrdinalIgnoreCase))
+            if (version.Major < 5 && identifierPart.Equals(PortableFrameworkIdentifier, StringComparison.OrdinalIgnoreCase))
             {
                 ValidatePortableFrameworkProfilePart(profilePart);
             }

--- a/test/Microsoft.Framework.Runtime.Tests/VersionUtilityFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/VersionUtilityFacts.cs
@@ -104,5 +104,22 @@ namespace Microsoft.Framework.Runtime.Tests
             var fx = new FrameworkName(longName, Version.Parse(version), profile);
             Assert.Equal(shortName, VersionUtility.GetShortFrameworkName(fx));
         }
+        
+        [Theory]
+        [InlineData(".NETPortable1.0", true)]
+        [InlineData(".NETPortable4.9", true)]
+        [InlineData(".NETPortable5.0", false)]
+        public void SkipPortablePartValidationWhenVersionIsHigherThanFive(string frameworkName, bool throwException)
+        {
+            if (throwException)
+            {
+                Assert.Throws<ArgumentException>(() => VersionUtility.ParseFrameworkName(frameworkName));
+            }
+            else
+            {
+                var framework = VersionUtility.ParseFrameworkName(frameworkName);
+                Assert.Equal(".NETPortable", framework.Identifier);
+            }
+        }
     }
 }


### PR DESCRIPTION
@davidfowl 