### PR TITLE
Remove duplicated build errors

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Building/BuildContext.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/BuildContext.cs
@@ -66,9 +66,6 @@ namespace Microsoft.Dnx.Tooling
                 diagnostics.AddRange(result.Diagnostics);
             }
 
-            var errors = _applicationHostContext.DependencyWalker.GetDependencyDiagnostics(_project.ProjectFilePath);
-            diagnostics.AddRange(errors);
-
             return result.Success && !diagnostics.HasErrors();
         }
 


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/2351

@davidfowl 

The diagnostics returned by `_applicationHostContext.DependencyWalker.GetDependencyDiagnostics(_project.ProjectFilePath)` is a subset of
`_applicationHostContext.GetAllDiagnostics()`, which is already added here: https://github.com/aspnet/dnx/blob/1b0f5975777093e267f2d45d3bf5149d1bed5155/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs#L62