### PR TITLE
Cleaning TPAs

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />

--- a/build/Dnx.Native.Settings
+++ b/build/Dnx.Native.Settings
@@ -26,6 +26,7 @@
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions);$(Defines)</PreprocessorDefinitions>
       <TreatWarningAsError Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningAsError>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(MsBuildThisFileDirectory)..\src\dnx.common\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/makefile.shade
+++ b/makefile.shade
@@ -346,7 +346,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
 
         Directory.CreateDirectory(soOutputDir);
 
-        Exec(CLANG, string.Format("-fPIC -shared {0} -g -o {1} -DPLATFORM_LINUX --std=c++11 -ldl", string.Join(" ", sourceFiles), soOutputPath));
+        Exec(CLANG, string.Format("-fPIC -shared {0} -g -o {1} -DPLATFORM_LINUX --std=c++11 -ldl -Isrc/dnx.common/include", string.Join(" ", sourceFiles), soOutputPath));
     }
 
     copy sourceDir='${soOutputDir}' include='*.so' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME + ".unix")}' overwrite='${true}'
@@ -366,7 +366,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
 
         Directory.CreateDirectory(soOutputDir);
 
-        Exec(CLANG, string.Format("{0} -g -o {1} -DCORECLR_LINUX -DPLATFORM_UNIX -std=c++11 -ldl", string.Join(" ", sourceFiles), soOutputPath));
+        Exec(CLANG, string.Format("{0} -g -o {1} -DCORECLR_LINUX -DPLATFORM_UNIX -std=c++11 -ldl -Isrc/dnx.common/include", string.Join(" ", sourceFiles), soOutputPath));
     }
 
     copy sourceDir='${soOutputDir}' include='*' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "linux", "x64")}' overwrite='${true}'
@@ -386,7 +386,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
 
         Directory.CreateDirectory(soOutputDir);
 
-        Exec(CLANG, string.Format("-fPIC -shared {0} -g -o {1} -DPLATFORM_DARWIN --std=c++11 -ldl", string.Join(" ", sourceFiles), soOutputPath));
+        Exec(CLANG, string.Format("-fPIC -shared {0} -g -o {1} -DPLATFORM_DARWIN --std=c++11 -ldl -Isrc/dnx.common/include", string.Join(" ", sourceFiles), soOutputPath));
     }
 
     copy sourceDir='${soOutputDir}' include='*.dylib' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_CORECLR_NAME + ".unix")}' overwrite='${true}'
@@ -406,7 +406,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
 
         Directory.CreateDirectory(soOutputDir);
 
-        Exec(CLANG, string.Format("{0} -g -o {1} -DCORECLR_DARWIN -DPLATFORM_UNIX -std=c++11 -ldl", string.Join(" ", sourceFiles), soOutputPath));
+        Exec(CLANG, string.Format("{0} -g -o {1} -DCORECLR_DARWIN -DPLATFORM_UNIX -std=c++11 -ldl -Isrc/dnx.common/include", string.Join(" ", sourceFiles), soOutputPath));
     }
 
     copy sourceDir='${soOutputDir}' include='*' outputDir='${Path.Combine(BUILD_DIR2, BOOTSTRAPPER_FOLDER_NAME, "bin", "darwin", "x64")}' overwrite='${true}'
