### PR TITLE
Cleanup some of ApplicationHostContext and dependency management

### DIFF
--- a/src/Microsoft.Dnx.ApplicationHost/DefaultHost.cs
+++ b/src/Microsoft.Dnx.ApplicationHost/DefaultHost.cs
@@ -154,7 +154,7 @@ Please make sure the runtime matches a framework specified in {Project.ProjectFi
             var hostEnvironment = (IApplicationEnvironment)hostServices.GetService(typeof(IApplicationEnvironment));
             var applicationEnvironment = new ApplicationEnvironment(Project, _targetFramework, options.Configuration, hostEnvironment);
 
-            var compilationContext = new CompilationEngineContext(applicationEnvironment, loadContextAccessor.Default, new CompilationCache(), fileWatcher);
+            var compilationContext = new CompilationEngineContext(applicationEnvironment, loadContextAccessor.Default, new CompilationCache(), fileWatcher, new ProjectGraphProvider());
 
             // Compilation services available only for runtime compilation
             compilationContext.AddCompilationService(typeof(RuntimeOptions), options);

--- a/src/Microsoft.Dnx.Compilation/CompilationEngineContext.cs
+++ b/src/Microsoft.Dnx.Compilation/CompilationEngineContext.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Dnx.Compilation;
 using Microsoft.Dnx.Compilation.Caching;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Common.DependencyInjection;
@@ -19,8 +18,17 @@ namespace Microsoft.Dnx.Compilation
 
         public CompilationEngineContext(IApplicationEnvironment applicationEnvironment,
                                         IAssemblyLoadContext defaultLoadContext,
+                                        CompilationCache cache,
+                                        IProjectGraphProvider projectGraphProvider) :
+            this(applicationEnvironment, defaultLoadContext, cache, NoopWatcher.Instance, projectGraphProvider)
+        {
+
+        }
+
+        public CompilationEngineContext(IApplicationEnvironment applicationEnvironment,
+                                        IAssemblyLoadContext defaultLoadContext,
                                         CompilationCache cache) :
-            this(applicationEnvironment, defaultLoadContext, cache, NoopWatcher.Instance)
+            this(applicationEnvironment, defaultLoadContext, cache, NoopWatcher.Instance, new ProjectGraphProvider())
         {
 
         }
@@ -28,11 +36,12 @@ namespace Microsoft.Dnx.Compilation
         public CompilationEngineContext(IApplicationEnvironment applicationEnvironment,
                                         IAssemblyLoadContext defaultLoadContext,
                                         CompilationCache cache,
-                                        IFileWatcher fileWatcher)
+                                        IFileWatcher fileWatcher,
+                                        IProjectGraphProvider projectGraphProvider)
         {
             ApplicationEnvironment = applicationEnvironment;
             DefaultLoadContext = defaultLoadContext;
-            ProjectGraphProvider = new ProjectGraphProvider();
+            ProjectGraphProvider = projectGraphProvider;
             CompilationCache = cache;
             FileWatcher = fileWatcher;
 

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/DependencyWalker.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/DependencyWalker.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Versioning;
@@ -9,43 +8,34 @@ using NuGet;
 
 namespace Microsoft.Dnx.Runtime
 {
-    public class DependencyWalker
+    internal static class DependencyWalker
     {
-        private readonly IEnumerable<IDependencyProvider> _dependencyProviders;
-        private readonly List<LibraryDescription> _libraries = new List<LibraryDescription>();
-
-        public DependencyWalker(IEnumerable<IDependencyProvider> dependencyProviders)
+        public static IList<LibraryDescription> Walk(IList<IDependencyProvider> providers, string name, SemanticVersion version, FrameworkName targetFramework)
         {
-            _dependencyProviders = dependencyProviders;
-        }
+            var libraries = new List<LibraryDescription>();
 
-        public IList<LibraryDescription> Libraries
-        {
-            get { return _libraries; }
-        }
-
-        public void Walk(string name, SemanticVersion version, FrameworkName targetFramework)
-        {
             var sw = Stopwatch.StartNew();
-            Logger.TraceInformation("[{0}]: Walking dependency graph for '{1} {2}'.", GetType().Name, name, targetFramework);
+            Logger.TraceInformation($"[{nameof(DependencyWalker)}]: Walking dependency graph for '{name} {targetFramework}'.");
 
             var context = new WalkContext();
 
             var walkSw = Stopwatch.StartNew();
 
             context.Walk(
-                _dependencyProviders,
+                providers,
                 name,
                 version,
                 targetFramework);
 
             walkSw.Stop();
-            Logger.TraceInformation("[{0}]: Graph walk took {1}ms.", GetType().Name, walkSw.ElapsedMilliseconds);
+            Logger.TraceInformation($"[{nameof(DependencyWalker)}]: Graph walk took {walkSw.ElapsedMilliseconds}ms.");
 
-            context.Populate(targetFramework, Libraries);
+            context.Populate(targetFramework, libraries);
 
             sw.Stop();
-            Logger.TraceInformation("[{0}]: Resolved dependencies for {1} in {2}ms", GetType().Name, name, sw.ElapsedMilliseconds);
+            Logger.TraceInformation($"$[{ nameof(DependencyWalker)}]: Resolved dependencies for {name} in { sw.ElapsedMilliseconds}ms");
+
+            return libraries;
         }
     }
 }

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Dnx.Runtime
             }
         }
 
-        public void Initialize(PackageDescription package)
+        private void Initialize(PackageDescription package)
         {
             string packagePath = ResolvePackagePath(package);
 
@@ -165,7 +165,7 @@ namespace Microsoft.Dnx.Runtime
                         var assemblyName = new AssemblyName(name);
 
                         string replacementPath;
-                        if (Servicing.ServicingTable.TryGetReplacement(
+                        if (ServicingTable.TryGetReplacement(
                             library.Identity.Name,
                             library.Identity.Version,
                             assemblyPath,

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/WalkContext.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/WalkContext.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Dnx.Runtime
         private readonly IDictionary<string, Item> _usedItems = new Dictionary<string, Item>();
 
         public void Walk(
-            IEnumerable<IDependencyProvider> dependencyResolvers,
+            IList<IDependencyProvider> dependencyResolvers,
             string name,
             SemanticVersion version,
             FrameworkName frameworkName)
@@ -28,7 +28,7 @@ namespace Microsoft.Dnx.Runtime
                 }
             };
 
-            var resolvers = dependencyResolvers as IDependencyProvider[] ?? dependencyResolvers.ToArray();
+            var resolvers = dependencyResolvers;
             var resolvedItems = new Dictionary<LibraryRange, Item>();
 
             var buildTreeSw = Stopwatch.StartNew();
@@ -209,7 +209,7 @@ namespace Microsoft.Dnx.Runtime
             {
                 var library = item.Description;
                 library.Dependencies = library.Dependencies.SelectMany(CorrectDependencyVersion).ToList();
-                library.Framework = library.Framework ?? frameworkName; 
+                library.Framework = library.Framework ?? frameworkName;
                 libraries.Add(library);
             }
 


### PR DESCRIPTION
- Made DependencyWalker static and internal
- Pass project to GetAllExports and avoid walking the
graph twice for the same project
- Allow passing in a project graph provider

/cc @anurse 