### PR TITLE
Fix a warning related to formatted output in dnx.coreclr.cpp

### DIFF
--- a/src/dnx.coreclr/dnx.coreclr.cpp
+++ b/src/dnx.coreclr/dnx.coreclr.cpp
@@ -506,7 +506,7 @@ extern "C" HRESULT __stdcall CallApplicationMain(PCALL_APPLICATION_MAIN_DATA dat
 
     if (FAILED(hr))
     {
-        wprintf_s(L"TPA      %d %s\n", wcslen(pwszTrustedPlatformAssemblies), pwszTrustedPlatformAssemblies);
+        wprintf_s(L"TPA      %Iu %s\n", wcslen(pwszTrustedPlatformAssemblies), pwszTrustedPlatformAssemblies);
         wprintf_s(L"AppPaths %s\n", wszAppPaths);
         printf_s("Failed to create app domain (%x).\n", hr);
         return hr;


### PR DESCRIPTION
@moozzyk 

After I upgrade my VS and C++ compiler, building DNX gives me an error:
![capture](https://cloud.githubusercontent.com/assets/1383883/8113630/1bf3fc92-1024-11e5-8dcc-78d4e5a96a36.PNG)
