### PR TITLE
fix #1113 by adding 'dnu feeds list' command

### DIFF
--- a/src/Microsoft.Framework.PackageManager/ConsoleCommands/ListSourcesConsoleCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/ConsoleCommands/ListSourcesConsoleCommand.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.Runtime.Common.CommandLine;
+
+namespace Microsoft.Framework.PackageManager
+{
+    internal static class FeedsConsoleCommand
+    {
+        public static void Register(CommandLineApplication cmdApp, ReportsFactory reportsFactory)
+        {
+            cmdApp.Command("feeds", c =>
+            {
+                c.Description = "Commands related to managing package feeds currently in use";
+                c.HelpOption("-?|-h|--help");
+                c.OnExecute(() =>
+                {
+                    c.ShowHelp();
+                    return 2;
+                });
+
+                RegisterListCommand(c, reportsFactory);
+            });
+        }
+
+        public static void RegisterListCommand(CommandLineApplication cmdApp, ReportsFactory reportsFactory)
+        {
+            cmdApp.Command("list", c =>
+            {
+                c.Description = "Displays a list of package sources in effect for a project";
+                var argRoot = c.Argument("[root]",
+                    "The path of the project to calculate effective package sources for (defaults to the current directory)");
+
+                c.OnExecute(() =>
+                {
+                    var command = new ListSourcesCommand(
+                        reportsFactory.CreateReports(quiet: false),
+                        string.IsNullOrEmpty(argRoot.Value) ? "." : argRoot.Value);
+
+                    return command.Execute();
+                });
+            });
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Install/InstallGlobalCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Install/InstallGlobalCommand.cs
@@ -142,18 +142,12 @@ namespace Microsoft.Framework.PackageManager
             if (string.IsNullOrEmpty(packageVersion))
             {
                 var rootDirectory = ProjectResolver.ResolveRootDirectory(_commandsRepository.Root.Root);
-                var settings = SettingsUtils.ReadSettings(
-                    rootDirectory,
-                    RestoreCommand.NuGetConfigFile,
-                    RestoreCommand.FileSystem,
-                    RestoreCommand.MachineWideSettings);
-
-                var sourceProvier = PackageSourceBuilder.CreateSourceProvider(settings);
+                var config = NuGetConfig.ForSolution(rootDirectory, RestoreCommand.FileSystem);
 
                 var packageFeeds = new List<IPackageFeed>();
 
                 var effectiveSources = PackageSourceUtils.GetEffectivePackageSources(
-                    sourceProvier,
+                    config.Sources,
                     FeedOptions.Sources,
                     FeedOptions.FallbackSources);
 

--- a/src/Microsoft.Framework.PackageManager/NuGetConfig.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGetConfig.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet;
+
+namespace Microsoft.Framework.PackageManager
+{
+    /// <summary>
+    /// Manages the NuGet.config hierarchy
+    /// </summary>
+    public class NuGetConfig
+    {
+        public NuGetConfig(ISettings settings, PackageSourceProvider sources)
+        {
+            Settings = settings;
+            Sources = sources;
+        }
+
+        public ISettings Settings { get; }
+
+        public IPackageSourceProvider Sources { get; }
+
+        public static NuGetConfig ForSolution(string solutionDirectory)
+        {
+            return ForSolution(solutionDirectory, new PhysicalFileSystem(Directory.GetCurrentDirectory()));
+        }
+
+        public static NuGetConfig ForSolution(string solutionDirectory, IFileSystem fileSystem)
+        {
+            var settings = SettingsUtils.ReadSettings(
+                solutionDirectory, 
+                nugetConfigFile: null, 
+                fileSystem: fileSystem, 
+                machineWideSettings: new CommandLineMachineWideSettings());
+
+            // Recreate the source provider
+            var sources = PackageSourceBuilder.CreateSourceProvider(settings);
+
+            return new NuGetConfig(settings, sources);
+        }
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Framework.PackageManager
             PublishConsoleCommand.Register(app, reportsFactory, _environment, _hostServices);
             RestoreConsoleCommand.Register(app, reportsFactory, _environment);
             WrapConsoleCommand.Register(app, reportsFactory);
+            FeedsConsoleCommand.Register(app, reportsFactory);
 
             return app.Execute(args);
         }

--- a/src/Microsoft.Framework.PackageManager/Sources/ListSourcesCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Sources/ListSourcesCommand.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.Framework.PackageManager
+{
+    internal class ListSourcesCommand
+    {
+        public Reports Reports { get; }
+        public string TargetDirectory { get; }
+
+        public ListSourcesCommand(Reports reports, string targetDirectory)
+        {
+            Reports = reports;
+            TargetDirectory = targetDirectory;
+        }
+
+        public int Execute()
+        {
+            // Most of this code is from NuGet, just some refactoring for our system.
+            // Collect config
+            var config = NuGetConfig.ForSolution(TargetDirectory);
+
+            var sources = config.Sources.LoadPackageSources();
+            if (!sources.Any())
+            {
+                Reports.Information.WriteLine("No sources found.");
+            }
+            else
+            {
+                Reports.Information.WriteLine("Registered Sources:");
+
+                // Iterate over the sources and report them
+                int index = 1; // This is an index for display so it should be 1-based
+                foreach (var source in sources)
+                {
+                    var enabledString = source.IsEnabled ? "" : " [Disabled]";
+                    var line = $"{index.ToString("0\\.").PadRight(3)} {source.Name} {source.Source}{enabledString.Yellow().Bold()}";
+                    Reports.Information.WriteLine(line);
+
+                    index++;
+                }
+            }
+            return 0;
+        }
+    }
+}

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuFeedsTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuFeedsTests.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Framework.CommonTestUtils;
+using Microsoft.Framework.PackageManager.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Framework.PackageManager
+{
+    [Collection(nameof(PackageManagerFunctionalTestCollection))]
+    public class DnuFeedsTests
+    {
+        private readonly PackageManagerFunctionalTestFixture _fixture;
+
+        public DnuFeedsTests(PackageManagerFunctionalTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public static IEnumerable<object[]> RuntimeComponents
+        {
+            get
+            {
+                return TestUtils.GetRuntimeComponentsCombinations();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuFeeds_NoSources(string flavor, string os, string architecture)
+        {
+            var environment = new Dictionary<string, string>
+            {
+                { "DNX_TRACE", "0" },
+            };
+
+            var rootConfig =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <clear /> <!-- Remove the effects of any machine-level config -->
+  </packageSources>
+</configuration>";
+
+            var projectStructure =
+@"{
+    'root': {
+        'NuGet.Config': """",
+    }
+}";
+
+            var expectedContent = @"Registered Sources:
+1.  https://www.nuget.org/api/v2/ https://www.nuget.org/api/v2/
+";
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
+            using (var testEnv = new DnuTestEnvironment(runtimeHomePath, projectName: "Project Name"))
+            {
+                var projectPath = testEnv.ProjectPath;
+                DirTree.CreateFromJson(projectStructure)
+                    .WithFileContents("root/NuGet.Config", rootConfig)
+                    .WriteTo(projectPath);
+
+                string output;
+                string error;
+                var exitCode = DnuTestUtils.ExecDnu(
+                    runtimeHomePath,
+                    subcommand: "feeds",
+                    arguments: "list root",
+                    stdOut: out output,
+                    stdErr: out error,
+                    environment: environment,
+                    workingDir: projectPath);
+
+                Assert.Equal(0, exitCode);
+                Assert.Empty(error);
+                Assert.Equal(expectedContent, output);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuFeeds_ListsAllSources(string flavor, string os, string architecture)
+        {
+            var environment = new Dictionary<string, string>
+            {
+                { "DNX_TRACE", "0" },
+            };
+
+            var rootConfig =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <clear /> <!-- Remove the effects of any machine-level config -->
+    <add key=""Source1"" value=""https://source1"" />
+    <add key=""Source2"" value=""https://source2"" />
+  </packageSources>
+</configuration>";
+
+            var subConfig =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""Source3"" value=""https://source3"" />
+  </packageSources>
+  <disabledPackageSources>
+    <add key=""Source1"" value=""https://source1"" />
+  </disabledPackageSources>
+</configuration>";
+
+            var projectStructure =
+@"{
+    'root': {
+        'NuGet.Config': """",
+        'sub': {
+            'NuGet.Config': """"
+        }
+    }
+}";
+
+            var expectedContent = @"Registered Sources:
+1.  Source1 https://source1 [Disabled]
+2.  Source2 https://source2
+3.  Source3 https://source3
+4.  https://www.nuget.org/api/v2/ https://www.nuget.org/api/v2/ [Disabled]
+";
+            var runtimeHomePath = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
+            using (var testEnv = new DnuTestEnvironment(runtimeHomePath, projectName: "Project Name"))
+            {
+                var projectPath = testEnv.ProjectPath;
+                DirTree.CreateFromJson(projectStructure)
+                    .WithFileContents("root/NuGet.Config", rootConfig)
+                    .WithFileContents("root/sub/NuGet.Config", subConfig)
+                    .WriteTo(projectPath);
+
+                string output;
+                string error;
+                var exitCode = DnuTestUtils.ExecDnu(
+                    runtimeHomePath,
+                    subcommand: "feeds",
+                    arguments: "list root/sub",
+                    stdOut: out output,
+                    stdErr: out error,
+                    environment: environment,
+                    workingDir: projectPath);
+
+                Assert.Equal(0, exitCode);
+                Assert.Empty(error);
+                Assert.Equal(expectedContent, output);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1113

Add `dnu sources` command that lists active sources. It looks like this:

![image](https://cloud.githubusercontent.com/assets/7574/8320841/5cdc137a-19d4-11e5-9d7a-fecf2485e659.png)

Disabled sources have `[Disabled]` next to them in yellow to identify them as disabled. I also tried to centralize some of the disjointed code we have to handle NuGet.config.

/cc @davidfowl @victorhurdugaci @troydai 