@@ -1403,47 +1403,32 @@ functions @{
         content.Add(@"// Copyright (c) .NET Foundation. All rights reserved.");
         content.Add(@"// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.");
         content.Add(@"");
-        content.Add(@"// This file will be dynamically updated during build to generate a ");
+        content.Add(@"// This file will be dynamically updated during build to generate a");
         content.Add(@"// minimal trusted platform assemblies list");
         content.Add(string.Empty);
         content.Add("#include \"stdafx.h\"");
-        content.Add("#include \"tpa.h\"");
+        content.Add("#include <vector>");
+        content.Add("#include <string>");
+        content.Add("#include \"xplat.h\"");
         content.Add(string.Empty);
-        content.Add("BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)");
+        content.Add("const std::vector<const dnx::char_t*> CreateTpaBase(bool native_images)");
         content.Add("{");
-        content.Add("    const size_t count = " + tpa.Length + ";");
-        content.Add("    LPCTSTR* pArray = new LPCTSTR[count];");
-        content.Add(string.Empty);
-        content.Add("    if (bNative)");
-        content.Add("    {");
-
+        content.Add("    return native_images");
+        content.Add("        ? std::vector<const dnx::char_t*>");
+        content.Add("        {");
         for (int i = 0; i < tpa.Length; ++i)
         {
-            content.Add(string.Format("        pArray[{0}] = _T(\"{1}{2}\");", i, tpa[i], ".ni.dll"));
+            content.Add(string.Format("            _X(\"{1}{2}\"),", i, tpa[i], ".ni.dll"));
         }
-
-        content.Add("    }");
-        content.Add("    else");
-        content.Add("    {");
-
+        content.Add("        }");
+        content.Add("        : std::vector<const dnx::char_t*>");
+        content.Add("        {");
         for (int i = 0; i < tpa.Length; ++i)
         {
-            content.Add(string.Format("        pArray[{0}] = _T(\"{1}{2}\");", i, tpa[i], ".dll"));
+            content.Add(string.Format("            _X(\"{1}{2}\"),", i, tpa[i], ".dll"));
         }
 
-        content.Add("    }");
-        content.Add(string.Empty);
-        content.Add("    *ppNames = pArray;");
-        content.Add("    *pcNames = count;");
-        content.Add(string.Empty);
-        content.Add("    return true;");
-        content.Add("}");
-        content.Add(string.Empty);
-        content.Add("BOOL FreeTpaBase(const LPCTSTR* values)");
-        content.Add("{");
-        content.Add("    delete[] values;");
-        content.Add(string.Empty);
-        content.Add("    return true;");
+        content.Add("        };");
         content.Add("}");
 
         File.WriteAllLines(output, content);

--- a/src/dnx.common/include/tpa.h
+++ b/src/dnx.common/include/tpa.h
@@ -3,5 +3,7 @@
 
 #pragma once
 
-BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative);
-BOOL FreeTpaBase(const LPCTSTR* values);
+#include <vector>
+#include "xplat.h"
+
+const std::vector<const dnx::char_t *> CreateTpaBase(bool bNative);

