### PR TITLE
Use Mono.4.0.1 on Travis CI to address dnu restore "unknown header" issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: csharp
 sudo: false
-mono:
-  - 3.12.0
 script:
   - ./build.sh --quiet verify


### PR DESCRIPTION
@davidfowl 

DNX build has been failing with the following error for 3 days
![capture](https://cloud.githubusercontent.com/assets/1383883/8295504/211e0db4-18fa-11e5-921b-57eb085d7464.PNG)

Investigated with @BrennanConroy and we tried using Mono.4.0.1 (default version) instead of 3.12. Turns out it can be fixed by switching to higher Mono version.

@Tratcher , can this error be regression introduced by recent HttpClient changes?