### PR TITLE
fix #2499 by adding ICompilationEngine to the compiler load context

### DIFF
--- a/src/Microsoft.Dnx.Compilation/CompilationEngine.cs
+++ b/src/Microsoft.Dnx.Compilation/CompilationEngine.cs
@@ -27,7 +27,11 @@ namespace Microsoft.Dnx.Compilation
             _compilerLoadContext = new Lazy<IAssemblyLoadContext>(() =>
             {
                 var factory = (IAssemblyLoadContextFactory)_context.Services.GetService(typeof(IAssemblyLoadContextFactory));
-                return factory.Create(_context.Services);
+
+                // Ensure this compilation engine is in the service provider
+                var services = new ServiceProvider(_context.Services);
+                services.Add(typeof(ICompilationEngine), this);
+                return factory.Create(services);
             });
 
             CompilationCache = compilationCache;
@@ -43,8 +47,6 @@ namespace Microsoft.Dnx.Compilation
         public CompilationCache CompilationCache { get; }
 
         public ILibraryExporter RootLibraryExporter { get; }
-
-        public event Action<string> OnInputFileChanged;
 
         public Assembly LoadProject(Project project, string aspect, IAssemblyLoadContext loadContext)
         {


### PR DESCRIPTION
It's not a perfect fix, but it will do for beta7 IMHO, especially given the refactoring planned for this area post-beta7.

/cc @davidfowl 

Fixes #2499 

I'll probably be actually merging this into `release` (once @pranavkm has finished branching) but the review would be identical.