### PR TITLE
Mark a nupkg as unresolved when it doesn't provide compatible assembly

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/LockFileUtils.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Framework.PackageManager.Utils
 {
     internal static class LockFileUtils
     {
+        private static readonly Func<string, object> PlaceholderFileParser =
+            s => string.Equals(s, "_._", StringComparison.Ordinal) ? s : null;
+
         public static LockFileLibrary CreateLockFileLibrary(LockFileLibrary previousLibrary, IPackagePathResolver resolver, IPackage package, string correctedPackageName = null)
         {
             var lockFileLib = new LockFileLibrary();
@@ -399,11 +402,13 @@ namespace Microsoft.Framework.PackageManager.Utils
 
             ContentPropertyDefinition _assembly = new ContentPropertyDefinition
             {
+                Parser = PlaceholderFileParser,
                 FileExtensions = { ".dll", ".exe", ".winmd" }
             };
 
             ContentPropertyDefinition _dynamicLibrary = new ContentPropertyDefinition
             {
+                Parser = PlaceholderFileParser,
                 FileExtensions = { ".dll", ".dylib", ".so" }
             };
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/DependencyWalker.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/DependencyWalker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
@@ -67,7 +68,17 @@ namespace Microsoft.Framework.Runtime
 
                 if (!library.Resolved)
                 {
-                    var message = string.Format("Dependency {0} could not be resolved", library.LibraryRange);
+                    string message;
+                    if (library.Compatible)
+                    {
+                        message = $"The dependency {library.LibraryRange} could not be resolved.";
+                    }
+                    else
+                    {
+                        var projectName = Directory.GetParent(projectFilePath).Name;
+                        message =
+                            $"The dependency {library.Identity} in project {projectName} does not support framework {library.Framework}.";
+                    }
 
                     messages.Add(new FileFormatMessage(message, projectPath, CompilationMessageSeverity.Error)
                     {

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDescription.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDescription.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Framework.Runtime
         public IEnumerable<LibraryDependency> Dependencies { get; set; }
 
         public bool Resolved { get; set; } = true;
+        public bool Compatible { get; set; } = true;
 
         public string Path { get; set; }
         public string Type { get; set; }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
@@ -224,7 +224,8 @@ namespace Microsoft.Framework.Runtime
                         Framework = entry.Value.Description.Framework ?? frameworkName,
                         Dependencies = entry.Value.Dependencies.SelectMany(CorrectDependencyVersion).ToList(),
                         LoadableAssemblies = entry.Value.Description.LoadableAssemblies ?? Enumerable.Empty<string>(),
-                        Resolved = entry.Value.Description.Resolved
+                        Resolved = entry.Value.Description.Resolved,
+                        Compatible = entry.Value.Description.Compatible
                     };
                 }).ToList();
 

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuListTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuListTests.cs
@@ -102,9 +102,12 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
             Assert.Equal(0, DnuTestUtils.ExecDnu(runtimeHomePath, "list", "", out stdOut, out stdErr, environment: null, workingDir: _workingDir.DirPath));
 
             // there should be 2 and only 2 dependencies of alpha
-            var hits = stdOut.Split('\n').Where(line => line.Contains("* alpha 0.1.0"))
+            var resolvedHits = stdOut.Split('\n').Where(line => line.Contains("* alpha 0.1.0"))
                                          .Where(line => !line.Contains("Unresolved"));
-            Assert.Equal(2, hits.Count());
+            var unresolvedHits = stdOut.Split('\n').Where(line => line.Contains("* alpha 0.1.0"))
+                                         .Where(line => line.Contains("Unresolved"));
+            Assert.Equal(1, resolvedHits.Count());
+            Assert.Equal(1, unresolvedHits.Count());
         }
 
         [Theory]
@@ -123,8 +126,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
                 },
                 frameworks = new
                 {
-                    dnx451 = new { },
-                    dnxcore50 = new { }
+                    dnx451 = new { }
                 }
             });
 

