### PR TITLE
Use the correct target framework when resolving project references

### DIFF
--- a/src/Microsoft.Dnx.Compilation/CompilationEngine.cs
+++ b/src/Microsoft.Dnx.Compilation/CompilationEngine.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Dnx.Compilation
 
             var loadContext = new RuntimeLoadContext(runtimeLibraryManager, this, _context.DefaultLoadContext);
 
-            return new LibraryExporter(libraryManager, loadContext, this, targetFramework, configuration);
+            return new LibraryExporter(libraryManager, loadContext, this, configuration);
         }
 
         public IProjectCompiler GetCompiler(TypeInformation provider, IAssemblyLoadContext loadContext)

--- a/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Dnx.Runtime
 
             dependencyWalker.Walk(context.Project.Name, context.Project.Version, context.TargetFramework);
 
-            context.LibraryManager = new LibraryManager(context.Project.ProjectFilePath, dependencyWalker.Libraries);
+            context.LibraryManager = new LibraryManager(context.Project.ProjectFilePath, context.TargetFramework, dependencyWalker.Libraries);
 
             if (!validLockFile)
             {

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/LibraryManager.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/LibraryManager.cs
@@ -23,10 +23,12 @@ namespace Microsoft.Dnx.Runtime
         private Dictionary<string, Tuple<Library, LibraryDescription>> _graph;
         private bool _initialized;
         private readonly string _projectPath;
+        private readonly FrameworkName _targetFramework;
 
-        public LibraryManager(string projectPath, IList<LibraryDescription> libraries)
+        public LibraryManager(string projectPath, FrameworkName targetFramework, IList<LibraryDescription> libraries)
         {
             _projectPath = projectPath;
+            _targetFramework = targetFramework;
             _libraries = libraries;
         }
 

--- a/test/Microsoft.Dnx.Runtime.Tests/LibraryManagerFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/LibraryManagerFacts.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Dnx.Runtime.Tests
                 CreateRuntimeLibrary("Config", Enumerable.Empty<String>()),
                 CreateRuntimeLibrary("MyApp", new[] { "DI", "Hosting", "Mvc", "HttpAbstractions" })
             };
-            return new LibraryManager("/foo/project.json", libraryInfo);
+            return new LibraryManager("/foo/project.json", frameworkName, libraryInfo);
         }
 
         private static LibraryDescription CreateRuntimeLibrary(string name, IEnumerable<string> dependencies)


### PR DESCRIPTION
- Don't store the target framework when creating the library exporter
- Store the target framework for the LibraryManager so that it's easy to
see the context for the library manager in the debugger.

