### PR TITLE
build: Enables FreeBSD support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if test `uname` = Darwin; then
     cachedir=~/Library/Caches/KBuild

--- a/build/batchcopy.sh
+++ b/build/batchcopy.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 echo "Copy From: $1"
 echo "       To: $2"

--- a/scripts/dnu.sh
+++ b/scripts/dnu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/scripts/dnx.sh
+++ b/scripts/dnx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishRoot.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishRoot.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Framework.PackageManager.Publish
                 relativeAppBase = string.Format("{0}/{1}/{2}", AppRootName, "src", _project.Name);
             }
 
-            const string template = @"#!/bin/bash
+            const string template = @"#!/usr/bin/env bash
 
 SOURCE=""${{BASH_SOURCE[0]}}""
 while [ -h ""$SOURCE"" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/src/Microsoft.Framework.PackageManager/Scripts/ScriptExecutor.cs
+++ b/src/Microsoft.Framework.PackageManager/Scripts/ScriptExecutor.cs
@@ -97,9 +97,9 @@ namespace Microsoft.Framework.PackageManager
                         scriptArguments[0] = $"{ quote }{ prefix }{ scriptCandidate }{ quote }";
                     }
 
-                    // Always use /bin/bash -c in order to support redirection and so on; similar to Windows case.
+                    // Always use /usr/bin/env bash -c in order to support redirection and so on; similar to Windows case.
                     // Unlike Windows, must escape quotation marks within the newly-quoted string.
-                    scriptArguments = new[] { "/bin/bash", "-c", "\"" }
+                    scriptArguments = new[] { "/usr/bin/env", "bash", "-c", "\"" }
                         .Concat(scriptArguments.Select(argument => argument.Replace("\"", "\\\"")))
                         .Concat(new[] { "\"" })
                         .ToArray();

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
 @""{0}{1}.exe"" --appbase ""%~dp0approot\src\{2}"" Microsoft.Framework.ApplicationHost {3} %*
 ";
 
-        private static readonly string BashScriptTemplate = @"#!/bin/bash
+        private static readonly string BashScriptTemplate = @"#!/usr/bin/env bash
 
 SOURCE=""${{BASH_SOURCE[0]}}""
 while [ -h ""$SOURCE"" ]; do # resolve $SOURCE until the file is no longer a symlink

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuRestoreTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuRestoreTests.cs
@@ -101,7 +101,7 @@ goto argumentStart
   }
 }";
                 scriptContent =
-@"#!/bin/bash --restricted
+@"#!/usr/bin/env bash
 set -o errexit
 
 for arg in ""$@""; do


### PR DESCRIPTION
Changed hardcoded bash shebang to env to support multiple directory
structures (required to build on FreeBSD).

Related-PR: #1756