### PR TITLE
fix #2168 by updating the lock file version

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Restore/LockFileFormat.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/LockFileFormat.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Framework.PackageManager
 {
     public class LockFileFormat
     {
-        public const int Version = -9996;
         public const string LockFileName = "project.lock.json";
 
         public LockFile Read(string filePath)
@@ -129,7 +128,7 @@ namespace Microsoft.Framework.PackageManager
         {
             var json = new JObject();
             json["locked"] = new JValue(lockFile.Islocked);
-            json["version"] = new JValue(Version);
+            json["version"] = new JValue(Runtime.Constants.LockFileVersion);
             json["targets"] = WriteObject(lockFile.Targets, WriteTarget);
             json["libraries"] = WriteObject(lockFile.Libraries, WriteLibrary);
             json["projectFileDependencyGroups"] = WriteObject(lockFile.ProjectFileDependencyGroups, WriteProjectFileDependencyGroup);

--- a/src/Microsoft.Framework.Runtime.Sources/Impl/Constants.cs
+++ b/src/Microsoft.Framework.Runtime.Sources/Impl/Constants.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Framework.Runtime
         public const string BootstrapperHostName = RuntimeShortName + ".host";
         public const string BootstrapperClrName = RuntimeShortName + ".clr";
         public const string BootstrapperCoreclrManagedName = RuntimeShortName + ".coreclr.managed";
+
+        public const int LockFileVersion = 1;
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFile.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFile.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
 
         public bool IsValidForProject(Project project)
         {
-            if (Version != LockFileReader.Version)
+            if (Version != Constants.LockFileVersion)
             {
                 return false;
             }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileReader.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileReader.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
 {
     internal class LockFileReader
     {
-        public const int Version = -9996;
         public const string LockFileName = "project.lock.json";
 
         public LockFile Read(string filePath)

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuPublishTests.cs
@@ -48,7 +48,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     """": [],
     ""DNX,Version=v4.5.1"": []
   }
-}".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString());
+}".Replace("LOCKFILEFORMAT_VERSION", Constants.LockFileVersion.ToString());
 
         public DnuPublishTests(PackageManagerFunctionalTestFixture fixture)
         {
@@ -1021,7 +1021,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     ""DNX,Version=v4.5.1"": [],
     ""DNXCore,Version=v5.0"": []
   }
-}".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString()))
+}".Replace("LOCKFILEFORMAT_VERSION", Constants.LockFileVersion.ToString()))
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
   ""packages"": ""packages""
 }")
@@ -1128,7 +1128,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     ""DNX,Version=v4.5.1"": [],
     ""DNXCore,Version=v5.0"": []
   }
-}".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString())
+}".Replace("LOCKFILEFORMAT_VERSION", Constants.LockFileVersion.ToString())
   .Replace("RUNTIME_TARGET", flavor == "coreclr" ? "DNXCore,Version=v5.0" : "DNX,Version=v4.5.1"))
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
   ""packages"": ""packages""
@@ -1212,7 +1212,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     ],
     ""DNX,Version=v4.5.1"": []
   }
-}".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString());
+}".Replace("LOCKFILEFORMAT_VERSION", Constants.LockFileVersion.ToString());
 
             var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);
 
@@ -1317,7 +1317,7 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
     ],
     ""DNX,Version=v4.5.1"": []
   }
-}".Replace("LOCKFILEFORMAT_VERSION", LockFileFormat.Version.ToString())
+}".Replace("LOCKFILEFORMAT_VERSION", Constants.LockFileVersion.ToString())
 .Replace("LOCKFILE_NAME", LockFileFormat.LockFileName);
 
             var runtimeHomeDir = _fixture.GetRuntimeHomeDir(flavor, os, architecture);

--- a/test/Microsoft.Framework.Runtime.Tests/LockFileReaderFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/LockFileReaderFacts.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Framework.Runtime.Tests
         {
             var lockFileData = @"{
   ""locked"": false,
-  ""version"": -9996,
+  ""version"": 1,
   ""targets"": {
                 "".NETFramework,Version=v4.5"": {
                     ""WindowsAzure.ServiceBus/2.6.7"": {


### PR DESCRIPTION
Fixes #2168 

Pinging pretty much everyone mostly as an FYI. I'll wait until dev opens back up (and of course, for squirrels) before I merge though :).

Nobody should have to change because of this, but DNX will consider any existing lock file with version -9996 out of date and require a re-restore.

/cc @davidfowl @victorhurdugaci @troydai @moozzyk @Tratcher @BrennanConroy @lodejard @Eilon @muratg 