### PR TITLE
Adding a test testing actual dnx code.

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -358,6 +358,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
     @{
         var sourceFiles = new string[] 
         {
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "main.cpp"),
             Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, BOOTSTRAPPER_EXE_NAME + ".cpp"),
             Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.unix.cpp"),
             Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.linux.cpp"),
@@ -398,6 +399,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
     @{
         var sourceFiles = new string[]
         {
+            Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "main.cpp"),
             Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, BOOTSTRAPPER_EXE_NAME + ".cpp"),
             Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.unix.cpp"),
             Path.Combine("src", BOOTSTRAPPER_FOLDER_NAME, "pal.darwin.cpp"),

--- a/src/dnx.clr/dnx.clr.cpp
+++ b/src/dnx.clr/dnx.clr.cpp
@@ -6,7 +6,7 @@
 #include "stdafx.h"
 
 #include "KatanaManager.h"
-#include "..\dnx\dnx.h"
+#include "app_main.h"
 
 IKatanaManagerPtr g_katanaManager;
 

--- a/src/dnx.common/dnx.common.vcxproj
+++ b/src/dnx.common/dnx.common.vcxproj
@@ -29,6 +29,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="include\app_main.h" />
     <ClInclude Include="include\tpa.h" />
     <ClInclude Include="include\utils.h" />
     <ClInclude Include="include\xplat.h" />

--- a/src/dnx.common/dnx.common.vcxproj.filters
+++ b/src/dnx.common/dnx.common.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="include\xplat.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\app_main.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">

--- a/src/dnx.common/include/app_main.h
+++ b/src/dnx.common/include/app_main.h
@@ -1,14 +1,22 @@
+#pragma once
+
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#include "xplat.h"
+
 typedef struct CALL_APPLICATION_MAIN_DATA
 {
-    LPCTSTR applicationBase; // application base of managed domain
-    LPCTSTR runtimeDirectory; // path to runtime helper directory
+    const dnx::char_t* applicationBase; // application base of managed domain
+    const dnx::char_t* runtimeDirectory; // path to runtime helper directory
     int argc; // Number of args in argv
-    LPCTSTR* argv; // Array of arguments
+    const dnx::char_t** argv; // Array of arguments
     int exitcode; // Exit code from Managed Application
 } *PCALL_APPLICATION_MAIN_DATA;
 
-typedef HRESULT (STDAPICALLTYPE *FnCallApplicationMain)(
+typedef HRESULT(
+#if defined(_WIN32)
+    __stdcall
+#endif
+    *FnCallApplicationMain)(
     PCALL_APPLICATION_MAIN_DATA pCallApplicationMainData);

--- a/src/dnx.common/include/utils.h
+++ b/src/dnx.common/include/utils.h
@@ -16,6 +16,8 @@ namespace dnx
         dnx::xstring_t to_xstring_t(const std::wstring& s);
         std::wstring to_wstring(const std::string& s);
 
+        bool strings_equal_ignore_case(const char_t* s1, const char_t* s2);
+
         dnx::xstring_t path_combine(const dnx::xstring_t& path1, const dnx::xstring_t& path2);
         bool file_exists(const dnx::xstring_t& path);
         dnx::xstring_t remove_file_from_path(const dnx::xstring_t& path);

--- a/src/dnx.common/utils.cpp
+++ b/src/dnx.common/utils.cpp
@@ -9,10 +9,10 @@
 // <codecvt> not supported in libstdc++ (gcc, Clang) but conversions from wstring are only
 // meant to be used on Windows
 #if defined(_WIN32)
-
 #include <locale>
 #include <codecvt>
-
+#else
+#include <string.h>
 #endif
 
 namespace dnx
@@ -52,6 +52,15 @@ namespace dnx
             return to_xstring_t(s);
         }
 #endif
