### PR TITLE
Make global.json accept project directories in 'projects' property

### DIFF
--- a/src/Microsoft.Framework.Runtime/ProjectResolver.cs
+++ b/src/Microsoft.Framework.Runtime/ProjectResolver.cs
@@ -79,9 +79,9 @@ namespace Microsoft.Framework.Runtime
 
             // Resolve all of the potential projects
             _projects = _searchPaths.Select(path => new DirectoryInfo(path))
-                .Distinct(new DirectoryInfoFullPathComparator())
                 .Where(d => d.Exists)
-                .SelectMany(d => d.EnumerateDirectories())
+                .SelectMany(d => new[] { d }.Concat(d.EnumerateDirectories()))
+                .Distinct(new DirectoryInfoFullPathComparator())
                 .Select(dirInfoToProjectInfo)
                 .ToLookup(d => d.Name);
         }

--- a/test/Microsoft.Framework.Runtime.FunctionalTests/ProjectResolverTests.cs
+++ b/test/Microsoft.Framework.Runtime.FunctionalTests/ProjectResolverTests.cs
@@ -194,5 +194,36 @@ namespace Microsoft.Framework.Runtime.FunctionalTests
                 Assert.NotNull(project);
             }
         }
+
+        [Fact]
+        public void CanSpecifyProjectDirectoryInGlobalJson()
+        {
+            var solutionStructure = @"{
+  'global.json': '',
+  'src': {
+    'ProjectA': {
+      'project.json': '{}'
+    }
+  },
+  'ProjectB': {
+    'project.json': '{}'
+  }
+}";
+
+            using (var solutionPath = new DisposableDir())
+            {
+                DirTree.CreateFromJson(solutionStructure)
+                    .WithFileContents("global.json", @"{
+  ""projects"": [""src"", ""ProjectB""]
+}")
+                    .WriteTo(solutionPath);
+
+                var resolutionRoot = Path.Combine(solutionPath, "src", "ProjectA");
+
+                Project project;
+                Assert.True(new ProjectResolver(resolutionRoot).TryResolveProject("ProjectB", out project));
+                Assert.NotNull(project);
+            }
+        }
     }
 }


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1841

Profiled with DotTrace and there is almost no impact on performance.

@davidfowl 