### PR TITLE
Add Id-property to `Project` to override NuGet package-id

### DIFF
--- a/src/Microsoft.Dnx.Runtime/Project.cs
+++ b/src/Microsoft.Dnx.Runtime/Project.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Dnx.Runtime
 
         public string Title { get; set; }
 
+        public string Id { get; private set; }
+
         public string Description { get; private set; }
 
         public string Copyright { get; set; }
@@ -210,6 +212,7 @@ namespace Microsoft.Dnx.Runtime
                 }
             }
 
+            project.Id = rawProject.ValueAsString("id");
             project.Description = rawProject.ValueAsString("description");
             project.Summary = rawProject.ValueAsString("summary");
             project.Copyright = rawProject.ValueAsString("copyright");

--- a/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Dnx.Tooling
             }
 
             builder.Description = project.Description ?? project.Name;
-            builder.Id = project.Name;
+            builder.Id = project.Id ?? project.Name;
             builder.Version = project.Version;
             builder.Title = project.Title;
             builder.Summary = project.Summary;


### PR DESCRIPTION
Previous behavior exclusively uses project name.
New behavior allows project config. to provide override via `id`-key.

Note: could not find any existing tests for validating other properties on `Project` related to `BuildManager`.