### PR TITLE
Update `.travis.yml` to run on OSX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: csharp
 sudo: false
+env:
+  - MONO_THREADS_PER_CPU=2000
+os:
+  - linux
+  - osx
 script:
   - ./build.sh --quiet verify

--- a/test/Microsoft.Dnx.CommonTestUtils/TestUtils.cs
+++ b/test/Microsoft.Dnx.CommonTestUtils/TestUtils.cs
@@ -30,6 +30,16 @@ namespace Microsoft.Dnx.CommonTestUtils
         {
             var tempDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(tempDirPath);
+
+            if (string.Equals(RuntimeEnvironmentHelper.RuntimeEnvironment.OperatingSystem, "Darwin"))
+            {
+                // Resolves issues on Mac where GetTempPath gives /var and GetCurrentDirectory gives /private/var
+                var currentDirectory = Directory.GetCurrentDirectory();
+                Directory.SetCurrentDirectory(tempDirPath);
+                tempDirPath = Directory.GetCurrentDirectory();
+                Directory.SetCurrentDirectory(currentDirectory);
+            }
+
             return tempDirPath;
         }
 


### PR DESCRIPTION
- Added `MONO_THREADS_PER_CPU=2000` environment variable to ensure `dnu restore` completes successfully.

**Note:** It looks like OSX is currently failing so that will need to be investigated.