### PR TITLE
Fixing a build break

### DIFF
--- a/build/Dnx.Common.Targets
+++ b/build/Dnx.Common.Targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="CreateVersionHeader" BeforeTargets="BeforeResourceCompile">
+  <Target Name="CreateVersionHeader" BeforeTargets="BeforeClCompile">
     <PropertyGroup>
       <ProductVersion Condition="'$(ProductVersion)' == ''">0.0.0</ProductVersion>
       <FileRevision Condition="'$(FileRevision)' == ''">0</FileRevision>


### PR DESCRIPTION
Before version.h would be generated before compiling resources. BeforeResourceCompile target is executed after BeforeClCompile target. Since we started including the version.h file in a cpp file we need to generate the file before the BeforeClCompile target otherwise the build fails after cleaning the working tree.

(Checking this in as soon as build passes on my box since this fixes the build)