### PR TITLE
Fix framework references for .NETCore 5.0 by not allowing them

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -42,9 +42,17 @@ namespace Microsoft.Framework.PackageManager.Utils
                     }
 
                     var assemblyPath = Path.Combine(installPath, filePath);
-                    if (IsAssemblyServiceable(assemblyPath))
+                    try
                     {
-                        lockFileLib.IsServiceable = true;
+                        if (IsAssemblyServiceable(assemblyPath))
+                        {
+                            lockFileLib.IsServiceable = true;
+                            break;
+                        }
+                    }
+                    catch
+                    {
+                        lockFileLib.IsServiceable = false;
                         break;
                     }
                 }
@@ -81,9 +89,8 @@ namespace Microsoft.Framework.PackageManager.Utils
             }
 
             // TODO: Remove this when we do #596
-            // ASP.NET Core isn't compatible with generic PCL profiles
-            if (!string.Equals(framework.Identifier, VersionUtility.AspNetCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
-                !string.Equals(framework.Identifier, VersionUtility.DnxCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase))
+            // ASP.NET Core and .NET Core 5.0 don't have framework reference assemblies
+            if (!VersionUtility.IsPackageBased(framework))
             {
                 IEnumerable<FrameworkAssemblyReference> frameworkAssemblies;
                 if (VersionUtility.GetNearest(framework, package.FrameworkAssemblies, out frameworkAssemblies))

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -24,9 +24,9 @@ namespace NuGet
         public static readonly string DnxCoreFrameworkIdentifier = "DNXCore";
         public static readonly string PortableFrameworkIdentifier = ".NETPortable";
         public static readonly string NetPlatformFrameworkIdentifier = ".NETPlatform";
+        public static readonly string NetCoreFrameworkIdentifier = ".NETCore";
 
         internal const string NetFrameworkIdentifier = ".NETFramework";
-        private const string NetCoreFrameworkIdentifier = ".NETCore";
         internal const string AspNetFrameworkIdentifier = "Asp.Net";
         internal const string DnxFrameworkIdentifier = "DNX";
         internal const string DnxFrameworkShortName = "dnx";
@@ -40,6 +40,7 @@ namespace NuGet
         public static readonly FrameworkName UnsupportedFrameworkName = new FrameworkName("Unsupported", new Version(0, 0));
 
         private static readonly Version _emptyVersion = new Version(0, 0);
+        private static readonly Version _version5 = new Version(5, 0);
 
         private static readonly IDictionary<string, string> _knownIdentifiers = PopulateKnownFrameworks();
 
@@ -89,6 +90,15 @@ namespace NuGet
                 }
             }
         };
+
+        public static bool IsPackageBased(FrameworkName framework)
+        {
+            return
+                string.Equals(framework.Identifier, DnxCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(framework.Identifier, AspNetCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) ||
+                (string.Equals(framework.Identifier, NetCoreFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) && framework.Version >= _version5);
+        }
+
 
         // These aliases allow us to accept 'wp', 'wp70', 'wp71', 'windows', 'windows8' as valid target farmework folders.
         private static readonly Dictionary<FrameworkName, FrameworkName> _frameworkNameAlias = new Dictionary<FrameworkName, FrameworkName>(FrameworkNameEqualityComparer.Default)


### PR DESCRIPTION
Once they are blocked, the regular assembly references (lib/netcore50 and friends) take over and everything is :sun_with_face: and :sparkles: and :bouquet:

I'm build verifying now and will push to release (with a better commit message) when that's done.

/cc @troydai @davidfowl 