### PR TITLE
Setting the correct version of Win10SDK

### DIFF
--- a/build/Config.Definitions.Props
+++ b/build/Config.Definitions.Props
@@ -26,4 +26,7 @@
       <Platform>ARM</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <PropertyGroup>
+    <WindowsTargetPlatformVersion Condition="'$(BuildForOneCore)' == 'True'">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0', 'ProductVersion', null, RegistryView.Registry64, RegistryView.Registry32)).0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Framework.PackageManager/Building/BuildOptions.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.PackageManager
     {
         public string OutputDir { get; set; }
 
-        public string ProjectDir { get; set; }
+        public IList<string> ProjectPatterns { get; set; }
 
         public IList<string> Configurations { get; set; }
 
@@ -24,6 +24,7 @@ namespace Microsoft.Framework.PackageManager
         {
             Configurations = new List<string>();
             TargetFrameworks = new List<string>();
+            ProjectPatterns = new List<string>();
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/ConsoleCommands/BuildConsoleCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/ConsoleCommands/BuildConsoleCommand.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Framework.PackageManager
                 var optionOut = c.Option("--out <OUTPUT_DIR>", "Output directory", CommandOptionType.SingleValue);
                 var optionQuiet = c.Option("--quiet", "Do not show output such as dependencies in use",
                     CommandOptionType.NoValue);
-                var argProjectDir = c.Argument("[project]", "Project to build, default is current directory");
+                var argProjectDir = c.Argument(
+                    "[projects]", 
+                    "One or more projects build. If not specified, the project in the current directory will be used.",
+                    multipleValues: true);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(() =>
@@ -29,7 +32,11 @@ namespace Microsoft.Framework.PackageManager
 
                     var buildOptions = new BuildOptions();
                     buildOptions.OutputDir = optionOut.Value();
-                    buildOptions.ProjectDir = argProjectDir.Value ?? Directory.GetCurrentDirectory();
+                    buildOptions.ProjectPatterns = argProjectDir.Values;
+                    if (buildOptions.ProjectPatterns.Count == 0)
+                    {
+                        buildOptions.ProjectPatterns.Add(Path.Combine(Directory.GetCurrentDirectory(), "project.json"));
+                    }
                     buildOptions.Configurations = optionConfiguration.Values;
                     buildOptions.TargetFrameworks = optionFramework.Values;
                     buildOptions.GeneratePackages = false;

--- a/src/Microsoft.Framework.PackageManager/ConsoleCommands/PackConsoleCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/ConsoleCommands/PackConsoleCommand.cs
@@ -22,7 +22,10 @@ namespace Microsoft.Framework.PackageManager
                 var optionDependencies = c.Option("--dependencies", "Copy dependencies", CommandOptionType.NoValue);
                 var optionQuiet = c.Option("--quiet", "Do not show output such as source/destination of nupkgs",
                     CommandOptionType.NoValue);
-                var argProjectDir = c.Argument("[project]", "Project to pack, default is current directory");
+                var argProjectDir = c.Argument(
+                    "[projects]", 
+                    "One or more projects to pack, default is current directory",
+                    multipleValues: true);
                 c.HelpOption("-?|-h|--help");
 
                 c.OnExecute(() =>
@@ -31,7 +34,11 @@ namespace Microsoft.Framework.PackageManager
 
                     var buildOptions = new BuildOptions();
                     buildOptions.OutputDir = optionOut.Value();
-                    buildOptions.ProjectDir = argProjectDir.Value ?? Directory.GetCurrentDirectory();
+                    buildOptions.ProjectPatterns = argProjectDir.Values;
+                    if (buildOptions.ProjectPatterns.Count == 0)
+                    {
+                        buildOptions.ProjectPatterns.Add(Path.Combine(Directory.GetCurrentDirectory(), "project.json"));
+                    }
                     buildOptions.Configurations = optionConfiguration.Values;
                     buildOptions.TargetFrameworks = optionFramework.Values;
                     buildOptions.GeneratePackages = true;

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Framework.PackageManager.Publish
 
             // Generate nupkg from this project dependency
             var buildOptions = new BuildOptions();
-            buildOptions.ProjectDir = project.ProjectDirectory;
+            buildOptions.ProjectPatterns.Add(project.ProjectDirectory);
             buildOptions.OutputDir = Path.Combine(project.ProjectDirectory, "bin");
             buildOptions.Configurations.Add(root.Configuration);
             buildOptions.GeneratePackages = true;

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/HttpSource.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
                 // The update of a cached file is divided into two steps:
                 // 1) Delete the old file. 2) Create a new file with the same name.
                 // To prevent race condition among multiple processes, here we use a lock to make the update atomic.
-                await ConcurrencyUtilities.ExecuteWithFileLocked(result.CacheFileName, timeout: TimeSpan.FromSeconds(20), action: async _ =>
+                await ConcurrencyUtilities.ExecuteWithFileLocked(result.CacheFileName, action: async _ =>
                 {
                     using (var stream = CreateAsyncFileStream(
                         newFile,
@@ -223,7 +223,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(cacheFile, timeout: TimeSpan.FromSeconds(20), action: _ =>
+            return await ConcurrencyUtilities.ExecuteWithFileLocked(cacheFile, action: _ =>
             {
                 if (File.Exists(cacheFile))
                 {

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, timeout: TimeSpan.FromSeconds(20), action: _ =>
+            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, action: _ =>
             {
                 return Task.FromResult(
                     new FileStream(result.TempFileName, FileMode.Open, FileAccess.Read,

--- a/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Framework.PackageManager
 
             // Acquire the lock on a nukpg before we extract it to prevent the race condition when multiple
             // processes are extracting to the same destination simultaneously
-            await ConcurrencyUtilities.ExecuteWithFileLocked(targetNupkg, timeout: TimeSpan.FromSeconds(20), action: async _ =>
+            await ConcurrencyUtilities.ExecuteWithFileLocked(targetNupkg, action: async _ =>
             {
                 string packageHash;
                 using (var sha512 = SHA512.Create())

--- a/src/Microsoft.Framework.PackageManager/project.json
+++ b/src/Microsoft.Framework.PackageManager/project.json
@@ -12,7 +12,13 @@
         "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
         "Newtonsoft.Json": "6.0.6"
     },
-    "compile": "..\\Microsoft.Framework.ApplicationHost\\Impl\\**\\*.cs",
+    "compile": [
+        "../Microsoft.Framework.ApplicationHost/Impl/**/*.cs",
+        "../../submodules/FileSystem/src/Microsoft.Framework.FileSystemGlobbing/**/*.cs"
+    ],
+    "preprocess": [
+        "../../ext/compiler/preprocess/Internalization.cs"
+    ],
 
     "frameworks": {
         "dnx451": {

--- a/src/Microsoft.Framework.Runtime/Servicing/Breadcrumbs.cs
+++ b/src/Microsoft.Framework.Runtime/Servicing/Breadcrumbs.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Framework.Runtime.Servicing
             string fullFilePath = Path.Combine(_breadcrumbsFolder, fileName);
 
             // Execute with file locked because multiple processes can run at the same time
-            ConcurrencyUtilities.ExecuteWithFileLocked(fullFilePath, timeout: TimeSpan.FromSeconds(20), action: _ =>
+            ConcurrencyUtilities.ExecuteWithFileLocked(fullFilePath, action: _ =>
             {
                 try
                 {


### PR DESCRIPTION
 - Enables buildign for OneCore on Win8.1 machines with Win10SDK installed.
 - Fixes an issue where broken/incomplete 10.0.10056.0 Wind10SDK is installed on the box and building fails

 Note build.cmd will not try building for onecore if it can't find Win10SDK with onecore.lib

This changes enables updating our CIs to build for OneCore/ARM
It also should prevent issues when dogfooding/upgrading VS on dev boxes
