### PR TITLE
fix #2117 by adding config information to feeds list

### DIFF
--- a/src/Microsoft.Framework.PackageManager/ConsoleCommands/FeedsConsoleCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/ConsoleCommands/FeedsConsoleCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Framework.PackageManager
 
                 c.OnExecute(() =>
                 {
-                    var command = new ListSourcesCommand(
+                    var command = new ListFeedsCommand(
                         reportsFactory.CreateReports(quiet: false),
                         string.IsNullOrEmpty(argRoot.Value) ? "." : argRoot.Value);
 

--- a/src/Microsoft.Framework.PackageManager/Feeds/ListFeedsCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Feeds/ListFeedsCommand.cs
@@ -1,16 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
+using NuGet;
 
 namespace Microsoft.Framework.PackageManager
 {
-    internal class ListSourcesCommand
+    internal class ListFeedsCommand
     {
         public Reports Reports { get; }
         public string TargetDirectory { get; }
 
-        public ListSourcesCommand(Reports reports, string targetDirectory)
+        public ListFeedsCommand(Reports reports, string targetDirectory)
         {
             Reports = reports;
             TargetDirectory = targetDirectory;
@@ -29,17 +31,38 @@ namespace Microsoft.Framework.PackageManager
             }
             else
             {
-                Reports.Information.WriteLine("Registered Sources:");
+                Reports.Information.WriteLine("Feeds in use:");
 
                 // Iterate over the sources and report them
-                int index = 1; // This is an index for display so it should be 1-based
                 foreach (var source in sources)
                 {
                     var enabledString = source.IsEnabled ? "" : " [Disabled]";
-                    var line = $"{index.ToString("0\\.").PadRight(3)} {source.Name} {source.Source}{enabledString.Yellow().Bold()}";
+
+                    var line = $"    {source.Source}{enabledString.Yellow().Bold()}";
                     Reports.Information.WriteLine(line);
 
-                    index++;
+                    var origin = source.Origin as Settings;
+                    if (origin != null)
+                    {
+                        Reports.Information.WriteLine($"      Origin: {origin.ConfigFilePath}");
+                    }
+                    else if (source.IsOfficial)
+                    {
+                        Reports.Information.WriteLine($"      Offical NuGet Source, enabled by default");
+                    }
+                }
+            }
+
+            // Display config files in use
+            var settings = config.Settings as Settings;
+            if (settings != null)
+            {
+                var configFiles = settings.GetConfigFiles();
+
+                Reports.Quiet.WriteLine($"{Environment.NewLine}NuGet Config files in use:");
+                foreach (var file in configFiles)
+                {
+                    Reports.Quiet.WriteLine($"    {file}");
                 }
             }
             return 0;

--- a/src/Microsoft.Framework.PackageManager/NuGet/Core/Configuration/SettingValue.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/Core/Configuration/SettingValue.cs
@@ -11,16 +11,19 @@ namespace NuGet
 {
     public class SettingValue
     {
-        public SettingValue(string key, string value, bool isMachineWide)
+        public SettingValue(string key, string value, bool isMachineWide, ISettings origin)
         {
             Key = key;
             Value = value;
             IsMachineWide = isMachineWide;
+            Origin = origin;
         }
 
         public string Key { get; private set; }
 
         public string Value { get; set; }
+
+        public ISettings Origin { get; set; }
 
         public bool IsMachineWide { get; private set; }
 

--- a/src/Microsoft.Framework.PackageManager/NuGet/Core/Configuration/Settings.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/Core/Configuration/Settings.cs
@@ -629,7 +629,7 @@ namespace NuGet
                 if (elementName.Equals("add", StringComparison.OrdinalIgnoreCase))
                 {
                     var v = ReadValue(element, isPath);
-                    values.Add(new SettingValue(v.Key, v.Value, _isMachineWideSettings));
+                    values.Add(new SettingValue(v.Key, v.Value, _isMachineWideSettings, this));
                 }
                 else if (elementName.Equals("remove", StringComparison.OrdinalIgnoreCase))
                 {
@@ -645,6 +645,7 @@ namespace NuGet
                     var v = ReadValue(element, isPath);
                     foreach (var updateItem in values.Where(f => f.Key.Equals(v.Key, StringComparison.OrdinalIgnoreCase)))
                     {
+                        updateItem.Origin = this;
                         updateItem.Value = v.Value;
                     }
                 }

--- a/src/Microsoft.Framework.PackageManager/NuGet/Core/PackageSource/PackageSource.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/Core/PackageSource/PackageSource.cs
@@ -17,6 +17,8 @@ namespace NuGet
         [DataMember]
         public string Source { get; private set; }
 
+        public ISettings Origin { get; private set; }
+
         /// <summary>
         /// This does not represent just the NuGet Official Feed alone
         /// It may also represent a Default Package Source set by Configuration Defaults
@@ -49,6 +51,11 @@ namespace NuGet
         }
 
         public PackageSource(string source, string name, bool isEnabled, bool isOfficial)
+            : this(source, name, isEnabled, isOfficial, origin: null)
+        {
+        }
+
+        public PackageSource(string source, string name, bool isEnabled, bool isOfficial, ISettings origin)
         {
             if (source == null)
             {
@@ -64,6 +71,7 @@ namespace NuGet
             Source = Environment.ExpandEnvironmentVariables(source);
             IsEnabled = isEnabled;
             IsOfficial = isOfficial;
+            Origin = origin;
             _hashCode = Name.ToUpperInvariant().GetHashCode() * 3137 + Source.ToUpperInvariant().GetHashCode();
         }
 
@@ -100,7 +108,7 @@ namespace NuGet
 
         public PackageSource Clone()
         {
-            return new PackageSource(Source, Name, IsEnabled, IsOfficial) { UserName = UserName, Password = Password, IsPasswordClearText = IsPasswordClearText, IsMachineWide = IsMachineWide };
+            return new PackageSource(Source, Name, IsEnabled, IsOfficial, Origin) { UserName = UserName, Password = Password, IsPasswordClearText = IsPasswordClearText, IsMachineWide = IsMachineWide };
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/NuGet/Core/PackageSource/PackageSourceProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/NuGet/Core/PackageSource/PackageSourceProvider.cs
@@ -119,7 +119,7 @@ namespace NuGet
                                                string src = p.Value;
                                                PackageSourceCredential creds = ReadCredential(name);
 
-                                               return new PackageSource(src, name, isEnabled: !disabledSources.Contains(name))
+                                               return new PackageSource(src, name, isEnabled: !disabledSources.Contains(name), isOfficial: false, origin: p.Origin)
                                                {
                                                    UserName = creds != null ? creds.Username : null,
                                                    Password = creds != null ? creds.Password : null,

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuFeedsTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/DnuFeedsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Framework.CommonTestUtils;
@@ -92,9 +93,9 @@ namespace Microsoft.Framework.PackageManager
 
                 // CI Machines and such have different sources in the user-global config
                 // So we can't actually assert the exact content of the output.
-                Assert.Contains("Source1 https://source1 [Disabled]", output);
-                Assert.Contains("Source2 https://source2", output);
-                Assert.Contains("Source3 https://source3", output);
+                Assert.Contains($"https://source1 [Disabled]{Environment.NewLine}      Origin: {Path.Combine(projectPath, "root", "NuGet.Config")}", output);
+                Assert.Contains($"https://source2{Environment.NewLine}      Origin: {Path.Combine(projectPath, "root", "NuGet.Config")}", output);
+                Assert.Contains($"https://source3{Environment.NewLine}      Origin: {Path.Combine(projectPath, "root", "sub", "NuGet.Config")}", output);
             }
         }
     }


### PR DESCRIPTION
Fixes #2177 

The list of config files is easy, but showing the config file used for each individual source required some changes to our forked NuGet code. It wasn't as invasive as I'd feared, but it would be something to be aware of when we integrate NuGetv3 Code here.

/cc @davidfowl @kichalla 

![image](https://cloud.githubusercontent.com/assets/7574/8607489/08cbb60c-2648-11e5-802d-16d155a73485.png)
