### PR TITLE
teach dnx about netcore50 compat with netportable50

### DIFF
--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -116,7 +116,8 @@ namespace NuGet
             // Allow a net package to be installed in an aspnet (or dnx, transitively by above) project
             { AspNetFrameworkIdentifier, Tuple.Create(_emptyVersion, new FrameworkName(NetFrameworkIdentifier, MaxVersion)) },
 
-            { NetFrameworkIdentifier, Tuple.Create(new Version(4, 6), new FrameworkName(PortableFrameworkIdentifier, new Version(5, 0))) }
+            { NetFrameworkIdentifier, Tuple.Create(new Version(4, 6), new FrameworkName(PortableFrameworkIdentifier, new Version(5, 0))) },
+            { NetCoreFrameworkIdentifier, Tuple.Create(new Version(5, 0), new FrameworkName(PortableFrameworkIdentifier, new Version(5, 0))) }
         };
 
         public static Version DefaultTargetFrameworkVersion


### PR DESCRIPTION
We're still locking down the netportable name, but this logic is sound no matter the final name :).

/cc @bricelam @troydai @muratg @davidfowl 