### PR TITLE
Fixing a bug where appbase was not expanded correctly

### DIFF
--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -123,6 +123,12 @@ dnx::char_t* GetAppBaseParameterValue(int argc, dnx::char_t* argv[])
 {
     for (auto i = 0; i < argc - 1; ++i)
     {
+        // not starting with '-' means that this and any following parameter is not a bootstrapper
+        if (*argv[i] != _X('-'))
+        {
+            break;
+        }
+
         if (dnx::utils::strings_equal_ignore_case(argv[i], _X("--appbase")))
         {
             return argv[i + 1];

--- a/test/dnx.tests/parameter_expansion_tests.cpp
+++ b/test/dnx.tests/parameter_expansion_tests.cpp
@@ -5,11 +5,29 @@
 #include "xplat.h"
 
 bool ExpandCommandLineArguments(int nArgc, dnx::char_t** ppszArgv, int& nExpandedArgc, dnx::char_t**& ppszExpandedArgv);
+void FreeExpandedCommandLineArguments(int nArgc, dnx::char_t** ppszArgv);
 
 TEST(parameter_expansion, ExpandCommandLineArguments_returns_false_when_no_params)
 {
     int expanded_arg_count;
-    dnx::char_t** expanded_argv = nullptr;
-    ASSERT_FALSE(ExpandCommandLineArguments(0, nullptr, expanded_arg_count, expanded_argv));
-    ASSERT_EQ(nullptr, expanded_argv);
+    dnx::char_t** expanded_args = nullptr;
+    ASSERT_FALSE(ExpandCommandLineArguments(0, nullptr, expanded_arg_count, expanded_args));
+    ASSERT_EQ(nullptr, expanded_args);
+}
+
+TEST(parameter_expansion, ExpandCommandLineArguments_should_ignore_appbase_after_bootstrapper_commands)
+{
+    int expanded_arg_count;
+    dnx::char_t** expanded_args = nullptr;
+    dnx::char_t* args[]{ _X("."), _X("run"), _X("--appbase"), _X("C:\\temp") };
+    ASSERT_TRUE(ExpandCommandLineArguments(4, args, expanded_arg_count, expanded_args));
+    ASSERT_EQ(6, expanded_arg_count);
+    ASSERT_STREQ(_X("--appbase"), expanded_args[0]);
+    ASSERT_STREQ(_X("."), expanded_args[1]);
+    ASSERT_STREQ(_X("Microsoft.Framework.ApplicationHost"), expanded_args[2]);
+    ASSERT_STREQ(_X("run"), expanded_args[3]);
+    ASSERT_STREQ(_X("--appbase"), expanded_args[4]);
+    ASSERT_STREQ(_X("C:\\temp"), expanded_args[5]);
+
+    FreeExpandedCommandLineArguments(expanded_arg_count, expanded_args);
 }


### PR DESCRIPTION
Before when looking for --appbase we would look at all the parameters instead of stopping after reaching the first non-bootstrapper parameter. As a result if --appbase appeared after the first non-bootstrapper parameter we would not expand the path and the app would fail.