### PR TITLE
Remove help subcommand

### DIFF
--- a/src/Microsoft.Framework.ApplicationHost/Program.cs
+++ b/src/Microsoft.Framework.ApplicationHost/Program.cs
@@ -139,7 +139,6 @@ namespace Microsoft.Framework.ApplicationHost
                     return 0;
                 });
             },
-            addHelpCommand: false,
             throwOnUnexpectedArg: false);
             app.Execute(args);
 

--- a/src/Microsoft.Framework.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Framework.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
@@ -44,35 +44,11 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
         public List<CommandLineApplication> Commands { get; private set; }
 
         public CommandLineApplication Command(string name, Action<CommandLineApplication> configuration,
-            bool addHelpCommand = true, bool throwOnUnexpectedArg = true)
+            bool throwOnUnexpectedArg = true)
         {
             var command = new CommandLineApplication(throwOnUnexpectedArg) { Name = name, Parent = this };
             Commands.Add(command);
             configuration(command);
-
-            if (addHelpCommand)
-            {
-                if (HasHelpCommand())
-                {
-                    // Already added before
-                    return this;
-                }
-
-                Command("help", c =>
-                {
-                    c.Description = "Show help information";
-
-                    var argCommand = c.Argument("[command]", "Command that help information explains");
-
-                    c.OnExecute(() =>
-                    {
-                        ShowHelp(argCommand.Value);
-                        return 0;
-                    });
-                },
-                addHelpCommand: false);
-            }
-
             return command;
         }
 
@@ -414,13 +390,14 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
                     commandsBuilder.AppendLine();
                 }
 
-                if (HasHelpCommand())
+                if (OptionHelp != null)
                 {
                     commandsBuilder.AppendLine();
-                    commandsBuilder.AppendFormat("Use \"{0} help [command]\" for more information about a command.", Name);
+                    commandsBuilder.AppendFormat("Use \"{0} [command] --help\" for more information about a command.", Name);
                     commandsBuilder.AppendLine();
                 }
             }
+
             headerBuilder.AppendLine();
 
             var nameAndVersion = new StringBuilder();
@@ -456,12 +433,6 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
 
             Console.WriteLine(rootCmd.GetFullNameAndVersion());
             Console.WriteLine();
-        }
-
-        private bool HasHelpCommand()
-        {
-            var helpCmd = Commands.SingleOrDefault(cmd => string.Equals("help", cmd.Name, StringComparison.OrdinalIgnoreCase));
-            return helpCmd != null;
         }
 
         private int MaxOptionTemplateLength(IEnumerable<CommandOption> options)

--- a/test/Microsoft.Framework.CommandLineUtils.Sources.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Framework.CommandLineUtils.Sources.Tests/CommandLineApplicationTests.cs
@@ -247,7 +247,6 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
             {
                 c.OnExecute(() => 0);
             },
-            addHelpCommand: false,
             throwOnUnexpectedArg: false);
 
             // (does not throw)
@@ -282,7 +281,6 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
             {
                 c.OnExecute(() => 0);
             },
-            addHelpCommand: false,
             throwOnUnexpectedArg: false);
 
             // (does not throw)
@@ -317,7 +315,6 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
             {
                 c.OnExecute(() => 0);
             },
-            addHelpCommand: false,
             throwOnUnexpectedArg: false);
 
             // (does not throw)
@@ -352,7 +349,6 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
             {
                 c.OnExecute(() => 0);
             },
-            addHelpCommand: false,
             throwOnUnexpectedArg: false);
 
             // (does not throw)
@@ -388,7 +384,7 @@ namespace Microsoft.Framework.Runtime.Common.CommandLine
 
             var testCmd = app.Command("k", c =>
             {
-                subCmd = c.Command("run", _ => { }, addHelpCommand: false, throwOnUnexpectedArg: false);
+                subCmd = c.Command("run", _ => { }, throwOnUnexpectedArg: false);
                 c.OnExecute(() => 0);
             });
 


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1116

@davidfowl @muratg @Eilon 

Correct usage of help subcommand is something like
```
dnu packages help add
```
However, people keep doing
```
dnu packages add help
```
or
```
dnu help packages add
```
This PR removes the confusing help subcommand and we only use `-?|-h|--help` option:
```
dnu packages add --help
```