### PR TITLE
Pass OS from native to managed

### DIFF
--- a/src/Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs
+++ b/src/Microsoft.Framework.Runtime.Sources/Impl/EnvironmentNames.cs
@@ -21,5 +21,6 @@ namespace Microsoft.Framework.Runtime
         public const string BuildKeyFile = "DNX_BUILD_KEY_FILE";
         public const string BuildDelaySign = "DNX_BUILD_DELAY_SIGN";
         public const string Sources = "DNX_SOURCES";
+        public const string DnxIsWindows = "DNX_IS_WINDOWS";
     }
 }

--- a/src/dnx.host/RuntimeEnvironment.cs
+++ b/src/dnx.host/RuntimeEnvironment.cs
@@ -23,6 +23,12 @@ namespace Microsoft.Framework.Runtime
             RuntimeType = Type.GetType("Mono.Runtime") == null ? "CLR" : "Mono";
             RuntimeArchitecture = Environment.Is64BitProcess ? "x64" : "x86";
 #endif
+
+            // This is a temporary workaround until we pass a struct with OS information from native code
+            if (Environment.GetEnvironmentVariable(EnvironmentNames.DnxIsWindows) == "1")
+            {
+                _osName = "Windows";
+            }
         }
 
         public string OperatingSystem

--- a/src/dnx.mono.managed/EntryPoint.cs
+++ b/src/dnx.mono.managed/EntryPoint.cs
@@ -58,6 +58,12 @@ public class EntryPoint
         // Set the default lib path to be next to the entry point location
         Environment.SetEnvironmentVariable(EnvironmentNames.DefaultLib, Path.GetDirectoryName(typeof(EntryPoint).Assembly.Location));
         Environment.SetEnvironmentVariable(EnvironmentNames.ConsoleHost, "1");
+        
+        var p = Environment.OSVersion.Platform;
+        if (p != PlatformID.MacOSX && p != PlatformID.Unix)
+        {
+            Environment.SetEnvironmentVariable(EnvironmentNames.DnxIsWindows, "1");
+        }
 
         arguments = ExpandCommandLineArguments(arguments);
 

--- a/src/dnx/dnx.cpp
+++ b/src/dnx/dnx.cpp
@@ -281,6 +281,7 @@ int CallApplicationProcessMain(int argc, dnx::char_t* argv[], dnx::trace_writer&
         _X("dnx.coreclr.so");
 #else
         _X("dnx.clr.dll");
+        SetEnvironmentVariable(_X("DNX_IS_WINDOWS"), _X("1"));
 #endif
 
         // Note: need to keep as ASCII as GetProcAddress function takes ASCII params


### PR DESCRIPTION
Prevents us from having first-chance exception when checking for OS on Windows.
#2265
@davidfowl @moozzyk 