### PR TITLE
Fix issue where TargetPackagesFolder not being set correctly

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Install/InstallGlobalCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/Install/InstallGlobalCommand.cs
@@ -61,10 +61,7 @@ namespace Microsoft.Dnx.Tooling
             // 1. Get the package without dependencies. We cannot resolve them now because
             // we don't know the target frameworks that the package supports
 
-            if (string.IsNullOrEmpty(FeedOptions.TargetPackagesFolder))
-            {
-                FeedOptions.TargetPackagesFolder = _commandsRepository.PackagesRoot.Root;
-            }
+            FeedOptions.TargetPackagesFolder = _commandsRepository.PackagesRoot.Root;
 
             var temporaryProjectFileFullPath = CreateTemporaryProject(FeedOptions.TargetPackagesFolder, packageId, packageVersion);
 


### PR DESCRIPTION
This fixes the issue where this `The specified package is not an application. The package was added but no commands were installed.` error shows up when trying to install a command from a package with specifying the target folder with `--packages` switch.

cc' @victorhurdugaci @BrennanConroy 