### PR TITLE
Use normalized version in publish package search

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Publish/PublishPackage.cs
+++ b/src/Microsoft.Framework.PackageManager/Publish/PublishPackage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.Framework.Runtime;
 using NuGet;
 
@@ -25,7 +23,8 @@ namespace Microsoft.Framework.PackageManager.Publish
         {
             root.Reports.Quiet.WriteLine("Using {0} dependency {1}", _libraryDescription.Type, Library);
 
-            var srcNupkgPath = Path.Combine(_libraryDescription.Path, Library.Name + "." + Library.Version + ".nupkg");
+            var packagePathResolver = new DefaultPackagePathResolver(root.SourcePackagesPath);
+            var srcNupkgPath = packagePathResolver.GetPackageFilePath(_libraryDescription.Identity.Name, _libraryDescription.Identity.Version);
 
             var options = new Microsoft.Framework.PackageManager.Packages.AddOptions
             {


### PR DESCRIPTION
Addressing issue #2267 

This is not a perfect fix. Ideally an `IPackagePathResolver` should be used to locate the package. I'd like to push this in beta-6 so I limit the scope of the change.

I track the remaining work in https://github.com/aspnet/dnx/issues/2273.