--- a/src/dnx.common/include/xplat.h
+++ b/src/dnx.common/include/xplat.h
@@ -9,7 +9,7 @@
 namespace dnx
 {
 
-#ifndef PLATFORM_UNIX
+#if !defined(PLATFORM_UNIX) && !defined(PLATFORM_LINUX) && !defined(PLATFORM_DARWIN)
 
 typedef wchar_t char_t;
 typedef std::wstring xstring_t;

--- a/src/dnx.coreclr.unix/dnx.coreclr.cpp
+++ b/src/dnx.coreclr.unix/dnx.coreclr.cpp
@@ -69,30 +69,18 @@ std::string GetPathToBootstrapper()
 
 bool GetTrustedPlatformAssembliesList(const std::string& tpaDirectory, bool isNative, std::string& trustedPlatformAssemblies)
 {
-    size_t cTpaAssemblyNames = 0;
-    LPCTSTR* ppszTpaAssemblyNames = nullptr;
-
-    CreateTpaBase(&ppszTpaAssemblyNames, &cTpaAssemblyNames, isNative);
-
-    assert(ppszTpaAssemblyNames != nullptr || cTpaAssemblyNames == 0);
-
-    //TODO: The Windows version of this actaully ensures the files are present.  We just fail for native and assume MSIL is present
+    //TODO: The Windows version of this actually ensures the files are present.  We just fail for native and assume MSIL is present
     if (isNative)
     {
         return false;
     }
 
-    for (size_t i = 0; i < cTpaAssemblyNames; i++)
+    for (auto assembly_name : CreateTpaBase(isNative))
     {
         trustedPlatformAssemblies.append(tpaDirectory);
         trustedPlatformAssemblies.append("/");
-        trustedPlatformAssemblies.append(ppszTpaAssemblyNames[i]);
+        trustedPlatformAssemblies.append(assembly_name);
         trustedPlatformAssemblies.append(":");
-    }
-
-    if (ppszTpaAssemblyNames)
-    {
-        FreeTpaBase(ppszTpaAssemblyNames);
     }
 
     return true;

--- a/src/dnx.coreclr.unix/stdafx.h
+++ b/src/dnx.coreclr.unix/stdafx.h
@@ -13,7 +13,4 @@
 #include <libproc.h>
 #endif
 
-typedef int BOOL;
 typedef const char* LPCTSTR;
-
-#define _T(str) str

--- a/src/dnx.coreclr.unix/tpa.cpp
+++ b/src/dnx.coreclr.unix/tpa.cpp
@@ -1,97 +1,85 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-// This file will be dynamically updated during build to generate a 
+// This file will be dynamically updated during build to generate a
 // minimal trusted platform assemblies list
 
 #include "stdafx.h"
-#include "tpa.h"
+#include <vector>
+#include <string>
+#include "xplat.h"
 
-BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
+const std::vector<const dnx::char_t*> CreateTpaBase(bool native_images)
 {
-    const size_t count = 32;
-    LPCTSTR* pArray = new LPCTSTR[count];
-
-    if (bNative)
-    {
-        pArray[0] = _T("dnx.coreclr.managed.ni.dll");
-        pArray[1] = _T("dnx.host.ni.dll");
-        pArray[2] = _T("Microsoft.Framework.Runtime.Abstractions.ni.dll");
-        pArray[3] = _T("Microsoft.Framework.Runtime.Loader.ni.dll");
-        pArray[4] = _T("mscorlib.ni.dll");
-        pArray[5] = _T("System.AppContext.ni.dll");
-        pArray[6] = _T("System.Collections.ni.dll");
-        pArray[7] = _T("System.Collections.Concurrent.ni.dll");
-        pArray[8] = _T("System.ComponentModel.ni.dll");
-        pArray[9] = _T("System.Console.ni.dll");
-        pArray[10] = _T("System.Diagnostics.Debug.ni.dll");
-        pArray[11] = _T("System.Diagnostics.Tracing.ni.dll");
-        pArray[12] = _T("System.Globalization.ni.dll");
-        pArray[13] = _T("System.IO.ni.dll");
-        pArray[14] = _T("System.IO.FileSystem.ni.dll");
-        pArray[15] = _T("System.IO.FileSystem.Primitives.ni.dll");
-        pArray[16] = _T("System.Linq.ni.dll");
-        pArray[17] = _T("System.Private.Uri.ni.dll");
-        pArray[18] = _T("System.Reflection.ni.dll");
-        pArray[19] = _T("System.Reflection.Extensions.ni.dll");
-        pArray[20] = _T("System.Reflection.Primitives.ni.dll");
-        pArray[21] = _T("System.Resources.ResourceManager.ni.dll");
-        pArray[22] = _T("System.Runtime.ni.dll");
-        pArray[23] = _T("System.Runtime.Extensions.ni.dll");
-        pArray[24] = _T("System.Runtime.Handles.ni.dll");
-        pArray[25] = _T("System.Runtime.InteropServices.ni.dll");
-        pArray[26] = _T("System.Runtime.Loader.ni.dll");
-        pArray[27] = _T("System.Text.Encoding.ni.dll");
-        pArray[28] = _T("System.Text.Encoding.Extensions.ni.dll");
-        pArray[29] = _T("System.Threading.ni.dll");
-        pArray[30] = _T("System.Threading.Overlapped.ni.dll");
-        pArray[31] = _T("System.Threading.Tasks.ni.dll");
-    }
-    else
-    {
-        pArray[0] = _T("dnx.coreclr.managed.dll");
-        pArray[1] = _T("dnx.host.dll");
-        pArray[2] = _T("Microsoft.Framework.Runtime.Abstractions.dll");
-        pArray[3] = _T("Microsoft.Framework.Runtime.Loader.dll");
-        pArray[4] = _T("mscorlib.dll");
-        pArray[5] = _T("System.AppContext.dll");
-        pArray[6] = _T("System.Collections.dll");
-        pArray[7] = _T("System.Collections.Concurrent.dll");
-        pArray[8] = _T("System.ComponentModel.dll");
-        pArray[9] = _T("System.Console.dll");
-        pArray[10] = _T("System.Diagnostics.Debug.dll");
-        pArray[11] = _T("System.Diagnostics.Tracing.dll");
-        pArray[12] = _T("System.Globalization.dll");
-        pArray[13] = _T("System.IO.dll");
-        pArray[14] = _T("System.IO.FileSystem.dll");
-        pArray[15] = _T("System.IO.FileSystem.Primitives.dll");
-        pArray[16] = _T("System.Linq.dll");
-        pArray[17] = _T("System.Private.Uri.dll");
-        pArray[18] = _T("System.Reflection.dll");
-        pArray[19] = _T("System.Reflection.Extensions.dll");
-        pArray[20] = _T("System.Reflection.Primitives.dll");
-        pArray[21] = _T("System.Resources.ResourceManager.dll");
-        pArray[22] = _T("System.Runtime.dll");
-        pArray[23] = _T("System.Runtime.Extensions.dll");
-        pArray[24] = _T("System.Runtime.Handles.dll");
-        pArray[25] = _T("System.Runtime.InteropServices.dll");
-        pArray[26] = _T("System.Runtime.Loader.dll");
-        pArray[27] = _T("System.Text.Encoding.dll");
-        pArray[28] = _T("System.Text.Encoding.Extensions.dll");
-        pArray[29] = _T("System.Threading.dll");
-        pArray[30] = _T("System.Threading.Overlapped.dll");
-        pArray[31] = _T("System.Threading.Tasks.dll");
-    }
-
-    *ppNames = pArray;
-    *pcNames = count;
-
-    return true;
-}
-
-BOOL FreeTpaBase(const LPCTSTR* values)
-{
-    delete[] values;
-
-    return true;
+    return native_images
+        ? std::vector<const dnx::char_t*>
+        {
+            _X("dnx.coreclr.managed.ni.dll"),
+            _X("dnx.host.ni.dll"),
+            _X("Microsoft.Framework.Runtime.Abstractions.ni.dll"),
+            _X("Microsoft.Framework.Runtime.Loader.ni.dll"),
+            _X("mscorlib.ni.dll"),
+            _X("System.AppContext.ni.dll"),
+            _X("System.Collections.ni.dll"),
+            _X("System.Collections.Concurrent.ni.dll"),
+            _X("System.ComponentModel.ni.dll"),
+            _X("System.Console.ni.dll"),
+            _X("System.Diagnostics.Debug.ni.dll"),
+            _X("System.Diagnostics.Tracing.ni.dll"),
+            _X("System.Globalization.ni.dll"),
+            _X("System.IO.ni.dll"),
+            _X("System.IO.FileSystem.ni.dll"),
+            _X("System.IO.FileSystem.Primitives.ni.dll"),
+            _X("System.Linq.ni.dll"),
+            _X("System.Private.Uri.ni.dll"),
+            _X("System.Reflection.ni.dll"),
+            _X("System.Reflection.Extensions.ni.dll"),
+            _X("System.Reflection.Primitives.ni.dll"),
+            _X("System.Resources.ResourceManager.ni.dll"),
+            _X("System.Runtime.ni.dll"),
+            _X("System.Runtime.Extensions.ni.dll"),
+            _X("System.Runtime.Handles.ni.dll"),
+            _X("System.Runtime.InteropServices.ni.dll"),
+            _X("System.Runtime.Loader.ni.dll"),
+            _X("System.Text.Encoding.ni.dll"),
+            _X("System.Text.Encoding.Extensions.ni.dll"),
+            _X("System.Threading.ni.dll"),
+            _X("System.Threading.Overlapped.ni.dll"),
+            _X("System.Threading.Tasks.ni.dll"),
+        }
+        : std::vector<const dnx::char_t*>
+        {
+            _X("dnx.coreclr.managed.dll"),
+            _X("dnx.host.dll"),
+            _X("Microsoft.Framework.Runtime.Abstractions.dll"),
+            _X("Microsoft.Framework.Runtime.Loader.dll"),
+            _X("mscorlib.dll"),
+            _X("System.AppContext.dll"),
+            _X("System.Collections.dll"),
+            _X("System.Collections.Concurrent.dll"),
+            _X("System.ComponentModel.dll"),
+            _X("System.Console.dll"),
+            _X("System.Diagnostics.Debug.dll"),
+            _X("System.Diagnostics.Tracing.dll"),
+            _X("System.Globalization.dll"),
+            _X("System.IO.dll"),
+            _X("System.IO.FileSystem.dll"),
+            _X("System.IO.FileSystem.Primitives.dll"),
+            _X("System.Linq.dll"),
+            _X("System.Private.Uri.dll"),
+            _X("System.Reflection.dll"),
+            _X("System.Reflection.Extensions.dll"),
+            _X("System.Reflection.Primitives.dll"),
+            _X("System.Resources.ResourceManager.dll"),
+            _X("System.Runtime.dll"),
+            _X("System.Runtime.Extensions.dll"),
+            _X("System.Runtime.Handles.dll"),
+            _X("System.Runtime.InteropServices.dll"),
+            _X("System.Runtime.Loader.dll"),
+            _X("System.Text.Encoding.dll"),
+            _X("System.Text.Encoding.Extensions.dll"),
+            _X("System.Threading.dll"),
+            _X("System.Threading.Overlapped.dll"),
+            _X("System.Threading.Tasks.dll"),
+        };
 }

--- a/src/dnx.coreclr/dnx.coreclr.vcxproj
+++ b/src/dnx.coreclr/dnx.coreclr.vcxproj
@@ -36,7 +36,6 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
-    <ClInclude Include="tpa.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>
@@ -56,10 +55,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-    <Target Name="CopyManagedForDebuggingLocally" AfterTargets="Build" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-        <Copy SourceFiles="bin\$(Platform)\$(Configuration)\$(ProjectName).dll"
-              DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
-        <Copy SourceFiles="bin\$(Platform)\$(Configuration)\$(ProjectName).pdb"
-              DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
-    </Target>
+  <Target Name="CopyManagedForDebuggingLocally" AfterTargets="Build" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Copy SourceFiles="bin\$(Platform)\$(Configuration)\$(ProjectName).dll" DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
+    <Copy SourceFiles="bin\$(Platform)\$(Configuration)\$(ProjectName).pdb" DestinationFolder="$(SolutionDir)\artifacts\build\dnx-coreclr-win-x86\bin" />
+  </Target>
 </Project>

--- a/src/dnx.coreclr/dnx.coreclr.vcxproj.filters
+++ b/src/dnx.coreclr/dnx.coreclr.vcxproj.filters
@@ -9,7 +9,6 @@
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
-    <ClInclude Include="tpa.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>

--- a/src/dnx.coreclr/tpa.cpp
+++ b/src/dnx.coreclr/tpa.cpp
@@ -1,97 +1,85 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-// This file will be dynamically updated during build to generate a 
+// This file will be dynamically updated during build to generate a
 // minimal trusted platform assemblies list
 
 #include "stdafx.h"
-#include "tpa.h"
+#include <vector>
+#include <string>
+#include "xplat.h"
 
-BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative)
+const std::vector<const dnx::char_t*> CreateTpaBase(bool native_images)
 {
-    const size_t count = 32;
-    LPCTSTR* pArray = new LPCTSTR[count];
-
-    if (bNative)
-    {
-        pArray[0] = _T("dnx.coreclr.managed.ni.dll");
-        pArray[1] = _T("dnx.host.ni.dll");
-        pArray[2] = _T("Microsoft.Framework.Runtime.Abstractions.ni.dll");
-        pArray[3] = _T("Microsoft.Framework.Runtime.Loader.ni.dll");
-        pArray[4] = _T("mscorlib.ni.dll");
-        pArray[5] = _T("System.AppContext.ni.dll");
-        pArray[6] = _T("System.Collections.ni.dll");
-        pArray[7] = _T("System.Collections.Concurrent.ni.dll");
-        pArray[8] = _T("System.ComponentModel.ni.dll");
-        pArray[9] = _T("System.Console.ni.dll");
-        pArray[10] = _T("System.Diagnostics.Debug.ni.dll");
-        pArray[11] = _T("System.Diagnostics.Tracing.ni.dll");
-        pArray[12] = _T("System.Globalization.ni.dll");
-        pArray[13] = _T("System.IO.ni.dll");
-        pArray[14] = _T("System.IO.FileSystem.ni.dll");
-        pArray[15] = _T("System.IO.FileSystem.Primitives.ni.dll");
-        pArray[16] = _T("System.Linq.ni.dll");
-        pArray[17] = _T("System.Private.Uri.ni.dll");
-        pArray[18] = _T("System.Reflection.ni.dll");
-        pArray[19] = _T("System.Reflection.Extensions.ni.dll");
-        pArray[20] = _T("System.Reflection.Primitives.ni.dll");
-        pArray[21] = _T("System.Resources.ResourceManager.ni.dll");
-        pArray[22] = _T("System.Runtime.ni.dll");
-        pArray[23] = _T("System.Runtime.Extensions.ni.dll");
-        pArray[24] = _T("System.Runtime.Handles.ni.dll");
-        pArray[25] = _T("System.Runtime.InteropServices.ni.dll");
-        pArray[26] = _T("System.Runtime.Loader.ni.dll");
-        pArray[27] = _T("System.Text.Encoding.ni.dll");
-        pArray[28] = _T("System.Text.Encoding.Extensions.ni.dll");
-        pArray[29] = _T("System.Threading.ni.dll");
-        pArray[30] = _T("System.Threading.Overlapped.ni.dll");
-        pArray[31] = _T("System.Threading.Tasks.ni.dll");
-    }
-    else
-    {
-        pArray[0] = _T("dnx.coreclr.managed.dll");
-        pArray[1] = _T("dnx.host.dll");
-        pArray[2] = _T("Microsoft.Framework.Runtime.Abstractions.dll");
-        pArray[3] = _T("Microsoft.Framework.Runtime.Loader.dll");
-        pArray[4] = _T("mscorlib.dll");
-        pArray[5] = _T("System.AppContext.dll");
-        pArray[6] = _T("System.Collections.dll");
-        pArray[7] = _T("System.Collections.Concurrent.dll");
-        pArray[8] = _T("System.ComponentModel.dll");
-        pArray[9] = _T("System.Console.dll");
-        pArray[10] = _T("System.Diagnostics.Debug.dll");
-        pArray[11] = _T("System.Diagnostics.Tracing.dll");
-        pArray[12] = _T("System.Globalization.dll");
-        pArray[13] = _T("System.IO.dll");
-        pArray[14] = _T("System.IO.FileSystem.dll");
-        pArray[15] = _T("System.IO.FileSystem.Primitives.dll");
-        pArray[16] = _T("System.Linq.dll");
-        pArray[17] = _T("System.Private.Uri.dll");
-        pArray[18] = _T("System.Reflection.dll");
-        pArray[19] = _T("System.Reflection.Extensions.dll");
-        pArray[20] = _T("System.Reflection.Primitives.dll");
-        pArray[21] = _T("System.Resources.ResourceManager.dll");
-        pArray[22] = _T("System.Runtime.dll");
-        pArray[23] = _T("System.Runtime.Extensions.dll");
-        pArray[24] = _T("System.Runtime.Handles.dll");
-        pArray[25] = _T("System.Runtime.InteropServices.dll");
-        pArray[26] = _T("System.Runtime.Loader.dll");
-        pArray[27] = _T("System.Text.Encoding.dll");
-        pArray[28] = _T("System.Text.Encoding.Extensions.dll");
-        pArray[29] = _T("System.Threading.dll");
-        pArray[30] = _T("System.Threading.Overlapped.dll");
-        pArray[31] = _T("System.Threading.Tasks.dll");
-    }
-
-    *ppNames = pArray;
-    *pcNames = count;
-
-    return true;
-}
-
-BOOL FreeTpaBase(const LPCTSTR* values)
-{
-    delete[] values;
-
-    return true;
+    return native_images
+        ? std::vector<const dnx::char_t*>
+        {
+            _X("dnx.coreclr.managed.ni.dll"),
+            _X("dnx.host.ni.dll"),
+            _X("Microsoft.Framework.Runtime.Abstractions.ni.dll"),
+            _X("Microsoft.Framework.Runtime.Loader.ni.dll"),
+            _X("mscorlib.ni.dll"),
+            _X("System.AppContext.ni.dll"),
+            _X("System.Collections.ni.dll"),
+            _X("System.Collections.Concurrent.ni.dll"),
+            _X("System.ComponentModel.ni.dll"),
+            _X("System.Console.ni.dll"),
+            _X("System.Diagnostics.Debug.ni.dll"),
+            _X("System.Diagnostics.Tracing.ni.dll"),
+            _X("System.Globalization.ni.dll"),
+            _X("System.IO.ni.dll"),
+            _X("System.IO.FileSystem.ni.dll"),
+            _X("System.IO.FileSystem.Primitives.ni.dll"),
+            _X("System.Linq.ni.dll"),
+            _X("System.Private.Uri.ni.dll"),
+            _X("System.Reflection.ni.dll"),
+            _X("System.Reflection.Extensions.ni.dll"),
+            _X("System.Reflection.Primitives.ni.dll"),
+            _X("System.Resources.ResourceManager.ni.dll"),
+            _X("System.Runtime.ni.dll"),
+            _X("System.Runtime.Extensions.ni.dll"),
+            _X("System.Runtime.Handles.ni.dll"),
+            _X("System.Runtime.InteropServices.ni.dll"),
+            _X("System.Runtime.Loader.ni.dll"),
+            _X("System.Text.Encoding.ni.dll"),
+            _X("System.Text.Encoding.Extensions.ni.dll"),
+            _X("System.Threading.ni.dll"),
+            _X("System.Threading.Overlapped.ni.dll"),
+            _X("System.Threading.Tasks.ni.dll"),
+        }
+        : std::vector<const dnx::char_t*>
+        {
+            _X("dnx.coreclr.managed.dll"),
+            _X("dnx.host.dll"),
+            _X("Microsoft.Framework.Runtime.Abstractions.dll"),
+            _X("Microsoft.Framework.Runtime.Loader.dll"),
+            _X("mscorlib.dll"),
+            _X("System.AppContext.dll"),
+            _X("System.Collections.dll"),
+            _X("System.Collections.Concurrent.dll"),
+            _X("System.ComponentModel.dll"),
+            _X("System.Console.dll"),
+            _X("System.Diagnostics.Debug.dll"),
+            _X("System.Diagnostics.Tracing.dll"),
+            _X("System.Globalization.dll"),
+            _X("System.IO.dll"),
+            _X("System.IO.FileSystem.dll"),
+            _X("System.IO.FileSystem.Primitives.dll"),
+            _X("System.Linq.dll"),
+            _X("System.Private.Uri.dll"),
+            _X("System.Reflection.dll"),
+            _X("System.Reflection.Extensions.dll"),
+            _X("System.Reflection.Primitives.dll"),
+            _X("System.Resources.ResourceManager.dll"),
+            _X("System.Runtime.dll"),
+            _X("System.Runtime.Extensions.dll"),
+            _X("System.Runtime.Handles.dll"),
+            _X("System.Runtime.InteropServices.dll"),
+            _X("System.Runtime.Loader.dll"),
+            _X("System.Text.Encoding.dll"),
+            _X("System.Text.Encoding.Extensions.dll"),
+            _X("System.Threading.dll"),
+            _X("System.Threading.Overlapped.dll"),
+            _X("System.Threading.Tasks.dll"),
+        };
 }

--- a/src/dnx.coreclr/tpa.h
+++ b/src/dnx.coreclr/tpa.h
@@ -1,7 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-#pragma once
-
-BOOL CreateTpaBase(LPCTSTR** ppNames, size_t* pcNames, bool bNative);
-BOOL FreeTpaBase(const LPCTSTR* values);

--- a/src/dnx/dnx.vcxproj
+++ b/src/dnx/dnx.vcxproj
@@ -52,7 +52,6 @@
     <ClInclude Include="targetver.h" />
     <ClInclude Include="TraceWriter.h" />
     <ClInclude Include="utils.h" />
-    <ClInclude Include="xplat.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- moving common header files to one location (avoid code duplication)
- replacing dynamic memory allocation for TPAs with a std::vector
- removing some goto's where applicable
- fixing a memory leak #2117