### PR TITLE
fix hang in FindRuntimeSpecs

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -555,9 +555,9 @@ namespace Microsoft.Framework.PackageManager
         {
             effectiveRuntimeSpecs.RemoveAll(spec => spec.Name == runtimeName);
 
+            IEnumerable<string> imports = null;
             foreach (var runtimeFile in runtimeFiles)
             {
-                IEnumerable<string> imports = null;
                 RuntimeSpec runtimeSpec;
                 if (runtimeFile.Runtimes.TryGetValue(runtimeName, out runtimeSpec))
                 {
@@ -571,23 +571,23 @@ namespace Microsoft.Framework.PackageManager
                     }
                     effectiveRuntimeSpecs.Add(runtimeSpec);
                 }
-                if (imports != null)
+            }
+            if (imports != null)
+            {
+                foreach (var import in imports)
                 {
-                    foreach (var import in imports)
+                    if (circularImport(import))
                     {
-                        if (circularImport(import))
+                        if (imports != null)
                         {
-                            if (imports != null)
-                            {
-                                throw new Exception(string.Format("Circular import for {0}", runtimeName));
-                            }
+                            throw new Exception(string.Format("Circular import for {0}", runtimeName));
                         }
-                        FindRuntimeSpecs(
-                            import,
-                            runtimeFiles,
-                            effectiveRuntimeSpecs,
-                            name => string.Equals(name, runtimeName, StringComparison.Ordinal) || circularImport(name));
                     }
+                    FindRuntimeSpecs(
+                        import,
+                        runtimeFiles,
+                        effectiveRuntimeSpecs,
+                        name => string.Equals(name, runtimeName, StringComparison.Ordinal) || circularImport(name));
                 }
             }
         }

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -555,9 +555,9 @@ namespace Microsoft.Framework.PackageManager
         {
             effectiveRuntimeSpecs.RemoveAll(spec => spec.Name == runtimeName);
 
-            IEnumerable<string> imports = null;
             foreach (var runtimeFile in runtimeFiles)
             {
+                IEnumerable<string> imports = null;
                 RuntimeSpec runtimeSpec;
                 if (runtimeFile.Runtimes.TryGetValue(runtimeName, out runtimeSpec))
                 {


### PR DESCRIPTION
Because `imports` was outside the loop, in the case where the last runtime in the list had no imports but the penultimate one DID have imports, the loop became infinite (technically it bounced between two call stack levels infinitely, it didn't actually get stuck in a single infinite loop)

/cc @lodejard @davidfowl