### PR TITLE
Remove Roslyn feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
-    <add key="Roslyn" value="https://www.myget.org/F/roslyn-nightly" />
-    <add key="DotNetFx" value="https://www.myget.org/F/dotnet-corefx" />
     <add key="NuGet" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Since we have these packages on vnext feed now.