### PR TITLE
Begin consuming Roslyn 2.0.0-beta1

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,8 @@
 <configuration>
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
+    <add key="Roslyn" value="https://www.myget.org/F/roslyn-nightly" />
+    <add key="DotNetFx" value="https://www.myget.org/F/dotnet-corefx" />
     <add key="NuGet" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/makefile.shade
+++ b/makefile.shade
@@ -21,7 +21,7 @@ var NUSPEC_ROOT = '${Path.Combine(ROOT, "nuspec")}'
 var TEST_RESULTS = '${Path.Combine(ROOT, "artifacts", "TestResults")}'
 var SAMPLES_DIR = '${Path.Combine(ROOT, "samples")}'
 var FULL_VERSION = '${PRODUCT_VERSION + "-" + E("DNX_BUILD_VERSION")}'
-var CORECLR_TARGET_PATH = '${Path.Combine(BUILD_DIR2, "CoreCLR")}'
+var CORECLR_TARGET_PATH = '${Path.Combine(BUILD_DIR2, "DnxCoreCLR")}'
 var RUNTIME_NAME_PREFIX = 'dnx-'
 
 - // Runtime names
@@ -451,7 +451,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
         }
     }
 
-    nuget-install package='CoreCLR' outputDir='packages' extra='${extras}' once='CoreCLR' nugetPath='.nuget/nuget.exe' if='!Directory.Exists(CORECLR_TARGET_PATH)'
+    nuget-install package='DnxCoreCLR' outputDir='packages' extra='${extras}' once='DnxCoreCLR' nugetPath='.nuget/nuget.exe' if='!Directory.Exists(CORECLR_TARGET_PATH)'
 
     var CoreCLR_DIR='${""}'
     @{
@@ -486,7 +486,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles
         };
 
         string packagesDir = Path.Combine(Directory.GetCurrentDirectory(), "packages");
-        CoreCLR_DIR = Directory.EnumerateDirectories(packagesDir, "CoreCLR*")
+        CoreCLR_DIR = Directory.EnumerateDirectories(packagesDir, "DnxCoreCLR*")
                                 .OrderByDescending(getVersion)
                                 .First();
                                       

--- a/src/Microsoft.Dnx.Compilation.CSharp.Abstractions/project.json
+++ b/src/Microsoft.Dnx.Compilation.CSharp.Abstractions/project.json
@@ -2,7 +2,8 @@
     "version": "1.0.0-*",
     "dependencies": {
         "Microsoft.Dnx.Compilation.Abstractions": "1.0.0-*",
-        "Microsoft.CodeAnalysis.CSharp": "1.0.0-*"
+        "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta1-*",
+        "System.Reflection.Metadata": "1.1.0-alpha-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.Dnx.Compilation.CSharp.Common/project.json
+++ b/src/Microsoft.Dnx.Compilation.CSharp.Common/project.json
@@ -3,7 +3,8 @@
     "description": "ASP.NET 5 Roslyn implementation code shared with libraries performing runtime compilation.",
     "compilationOptions": { "define": [ "TRACE" ], "allowUnsafe": true, "warningsAsErrors": true },
     "dependencies": {
-        "Microsoft.CodeAnalysis.CSharp": "1.0.0-*",
+        "System.Reflection.Metadata": "1.1.0-alpha-*",
+        "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta1-*",
         "Microsoft.Dnx.Compilation.CSharp.Abstractions": "1.0.0-*",
         "Microsoft.Dnx.Runtime.Sources": { "version": "1.0.0-*", "type": "build" }
     },

--- a/src/Microsoft.Dnx.Runtime/project.json
+++ b/src/Microsoft.Dnx.Runtime/project.json
@@ -20,7 +20,8 @@
         "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*",
         "Microsoft.Dnx.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },
-        "Microsoft.CodeAnalysis.CSharp": { "version": "1.0.0-*", "type": "build" }
+        "Microsoft.CodeAnalysis.CSharp": { "version": "2.0.0-beta1-*", "type": "build" },
+        "System.Reflection.Metadata": { "version": "1.1.0-alpha-*", "type": "build"}
     },
     "frameworks": {
         "dnx451": {


### PR DESCRIPTION
/cc @pranavkm @anurse @davidfowl @Eilon 

This change contains a work around to mitigate a package flawed in Roslyn package: The System.Reflection.Metadata is directly referenced.

I won't wait for sign off so as to unblock the build. Tested locally.