### PR TITLE
Cross-process sync utils fall back to process-local on cross-plat CoreCLR

### DIFF
--- a/src/Microsoft.Dnx.Runtime/Internal/ConcurrencyUtilities.cs
+++ b/src/Microsoft.Dnx.Runtime/Internal/ConcurrencyUtilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,35 +36,127 @@ namespace Microsoft.Dnx.Runtime.Internal
             while (!completed)
             {
                 var createdNew = false;
-                var fileLock = new Semaphore(initialCount: 0, maximumCount: 1, name: FilePathToLockName(filePath),
-                    createdNew: out createdNew);
-                try
+                using (var fileLock = SemaphoreWrapper.Create(initialCount: 0, maximumCount: 1, name: FilePathToLockName(filePath),
+                    createdNew: out createdNew))
                 {
-                    // If this lock is already acquired by another process, wait until we can acquire it
-                    if (!createdNew)
+                    try
                     {
-                        var signaled = fileLock.WaitOne(TimeSpan.FromSeconds(5));
-                        if (!signaled)
+                        // If this lock is already acquired by another process, wait until we can acquire it
+                        if (!createdNew)
                         {
-                            // Timeout and retry
-                            continue;
+                            var signaled = fileLock.WaitOne(TimeSpan.FromSeconds(5));
+                            if (!signaled)
+                            {
+                                // Timeout and retry
+                                continue;
+                            }
                         }
-                    }
 
-                    completed = true;
-                    return await action(createdNew);
-                }
-                finally
-                {
-                    if (completed)
+                        completed = true;
+                        return await action(createdNew);
+                    }
+                    finally
                     {
-                        fileLock.Release();
+                        if (completed)
+                        {
+                            fileLock.Release();
+                        }
                     }
                 }
             }
 
             // should never get here
             throw new TaskCanceledException($"Failed to acquire semaphore for file: {filePath}");
+        }
+
+        private class SemaphoreWrapper : IDisposable
+        {
+#if DNXCORE50
+            private static Dictionary<string, SemaphoreWrapper> _nameWrapper =
+                new Dictionary<string, SemaphoreWrapper>();
+
+            private readonly string _name;
+            private volatile int _refCount = 0;
+#endif
+
+            private readonly Semaphore _semaphore;
+
+            public static SemaphoreWrapper Create(int initialCount, int maximumCount, string name, out bool createdNew)
+            {
+#if DNXCORE50
+                if (RuntimeEnvironmentHelper.IsWindows)
+                {
+                    return new SemaphoreWrapper(new Semaphore(initialCount, maximumCount, name, out createdNew));
+                }
+                else
+                {
+                    var createdNewLocal = false;
+                    SemaphoreWrapper wrapper;
+
+                    lock (_nameWrapper)
+                    {
+                        wrapper = _nameWrapper.GetOrAdd(
+                            name,
+                            _ =>
+                            {
+                                createdNewLocal = true;
+                                return new SemaphoreWrapper(new Semaphore(initialCount, maximumCount), name);
+                            });
+                        wrapper._refCount++;
+                    }
+
+                    // C# doesn't allow assigning value to an out parameter directly in lambda expression
+                    createdNew = createdNewLocal;
+                    return wrapper;
+                }
+#else
+
+                return new SemaphoreWrapper(new Semaphore(initialCount, maximumCount, name, out createdNew));
+#endif
+            }
+
+            private SemaphoreWrapper(Semaphore semaphore, string name = null)
+            {
+                _semaphore = semaphore;
+#if DNXCORE50
+                _name = name;
+#endif
+            }
+
+            public bool WaitOne(TimeSpan timeout)
+            {
+                return _semaphore.WaitOne(timeout);
+            }
+
+            public int Release()
+            {
+                return _semaphore.Release();
+            }
+
+            public void Dispose()
+            {
+#if DNXCORE50
+                if (RuntimeEnvironmentHelper.IsWindows)
+                {
+                    _semaphore.Dispose();
+                }
+                else
+                {
+                    lock (_nameWrapper)
+                    {
+                        _refCount--;
+                        if (_refCount == 0)
+                        {
+                            _nameWrapper.Remove(_name);
+                            _semaphore.Dispose();
+                        }
+                    }
+
+                }
+#else
+                _semaphore.Dispose();
+#endif
+            }
         }
     }
 }


### PR DESCRIPTION
parent: https://github.com/aspnet/dnx/issues/2501

@davidfowl @anurse @danroth27 

Worked with @BrennanConroy on this and verified the change on cross-plat CoreCLR. This should unblock restore scenarios as long as you don't run multiple instances of `dnu restore` simultaneously.

However, we should explore the flock() option because that's a more robust solution, which provides real interprocess synchronization. We will do some experiments with flock() tomorrow and see whether we can get it in before beta7 sign-off.