### PR TITLE
teach DNX to support dnx46

### DIFF
--- a/DNX.sln
+++ b/DNX.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23020.0
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{189961D1-DFF4-406A-9D42-39B61221A73A}"
 	ProjectSection(SolutionItems) = preProject

--- a/misc/XreTestApps/Dnx451/Program.cs
+++ b/misc/XreTestApps/Dnx451/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Dnx46
+{
+    public class Program
+    {
+        public void Main(string[] args)
+        {
+            Console.WriteLine(AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName);
+        }
+    }
+}

--- a/misc/XreTestApps/Dnx451/project.json
+++ b/misc/XreTestApps/Dnx451/project.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+    },
+    "frameworks": {
+        "dnx451": {}
+    }
+}

--- a/misc/XreTestApps/Dnx46/Program.cs
+++ b/misc/XreTestApps/Dnx46/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Dnx46
+{
+    public class Program
+    {
+        public void Main(string[] args)
+        {
+            Console.WriteLine(AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName);
+        }
+    }
+}

--- a/misc/XreTestApps/Dnx46/project.json
+++ b/misc/XreTestApps/Dnx46/project.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": {
+    },
+    "frameworks": {
+        "dnx46": {},
+        "dnx451": {}
+    }
+}

--- a/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishProject.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Runtime.Common.Impl;
 using Newtonsoft.Json.Linq;
 using NuGet;
 
@@ -494,6 +495,19 @@ namespace Microsoft.Framework.PackageManager.Publish
                 }
 
                 addElement.SetAttributeValue("value", pair.Value);
+            }
+
+            // Generate target framework information
+            var bestDnxVersion = project.GetTargetFrameworks()
+                .Where(f => f.FrameworkName.Identifier.Equals(FrameworkNames.LongNames.Dnx))
+                .OrderByDescending(f => f.FrameworkName.Version)
+                .Select(f => f.FrameworkName.Version)
+                .FirstOrDefault();
+            if(bestDnxVersion != null)
+            {
+                var sysWebElement = GetOrAddElement(parent: xDoc.Root, name: "system.web");
+                var httpRuntimeElement = GetOrAddElement(parent: sysWebElement, name: "httpRuntime");
+                httpRuntimeElement.SetAttributeValue("targetFramework", bestDnxVersion.ToString());
             }
 
             var xmlWriterSettings = new XmlWriterSettings

--- a/src/Microsoft.Framework.Runtime.Sources/Impl/Constants.cs
+++ b/src/Microsoft.Framework.Runtime.Sources/Impl/Constants.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Framework.Runtime
         public const string BootstrapperHostName = RuntimeShortName + ".host";
         public const string BootstrapperClrName = RuntimeShortName + ".clr";
         public const string BootstrapperCoreclrManagedName = RuntimeShortName + ".coreclr.managed";
+        public const string ProjectJsonAppDomainDataKey = ".dnx.clr.DomainManager.projectJson";
+        public const string ProjectJsonPathAppDomainDataKey = ".dnx.clr.DomainManager.projectJsonPath";
 
         public const int LockFileVersion = 1;
     }

--- a/src/Microsoft.Framework.Runtime.Sources/Impl/FrameworkNames.cs
+++ b/src/Microsoft.Framework.Runtime.Sources/Impl/FrameworkNames.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Framework.Runtime.Common.Impl
             private const string VersionPrefix = ", Version=v";
             public const string Dnx = "DNX";
             public const string DnxCore = "DNXCore";
+            public const string NetFramework = ".NETFramework";
             public const string Dnx451 = Dnx + VersionPrefix + "4.5.1";
             public const string Dnx46 = Dnx + VersionPrefix + "4.6";
             public const string DnxCore50 = DnxCore + VersionPrefix + "5.0";

--- a/src/dnx.clr.managed/EntryPoint.cs
+++ b/src/dnx.clr.managed/EntryPoint.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using Microsoft.Framework.Runtime.Common.Impl;
 
 namespace dnx.clr.managed
 {
@@ -55,7 +57,19 @@ namespace dnx.clr.managed
                 }
             }
 
-            return new Awaiter(RuntimeBootstrapper.ExecuteAsync(args));
+            // Helios boots the DNX through this entry point. It has already
+            // set up the AppDomain though, so we just need to sniff the target framework based
+            // on the value provided by during AppDomain setup
+            var fxName = AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
+            var version = new Version(4, 5, 1);
+            if (!string.IsNullOrEmpty(fxName))
+            {
+                version = new FrameworkName(fxName).Version;
+            }
+
+            return new Awaiter(RuntimeBootstrapper.ExecuteAsync(
+                args,
+                new FrameworkName(FrameworkNames.LongNames.Dnx, version)));
         }
 
         private sealed class Awaiter : IAwaiter

