### PR TITLE
:lipstick: Move GetProject to a helper class

### DIFF
--- a/src/Microsoft.Dnx.Runtime/Internal/ProjectUtilities.cs
+++ b/src/Microsoft.Dnx.Runtime/Internal/ProjectUtilities.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Dnx.Runtime.Internal
+{
+    public class ProjectUtilities
+    {
+        /// <summary>
+        /// Create project from a project.json in string
+        /// </summary>
+        public static Project GetProject(string json,
+                                         string projectName,
+                                         string projectPath,
+                                         ICollection<DiagnosticMessage> diagnostics = null)
+        {
+            var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var project = Project.GetProjectFromStream(ms, projectName, projectPath, diagnostics);
+
+            return project;
+        }
+    }
+}

--- a/src/Microsoft.Dnx.Runtime/Project.cs
+++ b/src/Microsoft.Dnx.Runtime/Project.cs
@@ -154,15 +154,6 @@ namespace Microsoft.Dnx.Runtime
             return true;
         }
 
-        public static Project GetProject(string json, string projectName, string projectPath, ICollection<DiagnosticMessage> diagnostics = null)
-        {
-            var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
-
-            var project = GetProjectFromStream(ms, projectName, projectPath, diagnostics);
-
-            return project;
-        }
-
         internal static Project GetProjectFromStream(Stream stream, string projectName, string projectPath, ICollection<DiagnosticMessage> diagnostics = null)
         {
             var project = new Project();
@@ -305,7 +296,7 @@ namespace Microsoft.Dnx.Runtime
                 project.Repository = repository
                     .Keys
                     .ToDictionary(
-                        key => key, 
+                        key => key,
                         key => repository.ValueAsString(key).Value);
             }
 

--- a/test/Microsoft.Dnx.Compilation.CSharp.Tests/ProjectExtensionsFacts.cs
+++ b/test/Microsoft.Dnx.Compilation.CSharp.Tests/ProjectExtensionsFacts.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Helpers;
+using Microsoft.Dnx.Runtime.Internal;
 using Xunit;
 
 namespace Microsoft.Dnx.Compilation.CSharp.Tests
