### PR TITLE
"dnu restore" sends User-Agent header

### DIFF
--- a/src/Microsoft.Dnx.Runtime.Sources/Impl/RuntimeEnvironmentHelper.cs
+++ b/src/Microsoft.Dnx.Runtime.Sources/Impl/RuntimeEnvironmentHelper.cs
@@ -29,6 +29,14 @@ namespace Microsoft.Dnx.Runtime
             return environment;
         }
 
+        public static IRuntimeEnvironment RuntimeEnvironment
+        {
+            get
+            {
+                return _runtimeEnv.Value;
+            }
+        }
+
         public static bool IsWindows
         {
             get { return _isWindows.Value; }

--- a/src/Microsoft.Dnx.Tooling/Restore/NuGet/HttpSource.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/NuGet/HttpSource.cs
@@ -11,6 +11,7 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Internal;
 
 namespace Microsoft.Dnx.Tooling.Restore.NuGet
@@ -23,6 +24,8 @@ namespace Microsoft.Dnx.Tooling.Restore.NuGet
         private readonly string _userName;
         private readonly string _password;
         private readonly Reports _reports;
+
+        private const string UserAgentName = "Microsoft_.NET_Development_Utility";
 
         public HttpSource(
             string baseUri,
@@ -65,6 +68,10 @@ namespace Microsoft.Dnx.Tooling.Restore.NuGet
                 };
                 _client = new HttpClient(handler);
             }
+
+            var env = RuntimeEnvironmentHelper.RuntimeEnvironment;
+            var userAgentHeader = $"{UserAgentName}/{env.RuntimeVersion} ({env.OperatingSystem} {env.OperatingSystemVersion})";
+            _client.DefaultRequestHeaders.UserAgent.ParseAdd(userAgentHeader);
         }
 
         public string BaseUri


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/2417

Here is the User-Agent header being sent:
![capture1](https://cloud.githubusercontent.com/assets/1383883/9237015/46c699f2-40fd-11e5-92fc-e6abe2ab3675.PNG)

I used the header sent by nuget.exe as a reference:
![capture](https://cloud.githubusercontent.com/assets/1383883/9237030/5dbb9414-40fd-11e5-8fa0-29eaa336419b.PNG)

The agent name comes from the title of help info:
![capture](https://cloud.githubusercontent.com/assets/1383883/9237056/88b7eeec-40fd-11e5-9382-7591a7d4dc21.PNG)

Although the full name of DNU is `DNX Utility` according to our wiki: https://github.com/aspnet/Home/wiki/DNX-utility

@davidfowl @lodejard @Eilon @glennc 