--- a/test/Microsoft.Framework.Runtime.Tests/DependencyManagement/NuGetDependencyResolverFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/DependencyManagement/NuGetDependencyResolverFacts.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Versioning;
+using Microsoft.Framework.Runtime.DependencyManagement;
+using Xunit;
+using NuGet;
+
+namespace Microsoft.Framework.Runtime.Tests
+{
+    public class NuGetDependencyResolverFacts
+    {
+        [Theory]
+        [InlineData("MetaPackage", ".NETFramework,Version=v4.5", true)]
+        [InlineData("MetaPackage", "DNX,Version=v4.5.1", true)]
+        [InlineData("Net451LibPackage", ".NETFramework,Version=v4.5", false)]
+        [InlineData("Net451LibPackage", "DNX,Version=v4.5.1", true)]
+        [InlineData("Net451RefPackage", ".NETFramework,Version=v4.5", false)]
+        [InlineData("Net451RefPackage", "DNX,Version=v4.5.1", true)]
+        [InlineData("AssemblyPlaceholderPackage", ".NETFramework,Version=v4.5", true)]
+        [InlineData("AssemblyPlaceholderPackage", "DNX,Version=v4.5.1", false)]
+        public void LibrariesAreResolvedCorrectly(string packageName, string framework, bool resolved)
+        {
+            var repo = new PackageRepository("path/to/packages");
+            var resolver = new NuGetDependencyResolver(repo);
+
+            var net45Target = new LockFileTarget
+            {
+                TargetFramework = new FrameworkName(".NETFramework,Version=v4.5"),
+                Libraries = new List<LockFileTargetLibrary>
+                {
+                    new LockFileTargetLibrary
+                    {
+                        Name = "MetaPackage",
+                        Version = SemanticVersion.Parse("1.0.0"),
+                    },
+                    new LockFileTargetLibrary
+                    {
+                        Name = "Net451LibPackage",
+                        Version = SemanticVersion.Parse("1.0.0"),
+                    },
+                    new LockFileTargetLibrary
+                    {
+                        Name = "Net451RefPackage",
+                        Version = SemanticVersion.Parse("1.0.0"),
+                    },
+                    new LockFileTargetLibrary
+                    {
+                        Name = "AssemblyPlaceholderPackage",
+                        Version = SemanticVersion.Parse("1.0.0"),
+                        CompileTimeAssemblies = new List<LockFileItem> { Path.Combine("ref", "net45", "_._") },
+                        RuntimeAssemblies = new List<LockFileItem> { Path.Combine("lib", "net45", "_._") }
+                    }
+                }
+            };
+
+            var dnx451Target = new LockFileTarget
+            {
+                TargetFramework = new FrameworkName("DNX,Version=v4.5.1"),
+                Libraries = new List<LockFileTargetLibrary>
+                {
+                    new LockFileTargetLibrary
+                    {
+                        Name = "MetaPackage",
+                        Version = SemanticVersion.Parse("1.0.0")
+                    },
+                    new LockFileTargetLibrary
+                    {
+                        Name = "Net451LibPackage",
+                        Version = SemanticVersion.Parse("1.0.0"),
+                        CompileTimeAssemblies = new List<LockFileItem> { Path.Combine("lib", "net451", "Net451LibPackage.dll") },
+                        RuntimeAssemblies = new List<LockFileItem> { Path.Combine("lib", "net451", "Net451LibPackage.dll") }
+                    },
+                    new LockFileTargetLibrary
+                    {
+                        Name = "Net451RefPackage",
+                        Version = SemanticVersion.Parse("1.0.0"),
+                        CompileTimeAssemblies = new List<LockFileItem> { Path.Combine("ref", "net451", "Net451LibPackage.dll") }
+                    },
+                    new LockFileTargetLibrary
+                    {
+                        Name = "AssemblyPlaceholderPackage",
+                        Version = SemanticVersion.Parse("1.0.0")
+                    }
+                }
+            };
+
+            var metaPackageLibrary = new LockFileLibrary
+            {
+                Name = "MetaPackage",
+                Version = SemanticVersion.Parse("1.0.0")
+            };
+
+            var net451LibPackageLibrary = new LockFileLibrary
+            {
+                Name = "Net451LibPackage",
+                Version = SemanticVersion.Parse("1.0.0"),
+                Files = new List<string>
+                {
+                    Path.Combine("lib", "net451", "Net451LibPackage.dll"),
+                    Path.Combine("lib", "net451", "Net451LibPackage.xml")
+                }
+            };
+
+            var net451RefPackageLibrary = new LockFileLibrary
+            {
+                Name = "Net451RefPackage",
+                Version = SemanticVersion.Parse("1.0.0"),
+                Files = new List<string>
+                {
+                    Path.Combine("ref", "net451", "Net451LibPackage.dll")
+                }
+            };
+
+            var assemblyPlaceholderPackageLibrary = new LockFileLibrary
+            {
+                Name = "AssemblyPlaceholderPackage",
+                Version = SemanticVersion.Parse("1.0.0"),
+                Files = new List<string>
+                {
+                    Path.Combine("lib", "net45", "_._"),
+                    Path.Combine("ref", "net45", "_._"),
+                }
+            };
+
+            var lockFile = new LockFile()
+            {
+                Targets = new List<LockFileTarget> { net45Target, dnx451Target },
+                Libraries = new List<LockFileLibrary>
+                {
+                    metaPackageLibrary,
+                    net451LibPackageLibrary,
+                    net451RefPackageLibrary,
+                    assemblyPlaceholderPackageLibrary
+                }
+            };
+
+            resolver.ApplyLockFile(lockFile);
+
+            var libToLookup = new LibraryRange(packageName, frameworkReference: false);
+            Assert.Equal(resolved, resolver.GetDescription(libToLookup, new FrameworkName(framework)).Resolved);
+        }
+    }
+}


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/506

@davidfowl 

Learned the logic from @anurse . Here is what you get when a nupkg is only compatible with part of `frameworks`:
![capture](https://cloud.githubusercontent.com/assets/1383883/8466638/bf119fac-2009-11e5-832e-865115ec1288.PNG)
