### PR TITLE
Make dnx build 75% faster

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildOptions.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.PackageManager
     {
         public string OutputDir { get; set; }
 
-        public string ProjectDir { get; set; }
+        public IList<string> ProjectPatterns { get; set; }
 
         public IList<string> Configurations { get; set; }
 
@@ -24,6 +24,7 @@ namespace Microsoft.Framework.PackageManager
         {
             Configurations = new List<string>();
             TargetFrameworks = new List<string>();
+            ProjectPatterns = new List<string>();
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/ConsoleCommands/BuildConsoleCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/ConsoleCommands/BuildConsoleCommand.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Framework.PackageManager
                 var optionOut = c.Option("--out <OUTPUT_DIR>", "Output directory", CommandOptionType.SingleValue);
                 var optionQuiet = c.Option("--quiet", "Do not show output such as dependencies in use",
                     CommandOptionType.NoValue);
-                var argProjectDir = c.Argument("[project]", "Project to build, default is current directory");
+                var argProjectDir = c.Argument(
+                    "[projects]", 
+                    "One or more projects build. If not specified, the project in the current directory will be used.",
+                    multipleValues: true);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(() =>
@@ -29,7 +32,11 @@ namespace Microsoft.Framework.PackageManager
 
                     var buildOptions = new BuildOptions();
                     buildOptions.OutputDir = optionOut.Value();
-                    buildOptions.ProjectDir = argProjectDir.Value ?? Directory.GetCurrentDirectory();
+                    buildOptions.ProjectPatterns = argProjectDir.Values;
+                    if (buildOptions.ProjectPatterns.Count == 0)
+                    {
+                        buildOptions.ProjectPatterns.Add(Path.Combine(Directory.GetCurrentDirectory(), "project.json"));
+                    }
                     buildOptions.Configurations = optionConfiguration.Values;
                     buildOptions.TargetFrameworks = optionFramework.Values;
                     buildOptions.GeneratePackages = false;

--- a/src/Microsoft.Framework.PackageManager/ConsoleCommands/PackConsoleCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/ConsoleCommands/PackConsoleCommand.cs
@@ -22,7 +22,10 @@ namespace Microsoft.Framework.PackageManager
                 var optionDependencies = c.Option("--dependencies", "Copy dependencies", CommandOptionType.NoValue);
                 var optionQuiet = c.Option("--quiet", "Do not show output such as source/destination of nupkgs",
                     CommandOptionType.NoValue);
-                var argProjectDir = c.Argument("[project]", "Project to pack, default is current directory");
+                var argProjectDir = c.Argument(
+                    "[projects]", 
+                    "One or more projects to pack, default is current directory",
+                    multipleValues: true);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(() =>
@@ -31,7 +34,11 @@ namespace Microsoft.Framework.PackageManager
 
                     var buildOptions = new BuildOptions();
                     buildOptions.OutputDir = optionOut.Value();
-                    buildOptions.ProjectDir = argProjectDir.Value ?? Directory.GetCurrentDirectory();
+                    buildOptions.ProjectPatterns = argProjectDir.Values;
+                    if (buildOptions.ProjectPatterns.Count == 0)
+                    {
+                        buildOptions.ProjectPatterns.Add(Path.Combine(Directory.GetCurrentDirectory(), "project.json"));
+                    }
                     buildOptions.Configurations = optionConfiguration.Values;
                     buildOptions.TargetFrameworks = optionFramework.Values;
                     buildOptions.GeneratePackages = true;

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Framework.PackageManager.Publish
 
             // Generate nupkg from this project dependency
             var buildOptions = new BuildOptions();
-            buildOptions.ProjectDir = project.ProjectDirectory;
+            buildOptions.ProjectPatterns.Add(project.ProjectDirectory);
             buildOptions.OutputDir = Path.Combine(project.ProjectDirectory, "bin");
             buildOptions.Configurations.Add(root.Configuration);
             buildOptions.GeneratePackages = true;

--- a/src/Microsoft.Framework.PackageManager/project.json
+++ b/src/Microsoft.Framework.PackageManager/project.json
@@ -12,7 +12,13 @@
         "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
         "Newtonsoft.Json": "6.0.6"
     },
-    "compile": "..\\Microsoft.Framework.ApplicationHost\\Impl\\**\\*.cs",
+    "compile": [
+        "../Microsoft.Framework.ApplicationHost/Impl/**/*.cs",
+        "../../submodules/FileSystem/src/Microsoft.Framework.FileSystemGlobbing/**/*.cs"
+    ],
+    "preprocess": [
+        "../../ext/compiler/preprocess/Internalization.cs"
+    ],
 
     "frameworks": {
         "dnx451": {


### PR DESCRIPTION
Allow `dnu build` and `dnu pack` to work with globbing patterns and build all projects at once. This is a big perf improvement because each project is compiled only once (caches are shared). Change is 100% backward compatible with the old one-project-one-build.

The more projects you have, the better the results are. MVC has 77 projects in `src` and `test`  combined.

Perf results summary:

```
src:      60s -> 15s
test:     436s -> 106s
src+test: 493s -> 111s
```

Full perf results:

```
Measure-Command { Get-ChildItem -path 'src' -filter project.json -Recurse | Select -expand FullName | Split-Path | %{ dnu build $_ }} | Select -expand TotalSeconds
60.3610104
Measure-Command { dnu build src/** } | Select -expand TotalSeconds
15.2666252
Measure-Command { Get-ChildItem -path 'test' -filter project.json -Recurse | Select -expand FullName | Split-Path | %{ dnu build $_ }} | Select -expand TotalSeconds
436.9794821
Measure-Command { dnu build  test/** } | Select -expand TotalSeconds
103.2918838
Measure-Command { Get-ChildItem -path 'src','test' -filter project.json -Recurse | Select -expand FullName | Split-Path | %{ dnu build $_ }} | Select -expand TotalSeconds
493.5432721
Measure-Command { dnu build  src/** test/** } | Select -expand TotalSeconds
111.036362
```

Please review: @davidfowl @ChengTian 