### PR TITLE
fix #1150 by checking for http URLs manually

### DIFF
--- a/test/Microsoft.Framework.PackageManager.Tests/PackageSourceUtilsFacts.cs
+++ b/test/Microsoft.Framework.PackageManager.Tests/PackageSourceUtilsFacts.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.PackageManager;
+using NuGet;
+using Xunit;
+
+namespace Microsoft.Dnx.Tooling.Tests
+{
+    public class PackageSourceUtilsFacts
+    {
+        [Theory]
+        [InlineData(@"C:\\foo\\bar", true)]
+        [InlineData(@".\foo\bar", true)]
+        [InlineData(@"foo\bar", true)]
+        [InlineData(@"/var/NuGet/packages", true)]
+        [InlineData(@"foo/bar", true)]
+        [InlineData(@"\\file\share", true)]
+        [InlineData(@"http://www.nuget.org", false)]
+        [InlineData(@"https://www.nuget.org", false)]
+        public void IsLocalFileSystem_CorrectlyIdentifiesIfStringIsLocalFileSystemPath(string path, bool isFileSystem)
+        {
+            Assert.Equal(isFileSystem, new PackageSource(path).IsLocalFileSystem());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1150 

I've never heard of a NuGet Feed source that wasn't an HTTP url so a simple starts-with check should be all we need :).

/cc @ChengTian @troydai 