### PR TITLE
Ensuring readability of servicing index

### DIFF
--- a/src/dnx.common/include/utils.h
+++ b/src/dnx.common/include/utils.h
@@ -18,6 +18,7 @@ namespace dnx
 
         dnx::xstring_t path_combine(const dnx::xstring_t& path1, const dnx::xstring_t& path2);
         bool file_exists(const dnx::xstring_t& path);
+        bool directory_exists(const dnx::xstring_t& path);
         dnx::xstring_t remove_file_from_path(const dnx::xstring_t& path);
     }
 }

--- a/src/dnx.common/utils.cpp
+++ b/src/dnx.common/utils.cpp
@@ -92,6 +92,13 @@ namespace dnx
 
             return attributes != INVALID_FILE_ATTRIBUTES && ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0);
         }
+
+        bool directory_exists(const xstring_t& path)
+        {
+            auto attributes = GetFileAttributes(path.c_str());
+
+            return attributes != INVALID_FILE_ATTRIBUTES && ((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
+        }
 #endif
 
         xstring_t remove_file_from_path(const xstring_t& path)


### PR DESCRIPTION
The application now will fail if:
- the %DNX_SERVICING%\index.txt cannot be open
- %PROGRAMFILES(X86)%\Microsoft DNX\Servicing exists but does not contain index.txt file