--- a/src/dnx.clr.managed/RuntimeBootstrapper.cs
+++ b/src/dnx.clr.managed/RuntimeBootstrapper.cs
@@ -1,23 +1,24 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 namespace dnx.clr.managed
 {
     internal class RuntimeBootstrapper
     {
-        public static int Execute(string[] argv)
+        public static int Execute(string[] argv, FrameworkName targetFramework)
         {
             var executeMethodInfo = GetBootstrapperType()
-                .GetMethod("Execute", BindingFlags.Static | BindingFlags.Public, null, new[] { argv.GetType() }, null);
-            return (int)executeMethodInfo.Invoke(null, new object[] { argv });
+                .GetMethod("Execute", BindingFlags.Static | BindingFlags.Public, null, new[] { typeof(string[]), typeof(FrameworkName) }, null);
+            return (int)executeMethodInfo.Invoke(null, new object[] { argv, targetFramework });
         }
 
-        public static Task<int> ExecuteAsync(string[] argv)
+        public static Task<int> ExecuteAsync(string[] argv, FrameworkName targetFramework)
         {
             var executeMethodInfo = GetBootstrapperType()
-                .GetMethod("ExecuteAsync", BindingFlags.Static | BindingFlags.Public, null, new[] { argv.GetType() }, null);
-            return (Task<int>)executeMethodInfo.Invoke(null, new object[] { argv });
+                .GetMethod("ExecuteAsync", BindingFlags.Static | BindingFlags.Public, null, new[] { typeof(string[]), typeof(FrameworkName) }, null);
+            return (Task<int>)executeMethodInfo.Invoke(null, new object[] { argv, targetFramework });
         }
 
         private static Type GetBootstrapperType()

--- a/src/dnx.clr.managed/project.json
+++ b/src/dnx.clr.managed/project.json
@@ -6,9 +6,13 @@
     "frameworks": {
         "dnx451": { }
     },
-    "compileFiles": [
-      "../Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs",
-      "../Microsoft.Framework.Runtime.Sources/Impl/Constants.cs"
+    "compile": [
+        "../Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs",
+        "../Microsoft.Framework.Runtime.Sources/Impl/Logger.cs",
+        "../Microsoft.Framework.Runtime.Sources/Impl/Constants.cs",
+        "../Microsoft.Framework.Runtime.Sources/Impl/FrameworkNames.cs",
+        "../dnx.host/FrameworkNameUtility.cs",
+        "../Microsoft.Framework.Runtime/Json/**/*.cs"
     ],
     "scripts": {
         "postbuild": [
@@ -16,4 +20,3 @@
         ]
     }
 }
-

--- a/src/dnx.coreclr.managed/DomainManager.cs
+++ b/src/dnx.coreclr.managed/DomainManager.cs
@@ -1,8 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Runtime.Versioning;
 using System.Security;
 using dnx.host;
+using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Runtime.Common.Impl;
 
 [SecurityCritical]
 sealed class DomainManager
@@ -10,6 +14,8 @@ sealed class DomainManager
     [SecurityCritical]
     unsafe static int Execute(int argc, char** argv)
     {
+        Logger.TraceInformation($"[{nameof(DomainManager)}] Using CoreCLR");
+
         // Pack arguments
         var arguments = new string[argc];
         for (var i = 0; i < arguments.Length; i++)
@@ -17,6 +23,8 @@ sealed class DomainManager
             arguments[i] = new string(argv[i]);
         }
 
-        return RuntimeBootstrapper.Execute(arguments);
+        return RuntimeBootstrapper.Execute(
+            arguments,
+            new FrameworkName(FrameworkNames.LongNames.DnxCore, new Version(5, 0)));
     }
 }

--- a/src/dnx.coreclr.managed/project.json
+++ b/src/dnx.coreclr.managed/project.json
@@ -7,6 +7,12 @@
     "frameworks": {
         "dnxcore50": { }
     },
+    "compile": [
+        "../Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs",
+        "../Microsoft.Framework.Runtime.Sources/Impl/FrameworkNames.cs",
+        "../Microsoft.Framework.Runtime.Sources/Impl/Constants.cs",
+        "../Microsoft.Framework.Runtime.Sources/Impl/Logger.cs"
+    ],
 
     "scripts": {
         "postbuild": [
@@ -14,4 +20,3 @@
         ]
     }
 }
-

