### PR TITLE
"dnu restore" checks corrupted packages

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/NuGetPackageUtils.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Framework.PackageManager
 
                 var actionName = "Installing";
                 var installedPackageHash = string.Empty;
-                if (File.Exists(targetHashPath))
+                if (File.Exists(targetHashPath) && File.Exists(targetNuspec))
                 {
                     installedPackageHash = File.ReadAllText(targetHashPath);
                     actionName = "Overwriting";

--- a/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
@@ -108,6 +108,14 @@ namespace NuGet
                         continue;
                     }
 
+                    var manifestFilePath = _repositoryRoot.GetFiles(versionDir, "*" + Constants.ManifestExtension)
+                        .FirstOrDefault();
+                    if (string.IsNullOrEmpty(manifestFilePath))
+                    {
+                        // This is a corrupted packages because {id}.nupsec is missing
+                        continue;
+                    }
+
                     if (CheckHashFile && !_repositoryRoot.GetFiles(versionDir, "*" + Constants.HashFileExtension).Any())
                     {
                         // Writing the marker file is the last operation performed by NuGetPackageUtils.InstallFromStream. We'll use the
@@ -120,13 +128,7 @@ namespace NuGet
                     // Otherwise we just use the passed in package id for efficiency
                     if (_checkPackageIdCase)
                     {
-                        var manifestFileName = Path.GetFileName(
-                            _repositoryRoot.GetFiles(versionDir, "*" + Constants.ManifestExtension).FirstOrDefault());
-                        if (string.IsNullOrEmpty(manifestFileName))
-                        {
-                            continue;
-                        }
-                        id = Path.GetFileNameWithoutExtension(manifestFileName);
+                        id = Path.GetFileNameWithoutExtension(manifestFilePath);
                     }
 
                     packages.Add(new PackageInfo(_repositoryRoot, id, version, versionDir));

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuCommandsTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuCommandsTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Framework.CommonTestUtils;
 using Microsoft.Framework.Runtime.DependencyManagement;
+using NuGet;
 using Xunit;
 
 namespace Microsoft.Framework.PackageManager.FunctionalTests
@@ -103,7 +104,7 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
             {
                 var directory = Path.Combine(testEnv.RootDir, Runtime.Constants.DefaultLocalRuntimeHomeDir, "bin");
                 InstallFakeApp(directory, "pack1", "0.0.0");
-                Directory.CreateDirectory($"{directory}/packages/pack2/0.0.0/");
+                InstallFakePackage(directory, "pack2", "0.0.0");
                 WriteLockFile($"{directory}/packages/pack1/0.0.0/app", "pack1", "0.0.0");
 
                 var environment = new Dictionary<string, string> { { "USERPROFILE", testEnv.RootDir } };
@@ -140,9 +141,16 @@ namespace Microsoft.Framework.PackageManager.FunctionalTests
 
         private void InstallFakeApp(string directory, string name, string version)
         {
+            InstallFakePackage(directory, name, version);
             Directory.CreateDirectory($"{directory}/packages/{name}/{version}/app");
             File.WriteAllText($"{directory}/packages/{name}/{version}/app/{name}.cmd", "");
             File.WriteAllText($"{directory}/{name}.cmd", $"~dp0/packages/{name}/{version}/app/{name}.cmd".Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        private void InstallFakePackage(string directory, string name, string version)
+        {
+            Directory.CreateDirectory($"{directory}/packages/{name}/{version}");
+            File.WriteAllText($"{directory}/packages/{name}/{version}/{name}{Constants.ManifestExtension}", "");
             File.WriteAllText($"{directory}/packages/{name}/{version}/{name}.{version}.nupkg.sha512", "TestSha");
         }
 


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/1243

Without this change, when `{id}.nuspec` is missing, `dnu restore` fails instead of reinstalling.

@davidfowl 
@BrennanConroy (I modified some of your tests)