+
+        bool strings_equal_ignore_case(const char_t* s1, const char_t* s2)
+        {
+#if defined(_WIN32)
+            return _wcsicmp(s1, s2) == 0;
+#else
+            return strcasecmp(s1, s2) == 0;
+#endif
+        }
 
         bool ends_with_slash(const xstring_t& path)
         {

--- a/src/dnx.coreclr/dnx.coreclr.cpp
+++ b/src/dnx.coreclr/dnx.coreclr.cpp
@@ -3,11 +3,11 @@
 
 #include "stdafx.h"
 
-#include "..\dnx\dnx.h"
 #include "dnx.coreclr.h"
 #include "tpa.h"
 #include "utils.h"
 #include "trace_writer.h"
+#include "app_main.h"
 
 typedef int (STDMETHODCALLTYPE *HostMain)(const int argc, const wchar_t** argv);
 

--- a/src/dnx/dnx.vcxproj
+++ b/src/dnx/dnx.vcxproj
@@ -44,7 +44,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
-    <ClInclude Include="dnx.h" />
     <ClInclude Include="pal.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="servicing.h" />
@@ -55,6 +54,7 @@
   <ItemGroup>
     <ClCompile Condition="'$(Platform)' != 'ARM'" Include="dllmain.cpp" />
     <ClCompile Include="dnx.cpp" />
+    <ClCompile Include="main.cpp" />
     <ClCompile Include="pal.win32.cpp" />
     <ClCompile Include="servicing.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/src/dnx/main.cpp
+++ b/src/dnx/main.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "pal.h"
+#include "utils.h"
+
+
+int CallApplicationProcessMain(int argc, dnx::char_t* argv[], dnx::trace_writer& trace_writer);
+void FreeExpandedCommandLineArguments(int argc, dnx::char_t** ppszArgv);
+bool ExpandCommandLineArguments(int argc, dnx::char_t** ppszArgv, int& expanded_argc, dnx::char_t**& ppszExpandedArgv);
+
+#if defined(ARM)
+int wmain(int argc, wchar_t* argv[])
+#elif defined(PLATFORM_UNIX)
+int main(int argc, char* argv[])
+#else
+extern "C" int __stdcall DnxMain(int argc, wchar_t* argv[])
+#endif
+{
+    // Check for the debug flag before doing anything else
+    for (int i = 1; i < argc; ++i)
+    {
+        //anything without - or -- is appbase or non-dnx command
+        if (argv[i][0] != _X('-'))
+        {
+            break;
+        }
+        if (dnx::utils::strings_equal_ignore_case(argv[i], _X("--appbase")))
+        {
+            //skip path argument
+            ++i;
+            continue;
+        }
+        if (dnx::utils::strings_equal_ignore_case(argv[i], _X("--debug")))
+        {
+            WaitForDebuggerToAttach();
+            break;
+        }
+    }
+
+    int nExpandedArgc = -1;
+    LPTSTR* ppszExpandedArgv = nullptr;
+    auto expanded = ExpandCommandLineArguments(argc - 1, &(argv[1]), nExpandedArgc, ppszExpandedArgv);
+
+    auto trace_writer = dnx::trace_writer{ IsTracingEnabled() };
+    if (!expanded)
+    {
+        return CallApplicationProcessMain(argc - 1, &argv[1], trace_writer);
+    }
+
+    auto exitCode = CallApplicationProcessMain(nExpandedArgc, ppszExpandedArgv, trace_writer);
+    FreeExpandedCommandLineArguments(nExpandedArgc, ppszExpandedArgv);
+    return exitCode;
+}

--- a/src/dnx/pal.h
+++ b/src/dnx/pal.h
@@ -5,6 +5,7 @@
 
 #include "xplat.h"
 #include "trace_writer.h"
+#include "app_main.h"
 
 dnx::xstring_t GetNativeBootstrapperDirectory();
 void WaitForDebuggerToAttach();

--- a/src/dnx/pal.unix.cpp
+++ b/src/dnx/pal.unix.cpp
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <assert.h>
 #include <dlfcn.h>
-#include "dnx.h"
+#include "app_main.h"
 #include "trace_writer.h"
 
 std::string GetNativeBootstrapperDirectory();

--- a/src/dnx/pal.win32.cpp
+++ b/src/dnx/pal.win32.cpp
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include "dnx.h"
+#include "app_main.h"
 #include "xplat.h"
 #include "trace_writer.h"
 #include "utils.h"

--- a/src/dnx/stdafx.h
+++ b/src/dnx/stdafx.h
@@ -33,7 +33,6 @@ typedef void* HANDLE;
 
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
 
-#define STDAPICALLTYPE
 #define MAX_PATH PATH_MAX
 #define S_OK 0
 #define TRUE 1

--- a/src/dnx/tchar.h
+++ b/src/dnx/tchar.h
@@ -9,7 +9,6 @@ typedef const char* LPCSTR;
 #define _T(x) x
 
 #define _tcsnicmp strncasecmp
-#define _tcsicmp strcasecmp
 #define _tcsnlen strnlen
 #define _tprintf_s printf_s
 

--- a/test/dnx.tests/dnx.tests.vcxproj
+++ b/test/dnx.tests/dnx.tests.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile>
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\gtest-1.7.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <Link>
       <Subsystem>Console</Subsystem>
@@ -47,13 +48,15 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\dnx\dnx.cpp" />
     <ClCompile Include="dnxtests.cpp" />
+    <ClCompile Include="pal.tests.cpp" />
     <ClCompile Include="parameter_expansion_tests.cpp" />
-    <ClCompile Include="stdafx.cpp">
-      <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\dnx.common\dnx.common.vcxproj">
+      <Project>{1fe82655-09ee-456d-82b5-4625857ff53d}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\gtest-1.7.0\msvc\gtest.vcxproj">
       <Project>{2af210a9-5bdc-45e8-95dd-07b5a2616493}</Project>
     </ProjectReference>

--- a/test/dnx.tests/dnx.tests.vcxproj.filters
+++ b/test/dnx.tests/dnx.tests.vcxproj.filters
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
@@ -13,6 +9,13 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Tests">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{fd2b8f44-b654-4f41-adfd-5f252eb426b7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -20,14 +23,17 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="stdafx.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="dnxtests.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="parameter_expansion_tests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dnx\dnx.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pal.tests.cpp">
+      <Filter>Tests</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/test/dnx.tests/pal.tests.cpp
+++ b/test/dnx.tests/pal.tests.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include "stdafx.h"
+#include "xplat.h"
+#include "trace_writer.h"
+#include "app_main.h"
+
+dnx::xstring_t GetNativeBootstrapperDirectory() { return L""; }
+void WaitForDebuggerToAttach() {}
+bool IsTracingEnabled() { return true; }
+void SetConsoleHost() {}
+BOOL GetAppBasePathFromEnvironment(LPTSTR /*szPath*/) { return false; };
+BOOL GetFullPath(LPCTSTR /*szPath*/, LPTSTR /*szFullPath*/) { return false; }
+int CallApplicationMain(const dnx::char_t* /*moduleName*/, const char* /*functionName*/, CALL_APPLICATION_MAIN_DATA* /*data*/, dnx::trace_writer& /*trace_writer*/) { return 3; }
+
+#ifndef SetEnvironmentVariable
+BOOL SetEnvironmentVariable(LPCTSTR lpName, LPCTSTR lpValue);
+#endif //SetEnvironmentVariable

--- a/test/dnx.tests/parameter_expansion_tests.cpp
+++ b/test/dnx.tests/parameter_expansion_tests.cpp
@@ -2,8 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
+#include "xplat.h"
 
-TEST(parameter_expansion, always_passes)
+bool ExpandCommandLineArguments(int nArgc, dnx::char_t** ppszArgv, int& nExpandedArgc, dnx::char_t**& ppszExpandedArgv);
+
+TEST(parameter_expansion, ExpandCommandLineArguments_returns_false_when_no_params)
 {
-
+    int expanded_arg_count;
+    dnx::char_t** expanded_argv = nullptr;
+    ASSERT_FALSE(ExpandCommandLineArguments(0, nullptr, expanded_arg_count, expanded_argv));
+    ASSERT_EQ(nullptr, expanded_argv);
 }

--- a/test/dnx.tests/stdafx.cpp
+++ b/test/dnx.tests/stdafx.cpp
@@ -1,4 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-#include "stdafx.h"

--- a/test/dnx.tests/stdafx.h
+++ b/test/dnx.tests/stdafx.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
-#include <stdio.h>
 #include <tchar.h>
+#include <strsafe.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
- seperating out the entry point (DnxMain) to avoid having two `main` methods in tests
- moving string compare to a common location since it's now being used in multiple files
- moving CALL_APPLICATION_MAIN_DATA to dnx common - it was already being used by multiple projects
- diabling precompiled headers in main since we are including file from other projects which include different "stdafx.h" file