### PR TITLE
Fixing how we read environment variables in native code

### DIFF
--- a/src/dnx.clr/HostAssemblyStore.cpp
+++ b/src/dnx.clr/HostAssemblyStore.cpp
@@ -14,7 +14,8 @@ HRESULT STDMETHODCALLTYPE HostAssemblyStore::ProvideAssembly(AssemblyBindInfo *p
     if (_wcsicmp(AppDomainManagerAssemblyName, pBindInfo->lpReferencedIdentity) == 0)
     {
         wchar_t default_lib[MAX_PATH] = { 0 };
-        if (GetEnvironmentVariable(L"DNX_DEFAULT_LIB", default_lib, MAX_PATH) == 0)
+        auto result = GetEnvironmentVariable(L"DNX_DEFAULT_LIB", default_lib, MAX_PATH);
+        if (result == 0 || result > MAX_PATH)
         {
             return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
         }

--- a/src/dnx.coreclr/dnx.coreclr.cpp
+++ b/src/dnx.coreclr/dnx.coreclr.cpp
@@ -109,7 +109,14 @@ HMODULE LoadCoreClr(const std::wstring& runtime_directory, dnx::trace_writer& tr
     HMODULE coreclr_module;
 
     wchar_t coreclr_dir_buffer[MAX_PATH];
-    if (GetEnvironmentVariableW(L"CORECLR_DIR", coreclr_dir_buffer, MAX_PATH))
+    auto result = GetEnvironmentVariableW(L"CORECLR_DIR", coreclr_dir_buffer, MAX_PATH);
+    if (result > MAX_PATH)
+    {
+        trace_writer.write(L"The value of the 'CORECLR_DIR' variable is invalid. Aborting loading coreclr.dll.", true);
+        return nullptr;
+    }
+
+    if (result)
     {
         coreclr_module = LoadCoreClrFromPath(coreclr_dir_buffer, trace_writer);
     }
@@ -137,9 +144,9 @@ HMODULE LoadCoreClr(const std::wstring& runtime_directory, dnx::trace_writer& tr
 */
 void Win32KDisable(dnx::trace_writer& trace_writer)
 {
-    wchar_t szWin32KDisable[2] = { 0 , 0 };
+    wchar_t buff[2] = { 0 , 0 };
 
-    if (GetEnvironmentVariable(L"DNX_WIN32K_DISABLE", szWin32KDisable, _countof(szWin32KDisable)) == 0 || wcscmp(szWin32KDisable, L"1") != 0)
+    if (GetEnvironmentVariable(L"DNX_WIN32K_DISABLE", buff, 2) != 1 || buff[0] != L'1')
     {
         return;
     }

--- a/src/dnx/pal.win32.cpp
+++ b/src/dnx/pal.win32.cpp
@@ -95,7 +95,15 @@ namespace
 
         for (auto servicing_location : servicing_locations)
         {
-            if (GetEnvironmentVariable(servicing_location, servicing_location_buffer, MAX_PATH) != 0)
+            auto result = GetEnvironmentVariable(servicing_location, servicing_location_buffer, MAX_PATH);
+            if (result > MAX_PATH)
+            {
+                trace_writer.write(std::wstring(L"The value of the '")
+                    .append(servicing_location).append(L"' environment variable is invalid and the location will be skipped."), true);
+                continue;
+            }
+
+            if (result != 0)
             {
                 // %DNX_SERVICING% should point directly to servicing folder. For program files we need to append the
                 // actual servicing folder location to %ProgramFilesXXX%


### PR DESCRIPTION
We did not check if the buffer was big enough to hold the value. If it wouldn't be *`the contents of lpBuffer are undefined`* so we would crash or have other interesting side effects (like load dlls from wrong location).