--- a/src/dnx.host/Bootstrapper.cs
+++ b/src/dnx.host/Bootstrapper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Common;
@@ -25,7 +26,7 @@ namespace dnx.host
             _searchPaths = searchPaths;
         }
 
-        public Task<int> RunAsync(List<string> args, IRuntimeEnvironment env)
+        public Task<int> RunAsync(List<string> args, IRuntimeEnvironment env, FrameworkName targetFramework)
         {
             var accessor = LoadContextAccessor.Instance;
             var container = new LoaderContainer();
@@ -57,10 +58,8 @@ namespace dnx.host
                 string applicationBaseDirectory = AppContext.BaseDirectory;
 #endif
 
-                var framework = Environment.GetEnvironmentVariable("TARGET_FRAMEWORK") ?? Environment.GetEnvironmentVariable(EnvironmentNames.Framework);
                 var configuration = Environment.GetEnvironmentVariable("TARGET_CONFIGURATION") ?? Environment.GetEnvironmentVariable(EnvironmentNames.Configuration) ?? "Debug";
-
-                var targetFramework = FrameworkNameUtility.ParseFrameworkName(framework ?? FrameworkNames.ShortNames.Dnx451);
+                Logger.TraceInformation($"[{nameof(Bootstrapper)}] Runtime Framework: {targetFramework}");
 
                 var applicationEnvironment = new ApplicationEnvironment(applicationBaseDirectory,
                                                                         targetFramework,

--- a/src/dnx.host/FrameworkNameUtility.cs
+++ b/src/dnx.host/FrameworkNameUtility.cs
@@ -7,24 +7,44 @@ using Microsoft.Framework.Runtime.Common.Impl;
 
 namespace dnx.host
 {
+    /// <summary>
+    /// Parses framework names expected by the DNX _runtime_.
+    /// </summary>
+    /// <remarks>
+    /// Note: This does not need to be complete because there are a fixed set of frameworks
+    /// understood by the runtimes.
+    /// </remarks>
     internal class FrameworkNameUtility
     {
-        internal static FrameworkName ParseFrameworkName(string frameworkName)
+        internal static bool TryParseFrameworkName(string frameworkName, out FrameworkName parsed)
         {
+            parsed = null;
             if (frameworkName == FrameworkNames.ShortNames.Dnx451)
             {
-                return new FrameworkName(FrameworkNames.LongNames.Dnx, new Version(4, 5, 1));
+                parsed = new FrameworkName(FrameworkNames.LongNames.Dnx, new Version(4, 5, 1));
+                return true;
             }
             else if (frameworkName == FrameworkNames.ShortNames.Dnx46)
             {
-                return new FrameworkName(FrameworkNames.LongNames.Dnx, new Version(4, 6));
+                parsed = new FrameworkName(FrameworkNames.LongNames.Dnx, new Version(4, 6));
+                return true;
             }
             else if (frameworkName == FrameworkNames.ShortNames.DnxCore50)
             {
-                return new FrameworkName(FrameworkNames.LongNames.DnxCore, new Version(5, 0));
+                parsed = new FrameworkName(FrameworkNames.LongNames.DnxCore, new Version(5, 0));
+                return true;
             }
+            return false;
+        }
 
-            throw new NotSupportedException();
+        internal static FrameworkName ParseFrameworkName(string frameworkName)
+        {
+            FrameworkName fx;
+            if (!TryParseFrameworkName(frameworkName, out fx))
+            {
+                throw new NotSupportedException();
+            }
+            return fx;
         }
     }
 }

--- a/src/dnx.host/RuntimeBootstrapper.cs
+++ b/src/dnx.host/RuntimeBootstrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Common.CommandLine;
@@ -15,14 +16,14 @@ namespace dnx.host
     {
         private static readonly char[] _libPathSeparator = new[] { ';' };
 
-        public static int Execute(string[] args)
+        public static int Execute(string[] args, FrameworkName targetFramework)
         {
             // If we're a console host then print exceptions to stderr
             var printExceptionsToStdError = Environment.GetEnvironmentVariable(EnvironmentNames.ConsoleHost) == "1";
 
             try
             {
-                return ExecuteAsync(args).GetAwaiter().GetResult();
+                return ExecuteAsync(args, targetFramework).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
@@ -55,7 +56,7 @@ namespace dnx.host
             }
         }
 
-        public static Task<int> ExecuteAsync(string[] args)
+        public static Task<int> ExecuteAsync(string[] args, FrameworkName targetFramework)
         {
             var app = new CommandLineApplication(throwOnUnexpectedArg: false);
             app.Name = Constants.BootstrapperExeName;
@@ -140,7 +141,7 @@ namespace dnx.host
             IEnumerable<string> searchPaths = ResolveSearchPaths(optionLib.Values, app.RemainingArguments);
 
             var bootstrapper = new Bootstrapper(searchPaths);
-            return bootstrapper.RunAsync(app.RemainingArguments, env);
+            return bootstrapper.RunAsync(app.RemainingArguments, env, targetFramework);
         }
 
         private static IEnumerable<string> ResolveSearchPaths(List<string> libPaths, List<string> remainingArgs)

--- a/src/dnx.mono.managed/EntryPoint.cs
+++ b/src/dnx.mono.managed/EntryPoint.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading;
 using dnx.host;
 using Microsoft.Framework.Runtime;
@@ -68,7 +69,9 @@ public class EntryPoint
             Environment.SetEnvironmentVariable(EnvironmentNames.AppBase, arguments[appbaseIndex + 1]);
         }
 
-        return RuntimeBootstrapper.Execute(arguments);
+        return RuntimeBootstrapper.Execute(arguments, 
+            // NOTE(anurse): Mono is always "dnx451" (for now).
+            new FrameworkName("DNX", new Version(4, 5, 1)));
     }
 
     private static string[] ExpandCommandLineArguments(string[] arguments)

--- a/test/Bootstrapper.FunctionalTests/BootstrapperTestUtils.cs
+++ b/test/Bootstrapper.FunctionalTests/BootstrapperTestUtils.cs
@@ -22,7 +22,16 @@ namespace Bootstrapper.FunctionalTests
             IDictionary<string, string> environment = null,
             string workingDir = null)
         {
-            var runtimeRoot = Directory.EnumerateDirectories(Path.Combine(runtimeHomePath, "runtimes"), Constants.RuntimeNamePrefix + "*").First();
+            string runtimeRoot;
+            if (string.Equals(Environment.GetEnvironmentVariable("DNX_DEV"), "1"))
+            {
+                // If DNX_DEV is set, then the path provided is to the root of a package.
+                runtimeRoot = runtimeHomePath;
+            }
+            else
+            {
+                runtimeRoot = Directory.EnumerateDirectories(Path.Combine(runtimeHomePath, "runtimes"), Constants.RuntimeNamePrefix + "*").First();
+            }
             var program = Path.Combine(runtimeRoot, "bin", Constants.BootstrapperExeName);
 
             string stdOutStr, stdErrStr;

--- a/test/Bootstrapper.FunctionalTests/project.json
+++ b/test/Bootstrapper.FunctionalTests/project.json
@@ -2,6 +2,7 @@
     "dependencies": {
         "Microsoft.Framework.CommonTestUtils": "1.0.0-*",
         "Microsoft.Framework.Runtime.Sources": "1.0.0-*",
+        "Microsoft.AspNet.Testing": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
 

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
@@ -131,6 +131,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
   </appSettings>
+  <system.web>
+    <httpRuntime targetFramework=""4.5.1"" />
+  </system.web>
 </configuration>", Constants.WebConfigBootstrapperVersion,
                 Constants.WebConfigRuntimePath,
                 Constants.WebConfigRuntimeVersion,
@@ -242,6 +245,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
   </appSettings>
+  <system.web>
+    <httpRuntime targetFramework=""4.5.1"" />
+  </system.web>
 </configuration>", Constants.WebConfigBootstrapperVersion,
                 Constants.WebConfigRuntimePath,
                 Constants.WebConfigRuntimeVersion,
@@ -794,6 +800,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
   </appSettings>
+  <system.web>
+    <httpRuntime targetFramework=""4.5.1"" />
+  </system.web>
 </configuration>", Constants.WebConfigBootstrapperVersion,
                 Constants.WebConfigRuntimePath,
                 Constants.WebConfigRuntimeVersion,
@@ -896,6 +905,9 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     <add key=""{3}"" value="""" />
     <add key=""{4}"" value=""..\approot\src\{{0}}"" />
   </appSettings>
+  <system.web>
+    <httpRuntime targetFramework=""4.5.1"" />
+  </system.web>
 </configuration>", Constants.WebConfigBootstrapperVersion,
                 Constants.WebConfigRuntimePath,
                 Constants.WebConfigRuntimeVersion,


### PR DESCRIPTION
Now, dnx.clr.managed reads the project.json and determines the highest dnxNN framework in use, then boots the Desktop CLR with the quirking mode for the matching .NET version.

Fixes #2119

Note: Mono still only supports `dnx451` at the moment, see #2118 

Note the Second: Helios may need to be updated for this. I've filed aspnet/Helios#175 to check how it behaves and update as appropriate.