### PR TITLE
Fx prefix should be stripped when LibraryRange is created

### DIFF
--- a/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Framework.Runtime
                     Version = version,
                     IsGacOrFrameworkReference = true
                 },
-                LoadableAssemblies = new[] { name },
+                LoadableAssemblies = new[] { libraryRange.GetReferenceAssemblyName() },
                 Dependencies = Enumerable.Empty<LibraryDependency>()
             };
         }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryRange.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryRange.cs
@@ -25,11 +25,20 @@ namespace Microsoft.Framework.Runtime
         public LibraryRange(string name, bool frameworkReference)
         {
             Name = name;
+
             if (frameworkReference)
             {
-                _frameworkAssemblyName = Name;
-                Name = FrameworkReferencePrefix + Name;
+                if (Name.IndexOf(FrameworkReferencePrefix) == 0)
+                {
+                    _frameworkAssemblyName = Name.Substring(FrameworkReferencePrefix.Length);
+                }
+                else
+                {
+                    _frameworkAssemblyName = Name;
+                    Name = FrameworkReferencePrefix + Name;
+                }
             }
+
             IsGacOrFrameworkReference = frameworkReference;
         }
 


### PR DESCRIPTION
@anurse @davidfowl @Eilon @muratg 
/cc @bricelam 

The issue is found by EF when `dnu list -a` failed in their build when targeting `net46`.

The issue is that when a `LibraryRange` is created from a framework assembly library, the loaded assembly name given has the `fx/` prefix. Also when a `LibraryRange` is created from `Library` the prefix is not stripped.

This should be checked in beta5 since it does breaks users.