### PR TITLE
fix issues with installing from a locked lock file

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -274,14 +274,6 @@ namespace Microsoft.Framework.PackageManager
                     new ProjectReferenceDependencyProvider(
                         projectResolver)));
 
-            if (useLockFile)
-            {
-                var lockFileProvider = new NuGetDependencyResolver(new PackageRepository(packagesDirectory));
-                lockFileProvider.ApplyLockFile(lockFile);
-                localProviders.Add(
-                    new LocalWalkProvider(lockFileProvider));
-            }
-
             localProviders.Add(
                 new LocalWalkProvider(
                     new NuGetDependencyResolver(packageRepository)));


### PR DESCRIPTION
Verbally approved by @Eilon and @danroth27 for beta5

@davidfowl says this should work :). Basically this was causing us to add the Lock File Libraries as synthetic "Packages" that already exist on disk meaning we never tried to download them.

/cc @davidfowl @ericstj @muratg 