### PR TITLE
Adding fallback to default servicing location (Fixes #2082)

### DIFF
--- a/src/Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs
+++ b/src/Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs
@@ -5,22 +5,21 @@ namespace Microsoft.Framework.Runtime
 {
     internal static class EnvironmentNames
     {
-        public static readonly string CommonPrefix = Constants.RuntimeShortName.ToUpper() + "_";
         public static readonly string Packages = "NUGET_PACKAGES";
-        public static readonly string DnxPackages = CommonPrefix + "PACKAGES";
-        public static readonly string PackagesCache = CommonPrefix + "PACKAGES_CACHE";
-        public static readonly string Servicing = CommonPrefix + "SERVICING";
-        public static readonly string Trace = CommonPrefix + "TRACE";
-        public static readonly string CompilationServerPort = CommonPrefix + "COMPILATION_SERVER_PORT";
-        public static readonly string Home = CommonPrefix + "HOME";
-        public static readonly string GlobalPath = CommonPrefix + "GLOBAL_PATH";
-        public static readonly string AppBase = CommonPrefix + "APPBASE";
-        public static readonly string Framework = CommonPrefix + "FRAMEWORK";
-        public static readonly string Configuration = CommonPrefix + "CONFIGURATION";
-        public static readonly string ConsoleHost = CommonPrefix + "CONSOLE_HOST";
-        public static readonly string DefaultLib = CommonPrefix + "DEFAULT_LIB";
-        public static readonly string BuildKeyFile = CommonPrefix + "BUILD_KEY_FILE";
-        public static readonly string BuildDelaySign = CommonPrefix + "BUILD_DELAY_SIGN";
-        public static readonly string Sources = CommonPrefix + "SOURCES";
+        public static readonly string DnxPackages = "DNX_PACKAGES";
+        public static readonly string PackagesCache = "DNX_PACKAGES_CACHE";
+        public static readonly string Servicing = "DNX_SERVICING";
+        public static readonly string Trace = "DNX_TRACE";
+        public static readonly string CompilationServerPort = "DNX_COMPILATION_SERVER_PORT";
+        public static readonly string Home = "DNX_HOME";
+        public static readonly string GlobalPath = "DNX_GLOBAL_PATH";
+        public static readonly string AppBase = "DNX_APPBASE";
+        public static readonly string Framework = "DNX_FRAMEWORK";
+        public static readonly string Configuration = "DNX_CONFIGURATION";
+        public static readonly string ConsoleHost = "DNX_CONSOLE_HOST";
+        public static readonly string DefaultLib = "DNX_DEFAULT_LIB";
+        public static readonly string BuildKeyFile = "DNX_BUILD_KEY_FILE";
+        public static readonly string BuildDelaySign = "DNX_BUILD_DELAY_SIGN";
+        public static readonly string Sources = "DNX_SOURCES";
     }
 }


### PR DESCRIPTION
Fixing a bug where servicing would not work on 32-bit OSes because we never assigned the value of the `PROGRAMFILES` environment variable