### PR TITLE
Servicing:

### DIFF
--- a/build/Dnx.Native.Settings
+++ b/build/Dnx.Native.Settings
@@ -30,6 +30,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>shlwapi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
@@ -55,8 +56,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' And $(BuildForOneCore)=='True'">
     <ClCompile>
-      <!--WINAPI_FAMILY=WINAPI_FAMILY_SERVER; commented due to a bug in Windows SDK that should be fixed by VS 2015 RTM-->
-      <PreprocessorDefinitions><!--WINAPI_FAMILY=WINAPI_FAMILY_SERVER;-->%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ONECORE;WINAPI_FAMILY=WINAPI_FAMILY_SERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
@@ -66,8 +66,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' And $(BuildForOneCore)=='True'">
     <ClCompile>
-      <!--WINAPI_FAMILY=WINAPI_FAMILY_SERVER; commented due to a bug in Windows SDK that should be fixed by VS 2015 RTM-->
-      <PreprocessorDefinitions><!-- WINAPI_FAMILY=WINAPI_FAMILY_SERVER;-->%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ONECORE;WINAPI_FAMILY=WINAPI_FAMILY_SERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
@@ -89,7 +88,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
-      <PreprocessorDefinitions>ARM;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ONECORE;ARM;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>onecoreuap.lib</AdditionalDependencies>
@@ -111,7 +110,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
-      <PreprocessorDefinitions>ARM;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ONECORE;ARM;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>onecoreuap.lib</AdditionalDependencies>


### PR DESCRIPTION
- enabling retrying reading of the servicing index file in case of failures
- preventing from using network drives for custom servicing root

Bonus:
- removing a path to the requested servicing location from an exception message