@@ -15,7 +16,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         [Fact]
         public void DefaultDesktopCompilationSettings()
         {
-            var project = Project.GetProject(
+            var project = ProjectUtilities.GetProject(
 @"{
 
 }",
@@ -39,7 +40,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         [Fact]
         public void ChangingLanguageVersionIsEffective()
         {
-            var project = Project.GetProject(
+            var project = ProjectUtilities.GetProject(
 @"{
     ""compilationOptions"": { ""languageVersion"" : ""CSharp3"" }
 }",
@@ -56,7 +57,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         [InlineData("k10", "DEBUG,TRACE")]
         public void DefaultDefines(string shortName, string define)
         {
-            var project = Project.GetProject(
+            var project = ProjectUtilities.GetProject(
 @"{
 
 }",
@@ -74,7 +75,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         [Fact]
         public void DefinesFromTopLevelAreCombinedWithFrameworkSpecific()
         {
-            var project = Project.GetProject(
+            var project = ProjectUtilities.GetProject(
 @"{
     ""compilationOptions"": { ""define"": [""X""] },
     ""frameworks"": {
@@ -95,7 +96,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         [Fact]
         public void CompilerOptionsAreSetPerConfiguration()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""frameworks"" : {
         ""net45"":  {
@@ -125,7 +126,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         [Fact]
         public void CompilerOptionsForNonExistantConfigurationReturnsDefaults()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""frameworks"" : {
         ""net45"":  {
@@ -150,7 +151,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         [Fact]
         public void CompilerOptionsForExistantConfigurationReturnsTopLevelIfNotSpecified()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""compilationOptions"": { ""allowUnsafe"": true },
     ""frameworks"" : {

--- a/test/Microsoft.Dnx.Runtime.FunctionalTests/ProjectFileGlobbing/ProjectFilesTests.cs
+++ b/test/Microsoft.Dnx.Runtime.FunctionalTests/ProjectFileGlobbing/ProjectFilesTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using Microsoft.Dnx.Runtime.FunctionalTests.Utilities;
+using Microsoft.Dnx.Runtime.Internal;
 
 namespace Microsoft.Dnx.Runtime.FunctionalTests.ProjectFileGlobbing
 {
@@ -10,7 +11,7 @@ namespace Microsoft.Dnx.Runtime.FunctionalTests.ProjectFileGlobbing
     {
         protected override ProjectFilesCollection CreateFilesCollection(string jsonContent, string projectDir)
         {
-            var project = Project.GetProject(
+            var project = ProjectUtilities.GetProject(
                 jsonContent,
                 "testproject",
                 Path.Combine(Root.DirPath, PathHelper.NormalizeSeparator(projectDir), "project.json"));

--- a/test/Microsoft.Dnx.Runtime.FunctionalTests/ResourcesTests/ResourceResolverFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.FunctionalTests/ResourcesTests/ResourceResolverFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using Microsoft.Dnx.Runtime.Internal;
 using Xunit;
 
 namespace Microsoft.Dnx.Runtime.FunctionalTests.ResourcesTests
@@ -56,20 +57,20 @@ namespace Microsoft.Dnx.Runtime.FunctionalTests.ResourcesTests
             var rootDir = ProjectResolver.ResolveRootDirectory(Directory.GetCurrentDirectory());
             var testProjectFolder = Path.Combine(rootDir, "misc", "ResourcesTestProjects", "testproject");
 
-            Project project = Project.GetProject(@"
+            Project project = ProjectUtilities.GetProject(@"
 {
     ""namedResource"": {
         ""renamedResource"": ""subfolder/nestedresource.resx""
     }
-}", 
-                "testproject", 
+}",
+                "testproject",
                 Path.Combine(testProjectFolder, "project.json"));
 
             var resolver = new ResxResourceProvider();
             var embeddedResource = resolver.GetResources(project);
 
             Assert.Equal("testproject.OwnResources.resources", embeddedResource[0].Name);
-            
+
             // This resource should get a new name instead of "testproject.subfolder.nestedresource.resources"
             Assert.Equal("renamedResource.resources", embeddedResource[1].Name);
         }
@@ -86,7 +87,7 @@ namespace Microsoft.Dnx.Runtime.FunctionalTests.ResourcesTests
             var rootDir = ProjectResolver.ResolveRootDirectory(Directory.GetCurrentDirectory());
             var testProjectFolder = Path.Combine(rootDir, "misc", "ResourcesTestProjects", "testproject");
 
-            Project project = Project.GetProject(@"
+            Project project = ProjectUtilities.GetProject(@"
 {
     ""namedResource"": {
         ""thisIs.New.Resource"": ""../someresources/OtherResources.resx""

--- a/test/Microsoft.Dnx.Runtime.Tests/ProjectExtensionsFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/ProjectExtensionsFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Dnx.Runtime.Helpers;
+using Microsoft.Dnx.Runtime.Internal;
 using Xunit;
 
 namespace Microsoft.Dnx.Runtime.Tests
@@ -28,7 +29,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void GetCompilerOptionsIgnoresTargetFrameworkAndConfigurationIfNull()
         {
             // Arrange
-            var project = Project.GetProject(_projectContent, "TestProj", "project.json");
+            var project = ProjectUtilities.GetProject(_projectContent, "TestProj", "project.json");
 
             // Act
             var options = project.GetCompilerOptions(targetFramework: null, configurationName: null);
@@ -44,7 +45,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void GetCompilerOptionsCombinesTargetFrameworkIfNotNull()
         {
             // Arrange
-            var project = Project.GetProject(_projectContent, "TestProj", "project.json");
+            var project = ProjectUtilities.GetProject(_projectContent, "TestProj", "project.json");
             var targetFramework = FrameworkNameHelper.ParseFrameworkName("dnx451");
 
             // Act
@@ -61,7 +62,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void GetCompilerOptionsCombinesConfigurationAndTargetFrameworkfNotNull()
         {
             // Arrange
-            var project = Project.GetProject(_projectContent, "TestProj", "project.json");
+            var project = ProjectUtilities.GetProject(_projectContent, "TestProj", "project.json");
             var targetFramework = FrameworkNameHelper.ParseFrameworkName("dnxcore50");
 
             // Act

--- a/test/Microsoft.Dnx.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/ProjectFacts.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Dnx.Runtime.Helpers;
+using Microsoft.Dnx.Runtime.Internal;
 using NuGet;
 using Xunit;
 
@@ -24,7 +25,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void VersionIsSet()
         {
-            var project = Project.GetProject(@"{ ""version"": ""1.2.3"" }", @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(@"{ ""version"": ""1.2.3"" }", @"foo", @"C:\Foo\Project.json");
 
             Assert.Equal(new SemanticVersion("1.2.3"), project.Version);
         }
@@ -32,7 +33,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void AuthorsAreSet()
         {
-            var project = Project.GetProject(@"{ ""authors"": [""Bob"", ""Dean""] }", @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(@"{ ""authors"": [""Bob"", ""Dean""] }", @"foo", @"C:\Foo\Project.json");
 
             Assert.Equal("Bob", project.Authors[0]);
             Assert.Equal("Dean", project.Authors[1]);
@@ -41,7 +42,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void OwnersAreSet()
         {
-            var project = Project.GetProject(@"{ ""owners"": [""Alice"", ""Chi""] }", @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(@"{ ""owners"": [""Alice"", ""Chi""] }", @"foo", @"C:\Foo\Project.json");
 
             Assert.Equal("Alice", project.Owners[0]);
             Assert.Equal("Chi", project.Owners[1]);
@@ -64,7 +65,7 @@ namespace Microsoft.Dnx.Runtime.Tests
 
             var expectValue = string.Format("this is a fake {0} at {1}", jsonPropertyName, DateTime.Now.Ticks);
             var projectContent = string.Format("{{ \"{0}\": \"{1}\" }}", jsonPropertyName, expectValue);
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
 
             var propertyValue = (string)propertyInfo.GetValue(project);
             Assert.Equal(expectValue, propertyValue);
@@ -98,7 +99,7 @@ namespace Microsoft.Dnx.Runtime.Tests
                 projectContent = @"{}";
             }
 
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
 
             var propertyValue = (bool)propertyInfo.GetValue(project);
             Assert.Equal(expectResult, propertyValue);
@@ -108,7 +109,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void CompilerServicesIsNullByDefault()
         {
             var projectContent = @"{}";
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
             Assert.Null(project.CompilerServices);
         }
 
@@ -116,7 +117,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void CompilerServicesDefaultValues()
         {
             var projectContent = @"{""compiler"": {} }";
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
 
             Assert.NotNull(project.CompilerServices);
             Assert.Equal("C#", project.CompilerServices.Name);
@@ -135,7 +136,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         ""compilerType"": ""Zulu.Compilation.Compiler""
     }
 }";
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
 
             Assert.NotNull(project.CompilerServices);
             Assert.Equal("Zulu#", project.CompilerServices.Name);
@@ -147,7 +148,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void CommandsSetIsEmptyByDefault()
         {
             var projectContent = @"{}";
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
             Assert.NotNull(project.Commands);
             Assert.Equal(0, project.Commands.Count);
         }
@@ -163,7 +164,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         ""cmd3"": ""cmd3value""
     }
 }";
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
             Assert.NotNull(project.Commands);
             Assert.Equal(3, project.Commands.Count);
         }
@@ -172,7 +173,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void ScriptsSetIsEmptyByDefault()
         {
             var projectContent = @"{}";
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
             Assert.NotNull(project.Scripts);
             Assert.Equal(0, project.Scripts.Count);
         }
@@ -191,7 +192,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         ]
     }
 }";
-            var project = Project.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
+            var project = ProjectUtilities.GetProject(projectContent, @"foo", @"C:\Foo\Project.json");
 
             Assert.NotNull(project.Scripts);
             Assert.Equal(2, project.Scripts.Count);
@@ -211,7 +212,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         public void NameIsIgnoredIsSpecified()
         {
             // Arrange & Act
-            var project = Project.GetProject(@"{ ""name"": ""hello"" }", @"foo", @"c:\foo\project.json");
+            var project = ProjectUtilities.GetProject(@"{ ""name"": ""hello"" }", @"foo", @"c:\foo\project.json");
 
             // Assert
             Assert.Equal("foo", project.Name);
@@ -220,7 +221,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void GetProjectNormalizesPaths()
         {
-            var project = Project.GetProject(@"{}", "name", "../../foo");
+            var project = ProjectUtilities.GetProject(@"{}", "name", "../../foo");
 
             Assert.True(Path.IsPathRooted(project.ProjectFilePath));
         }
@@ -228,7 +229,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void CommandsAreSet()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""commands"": { ""web"": ""Microsoft.AspNet.Hosting something"" }
 }",
@@ -244,7 +245,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void DependenciesAreSet()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""dependencies"": {  
         ""A"": """",
@@ -288,7 +289,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void DependenciesAreSetPerTargetFramework()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""frameworks"": {
         ""net45"": {
@@ -328,7 +329,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void FrameworkAssembliesAreSet()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""frameworks"": {
         ""net45"": {
@@ -371,7 +372,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void CompilerOptionsAreSet()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""compilationOptions"": { ""allowUnsafe"": true, ""define"": [""X"", ""y""], ""platform"": ""x86"", ""warningsAsErrors"": true, ""optimize"": true, ""keyFile"" : ""c:\\keyfile.snk"", ""delaySign"" : true, ""strongName"" : true }
 }",
@@ -393,7 +394,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void CompilerOptionsAreNotNullIfNotSpecified()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {}",
 "foo",
 @"c:\foo\project.json");
@@ -406,7 +407,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void CompilerOptionsAreSetPerConfiguration()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""frameworks"" : {
         ""net45"":  {
@@ -455,7 +456,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void ProjectUrlIsSet()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""projectUrl"": ""https://github.com/aspnet/KRuntime""
 }",
@@ -468,7 +469,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void TagsAreSet()
         {
-            var project = Project.GetProject(@"
+            var project = ProjectUtilities.GetProject(@"
 {
     ""tags"": [""awesome"", ""fantastic"", ""aspnet""]
 }",
@@ -485,7 +486,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         [Fact]
         public void EmptyTagsListWhenNotSpecified()
         {
-            var project = Project.GetProject(@" { }", "foo", @"c:\foo\project.json");
+            var project = ProjectUtilities.GetProject(@" { }", "foo", @"c:\foo\project.json");
 
             Assert.NotNull(project.Tags);
             Assert.Equal(0, project.Tags.Count());

--- a/test/Microsoft.Dnx.Tooling.Tests/InstallBuilderFacts.cs
+++ b/test/Microsoft.Dnx.Tooling.Tests/InstallBuilderFacts.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Dnx.Runtime.Internal;
 using Xunit;
 
 namespace Microsoft.Dnx.Tooling.Tests
@@ -12,7 +13,7 @@ namespace Microsoft.Dnx.Tooling.Tests
         [Fact]
         public void NoCommandsIsNonApplicationPackage()
         {
-            var project = Runtime.Project.GetProject(@"{ }", @"foo", @"c:\foo\project.json");
+            var project = ProjectUtilities.GetProject(@"{ }", @"foo", @"c:\foo\project.json");
             var builder = new InstallBuilder(project, null, null);
             Assert.False(builder.IsApplicationPackage);
         }
@@ -20,7 +21,7 @@ namespace Microsoft.Dnx.Tooling.Tests
         [Fact]
         public void ProjectWithCommandsIsApplicationPackage()
         {
-            var project = Runtime.Project.GetProject(@"{ ""commands"" : { ""demo"":""demo"" } }", @"foo", @"c:\foo\project.json");
+            var project = ProjectUtilities.GetProject(@"{ ""commands"" : { ""demo"":""demo"" } }", @"foo", @"c:\foo\project.json");
             var builder = new InstallBuilder(project, null, null);
             Assert.True(builder.IsApplicationPackage);
         }
@@ -28,7 +29,7 @@ namespace Microsoft.Dnx.Tooling.Tests
         [Fact]
         public void BuildSucceedsForNonApplicationPackage()
         {
-            var project = Runtime.Project.GetProject(@"{ }", @"foo", @"c:\foo\project.json");
+            var project = ProjectUtilities.GetProject(@"{ }", @"foo", @"c:\foo\project.json");
             var builder = new InstallBuilder(project, null, null);
             Assert.True(builder.Build(@"c:\foo"));
         }
@@ -36,7 +37,7 @@ namespace Microsoft.Dnx.Tooling.Tests
         [Fact]
         public void NotAllowedCommandNamesAreReportedAndTheBuildFails()
         {
-            var project = Runtime.Project.GetProject(@"{ ""commands"" : { ""dnx"":""demo"" } }", @"foo", @"c:\foo\project.json");
+            var project = ProjectUtilities.GetProject(@"{ ""commands"" : { ""dnx"":""demo"" } }", @"foo", @"c:\foo\project.json");
 
             var errorReport = new MockReport();
             var builder = new InstallBuilder(


### PR DESCRIPTION
The original Project.GetProject is used by tests only. Moving it to a helper class help to reduce the size of project.cs and improve the readability.