### PR TITLE
Use async xcopy to do package installation during publish

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Publish/PublishPackage.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishPackage.cs
@@ -25,21 +25,16 @@ namespace Microsoft.Dnx.Tooling.Publish
         {
             root.Reports.Quiet.WriteLine("Using {0} dependency {1}", _package.Type, Library);
 
-            var packagePathResolver = new DefaultPackagePathResolver(root.SourcePackagesPath);
-            var srcNupkgPath = packagePathResolver.GetPackageFilePath(_package.Identity.Name, _package.Identity.Version);
+            var srcPackagePathResolver = new DefaultPackagePathResolver(root.SourcePackagesPath);
+            var targetPackagePathResolver = new DefaultPackagePathResolver(root.TargetPackagesPath);
+            var srcPackageDir = srcPackagePathResolver.GetInstallPath(
+                _package.Identity.Name,
+                _package.Identity.Version);
+            var targetPackageDir = targetPackagePathResolver.GetInstallPath(
+                _package.Identity.Name,
+                _package.Identity.Version);
 
-            var options = new Packages.AddOptions
-            {
-                NuGetPackage = srcNupkgPath,
-                PackageHash = _package.Library.Sha512,
-                SourcePackages = root.TargetPackagesPath,
-            };
-
-            // Mute "packages add" subcommand
-            options.Reports = Reports.Constants.NullReports;
-
-            var packagesAddCommand = new Packages.AddCommand(options);
-            await packagesAddCommand.Execute();
+            await Task.Run(() => root.Operations.Copy(srcPackageDir, targetPackageDir));
         }
     }
 }


### PR DESCRIPTION
parent https://github.com/aspnet/dnx/issues/2489

Following @davidfowl 's suggestion and using xcopy instead of extracting from nupkgs.

It makes publishing a starter app 2 sec faster than current dev branch. The current time needed for publishing is around 5 sec.