### PR TITLE
Reuse hash from .nupkg.sha512 files

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Packages/Add/AddCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/Packages/Add/AddCommand.cs
@@ -33,7 +33,12 @@ namespace Microsoft.Dnx.Tooling.Packages
 
             using (var stream = File.OpenRead(Options.NuGetPackage))
             {
-                await NuGetPackageUtils.InstallFromStream(stream, library, LocalPackages, Reports.Quiet);
+                string packageHash = null;
+                if (File.Exists(Options.PackageHashFilePath))
+                {
+                    packageHash = File.ReadAllText(Options.PackageHashFilePath);
+                }
+                await NuGetPackageUtils.InstallFromStream(stream, library, LocalPackages, Reports.Quiet, packageHash);
             }
 
             Reports.Quiet.WriteLine(

--- a/src/Microsoft.Dnx.Tooling/Packages/Add/AddOptions.cs
+++ b/src/Microsoft.Dnx.Tooling/Packages/Add/AddOptions.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Dnx.Tooling.Packages
     public class AddOptions : PackagesOptions
     {
         public string NuGetPackage { get; set; }
+        public string PackageHashFilePath { get; set; }
     }
 }

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishPackage.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishPackage.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Dnx.Runtime;
 using NuGet;
@@ -30,6 +31,7 @@ namespace Microsoft.Dnx.Tooling.Publish
             var options = new Packages.AddOptions
             {
                 NuGetPackage = srcNupkgPath,
+                PackageHashFilePath = Path.ChangeExtension(srcNupkgPath, NuGet.Constants.HashFileExtension),
                 SourcePackages = root.TargetPackagesPath,
             };
 

--- a/src/Microsoft.Dnx.Tooling/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Dnx.Tooling/Utils/NuGetPackageUtils.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Dnx.Tooling
             Stream stream,
             LibraryIdentity library,
             string packagesDirectory,
-            IReport information)
+            IReport information,
+            string packageHash = null)
         {
             var packagePathResolver = new DefaultPackagePathResolver(packagesDirectory);
 
@@ -33,10 +34,12 @@ namespace Microsoft.Dnx.Tooling
             // processes are extracting to the same destination simultaneously
             await ConcurrencyUtilities.ExecuteWithFileLocked(targetNupkg, action: async _ =>
             {
-                string packageHash;
-                using (var sha512 = SHA512.Create())
+                if (string.IsNullOrEmpty(packageHash))
                 {
-                    packageHash = Convert.ToBase64String(sha512.ComputeHash(stream));
+                    using (var sha512 = SHA512.Create())
+                    {
+                        packageHash = Convert.ToBase64String(sha512.ComputeHash(stream));
+                    }
                 }
 
                 var actionName = "Installing";


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/2489

@davidfowl , during `dnu publish`, `SHA512.ComputeHash()` occupies 96% of time used by `packages add` subcommand:
![publish_perf](https://cloud.githubusercontent.com/assets/1383883/9286136/c1bf3456-42a2-11e5-8521-28abe6b5e05c.PNG)

We can get rid of hash computation by reading `.nupkg.sha512` file, which should be side by side with nupkg. Here is the profiler output after the change:
![publish_perf_more](https://cloud.githubusercontent.com/assets/1383883/9286146/f7bb5e4a-42a2-11e5-8e2a-58b488ba7a73.PNG)
