### PR TITLE
Move breadcrumbing to DefaultHost

### DIFF
--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
@@ -113,11 +113,6 @@ namespace Microsoft.Dnx.Runtime
 
             package.Path = packagePath;
 
-            if (Breadcrumbs.Instance.IsPackageServiceable(package))
-            {
-                Breadcrumbs.Instance.AddBreadcrumb(package.Identity.Name, package.Identity.Version);
-            }
-
             var assemblies = new List<string>();
 
             foreach (var runtimeAssemblyPath in package.Target.RuntimeAssemblies)


### PR DESCRIPTION
- This ensures bread crumbing only happens at runtime. It removes the side effects when
we use this API to create a library manager.

#2513

/cc @troydai @victorhurdugaci 

