### PR TITLE
Add a more descriptive message when wildcard is used in literal search pattern

### DIFF
--- a/src/Microsoft.Framework.Runtime/PatternGroup.cs
+++ b/src/Microsoft.Framework.Runtime/PatternGroup.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Framework.Runtime
                                                           .Concat(additionalExcluding)
                                                           .Distinct();
 
-            var includeLiterals = PatternsCollectionHelper.GetPatternsCollection(rawProject, projectDirectory, projectFilePath, propertyName: name + "Files")
+            var includeLiterals = PatternsCollectionHelper.GetPatternsCollection(rawProject, projectDirectory, projectFilePath, propertyName: name + "Files", literalPath: true)
                                                           .Distinct();
 
             return new PatternGroup(includePatterns, excludePatterns, includeLiterals);

--- a/test/Microsoft.Framework.Runtime.FunctionalTests/ProjectFileGlobbing/ProjectFilesCollectionTests.cs
+++ b/test/Microsoft.Framework.Runtime.FunctionalTests/ProjectFileGlobbing/ProjectFilesCollectionTests.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Framework.Runtime.FunctionalTests.ProjectFileGlobbing
                 CreateFilesCollection(projectJsonContent, @"src\project");
             });
 
-            Assert.True(exception.Message.Contains(absolutePath));
+            Assert.Equal(exception.Message, "The 'compile' property cannot be a rooted path.");
         }
 
         [Fact]

--- a/test/Microsoft.Framework.Runtime.Tests/FileGlobbing/ProjectFilesCollectionFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/FileGlobbing/ProjectFilesCollectionFacts.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Framework.Runtime.Tests.FileGlobbing
              ""compileFiles"": ""signle.cs"",
              ""shared"": ""shared/**/*.cs"",
              ""sharedExclude"": ""excludeShared*.cs"",
-             ""sharedFiles"": ""**/*.cs"",
+             ""sharedFiles"": ""shared.cs"",
              ""contentBuiltIn"": """",
              ""content"": ""**/*.content"",
              ""contentExclude"": ""excludecontent"",
@@ -109,6 +109,22 @@ namespace Microsoft.Framework.Runtime.Tests.FileGlobbing
 
             var target = new ProjectFilesCollection(rawProject, string.Empty, string.Empty);
             Assert.Equal(NormalizePatterns("*.cs", "../*.cs", "**/*.cpp", "**/*.h"), target.CompilePatternsGroup.IncludePatterns);
+        }
+
+
+        [Fact]
+        public void ExceptionThrowWhenWildcardPresentsInLiteralPath()
+        {
+            var rawProject = Deserialize(@"{""compileFiles"": ""*.cs""}");
+
+            var exception = Assert.Throws<FileFormatException>(() =>
+            {
+                var target = new ProjectFilesCollection(rawProject, string.Empty, string.Empty);
+            });
+
+            Assert.Equal(
+                "The 'compileFiles' property cannot contain wildcard characters.",
+                exception.InnerException.Message);
         }
 
         private JsonObject Deserialize(string content)


### PR DESCRIPTION
Addressing #1548 

![image](https://cloud.githubusercontent.com/assets/1329240/8837630/204064b6-307c-11e5-9da2-55dd293e57cb.png)
