### PR TITLE
Ensuring readability of servicing index

### DIFF
--- a/src/dnx.common/include/utils.h
+++ b/src/dnx.common/include/utils.h
@@ -18,6 +18,7 @@ namespace dnx
 
         dnx::xstring_t path_combine(const dnx::xstring_t& path1, const dnx::xstring_t& path2);
         bool file_exists(const dnx::xstring_t& path);
+        bool directory_exists(const dnx::xstring_t& path);
         dnx::xstring_t remove_file_from_path(const dnx::xstring_t& path);
     }
 }

--- a/src/dnx.common/utils.cpp
+++ b/src/dnx.common/utils.cpp
@@ -92,6 +92,13 @@ namespace dnx
 
             return attributes != INVALID_FILE_ATTRIBUTES && ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0);
         }
+
+        bool directory_exists(const xstring_t& path)
+        {
+            auto attributes = GetFileAttributes(path.c_str());
+
+            return attributes != INVALID_FILE_ATTRIBUTES && ((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
+        }
 #endif
 
         xstring_t remove_file_from_path(const xstring_t& path)

--- a/src/dnx/servicing.cpp
+++ b/src/dnx/servicing.cpp
@@ -70,7 +70,20 @@ namespace dnx
                 ? utils::path_combine(servicing_root_parent, std::wstring(L"Microsoft DNX\\Servicing"))
                 : servicing_root_parent;
 
+            if (is_default_servicing_location && !utils::directory_exists(servicing_root))
+            {
+                trace_writer.write(L"The default servicing root does not exist.", true);
+                return std::wstring{};
+            }
+
             auto servicing_manifest_path = utils::path_combine(servicing_root, std::wstring(L"index.txt"));
+
+            if (!utils::file_exists(servicing_manifest_path))
+            {
+                throw std::runtime_error(std::string("The servicing index file at: ")
+                    .append(dnx::utils::to_string(servicing_manifest_path))
+                    .append(" does not exist or is not accessible."));
+            }
 
             // index.txt is ASCII
             std::ifstream servicing_manifest;
@@ -80,23 +93,22 @@ namespace dnx
                 trace_writer.write(std::wstring(L"Found servicing index file at: ").append(servicing_manifest_path), true);
 
                 auto runtime_replacement_path = find_runtime_replacement(servicing_manifest, trace_writer);
+
+                servicing_manifest.close();
+
                 if (runtime_replacement_path.length() > 0)
                 {
                     return get_full_replacement_path(servicing_root, runtime_replacement_path);
                 }
 
                 trace_writer.write(L"No runtime redirections found.", true);
-            }
-            else
-            {
-                trace_writer.write(
-                    std::wstring(L"The servicing index file at: ")
-                    .append(servicing_manifest_path)
-                    .append(L" does not exist or could not be opened."),
-                    true);
+
+                return std::wstring{};
             }
 
-            return std::wstring{};
+            throw std::runtime_error(std::string("The servicing index file at: ")
+                .append(dnx::utils::to_string(servicing_manifest_path))
+                .append(" could not be opened."));
         }
     }
 }

--- a/src/dnx/servicing.cpp
+++ b/src/dnx/servicing.cpp
@@ -64,9 +64,9 @@ namespace dnx
 {
     namespace servicing
     {
-        std::wstring get_runtime_path(const std::wstring& servicing_root_parent, bool append_servicing_folder, dnx::trace_writer& trace_writer)
+        std::wstring get_runtime_path(const std::wstring& servicing_root_parent, bool is_default_servicing_location, dnx::trace_writer& trace_writer)
         {
-            auto servicing_root = append_servicing_folder
+            auto servicing_root = is_default_servicing_location
                 ? utils::path_combine(servicing_root_parent, std::wstring(L"Microsoft DNX\\Servicing"))
                 : servicing_root_parent;
 

--- a/src/dnx/servicing.h
+++ b/src/dnx/servicing.h
@@ -9,6 +9,6 @@ namespace dnx
 {
     namespace servicing
     {
-        std::wstring get_runtime_path(const std::wstring& servicing_root, bool append_servicing_folder, dnx::trace_writer& trace_writer);
+        std::wstring get_runtime_path(const std::wstring& servicing_root, bool is_default_servicing_location, dnx::trace_writer& trace_writer);
     }
 }


### PR DESCRIPTION
The application now will fail if:
- the %DNX_SERVICING%\index.txt cannot be open
- %PROGRAMFILES(X86)%\Microsoft DNX\Servicing exists but does not contain index.txt file