### PR TITLE
[Prototype] SemanticVersion performance optimzation

### DIFF
--- a/src/Microsoft.Dnx.DesignTimeHost/Program.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/Program.cs
@@ -12,20 +12,37 @@ using Microsoft.Dnx.Compilation;
 using Microsoft.Dnx.Compilation.Caching;
 using Microsoft.Dnx.DesignTimeHost.Models;
 using Microsoft.Dnx.Runtime;
-using Microsoft.Dnx.Runtime.Common.DependencyInjection;
-using Microsoft.Dnx.Runtime.Compilation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet;
 
 namespace Microsoft.Dnx.DesignTimeHost
 {
     public class Program
     {
         private readonly IServiceProvider _services;
+        private readonly Dictionary<string, SemanticVersion> _versionsCache;
 
         public Program(IServiceProvider services)
         {
             _services = services;
+            _versionsCache = new Dictionary<string, SemanticVersion>();
+            SemanticVersion.Factory = versionInString =>
+            {
+                SemanticVersion result;
+                if (_versionsCache.TryGetValue(versionInString, out result))
+                {
+                    return result;
+                }
+                else
+                {
+                    result = SemanticVersion.Parse(versionInString);
+
+                    _versionsCache[versionInString] = result;
+
+                    return result;
+                }
+            };
         }
 
         public void Main(string[] args)
@@ -76,7 +93,7 @@ namespace Microsoft.Dnx.DesignTimeHost
             Console.WriteLine($"Process ID {Process.GetCurrentProcess().Id}");
             Console.WriteLine("Listening on port {0}", port);
 
-            for (; ;)
+            for (;;)
             {
                 var acceptSocket = await AcceptAsync(listenSocket);
 

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/LockFileReader.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/LockFileReader.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Dnx.Runtime
 
                 var parts = key.Split(new[] { '/' }, 2);
                 var name = parts[0];
-                var version = parts.Length == 2 ? SemanticVersion.Parse(parts[1]) : null;
+                var version = parts.Length == 2 ? SemanticVersion.Create(parts[1]) : null;
 
                 var type = value.ValueAsString("type")?.Value;
 
@@ -181,7 +181,7 @@ namespace Microsoft.Dnx.Runtime
             library.Name = parts[0];
             if (parts.Length == 2)
             {
-                library.Version = SemanticVersion.Parse(parts[1]);
+                library.Version = SemanticVersion.Create(parts[1]);
             }
 
             library.Type = jobject.ValueAsString("type");

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Dnx.Runtime
             {
                 return new LibraryDescription(
                     libraryRange,
-                    new LibraryIdentity(libraryRange.Name, new SemanticVersion(assemblyVersion), isGacOrFrameworkReference: true),
+                    new LibraryIdentity(libraryRange.Name, SemanticVersion.Create(assemblyVersion), isGacOrFrameworkReference: true),
                     path,
                     LibraryTypes.ReferenceAssembly,
                     Enumerable.Empty<LibraryDependency>(),

--- a/src/Microsoft.Dnx.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Dnx.Runtime/NuGet/Utility/VersionUtility.cs
@@ -364,7 +364,7 @@ namespace NuGet
 
             // First, try to parse it as a plain version string
             SemanticVersion version;
-            if (SemanticVersion.TryParse(value, out version))
+            if (SemanticVersion.TryCreate(value, out version))
             {
                 // A plain version is treated as an inclusive minimum range
                 result = new VersionSpec
@@ -466,7 +466,7 @@ namespace NuGet
             {
                 IsMinInclusive = true,
                 MinVersion = version,
-                MaxVersion = new SemanticVersion(new Version(version.Version.Major, version.Version.Minor + 1))
+                MaxVersion = SemanticVersion.Create(new Version(version.Version.Major, version.Version.Minor + 1))
             };
         }
 
@@ -729,7 +729,7 @@ namespace NuGet
                 // Find exact matching items in expansion order.
                 foreach (var activeFramework in Expand(internalProjectFramework))
                 {
-                    var matchingGroups = frameworkGroups.Where(g => 
+                    var matchingGroups = frameworkGroups.Where(g =>
                         string.Equals(g.Key?.Identifier, activeFramework.Identifier, StringComparison.OrdinalIgnoreCase) &&
                         string.Equals(g.Key?.Profile, activeFramework.Profile, StringComparison.OrdinalIgnoreCase)).ToList();
                     var bestGroup = matchingGroups
@@ -829,16 +829,16 @@ namespace NuGet
             // Trim the version so things like 1.0.0.0 end up being 1.0
             Version version = TrimVersion(semVer.Version);
 
-            yield return new SemanticVersion(version, semVer.SpecialVersion);
+            yield return SemanticVersion.Create(version, semVer.SpecialVersion);
 
             if (version.Build == -1 && version.Revision == -1)
             {
-                yield return new SemanticVersion(new Version(version.Major, version.Minor, 0), semVer.SpecialVersion);
-                yield return new SemanticVersion(new Version(version.Major, version.Minor, 0, 0), semVer.SpecialVersion);
+                yield return SemanticVersion.Create(new Version(version.Major, version.Minor, 0), semVer.SpecialVersion);
+                yield return SemanticVersion.Create(new Version(version.Major, version.Minor, 0, 0), semVer.SpecialVersion);
             }
             else if (version.Revision == -1)
             {
-                yield return new SemanticVersion(new Version(version.Major, version.Minor, version.Build, 0), semVer.SpecialVersion);
+                yield return SemanticVersion.Create(new Version(version.Major, version.Minor, version.Build, 0), semVer.SpecialVersion);
             }
         }
 
@@ -1193,13 +1193,13 @@ namespace NuGet
         private static bool TryParseVersion(string versionString, out SemanticVersion version)
         {
             version = null;
-            if (!SemanticVersion.TryParse(versionString, out version))
+            if (!SemanticVersion.TryCreate(versionString, out version))
             {
                 // Support integer version numbers (i.e. 1 -> 1.0)
                 int versionNumber;
                 if (Int32.TryParse(versionString, out versionNumber) && versionNumber > 0)
                 {
-                    version = new SemanticVersion(new Version(versionNumber, 0));
+                    version = SemanticVersion.Create(new Version(versionNumber, 0));
                 }
             }
             return version != null;
@@ -1276,9 +1276,9 @@ namespace NuGet
         internal static SemanticVersion GetAssemblyVersion(string path)
         {
 #if DNX451
-            return new SemanticVersion(AssemblyName.GetAssemblyName(path).Version);
+            return SemanticVersion.Create(AssemblyName.GetAssemblyName(path).Version);
 #else
-            return new SemanticVersion(System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(path).Version);
+            return SemanticVersion.Create(System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(path).Version);
 #endif
         }
 

--- a/src/Microsoft.Dnx.Runtime/Project.cs
+++ b/src/Microsoft.Dnx.Runtime/Project.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Dnx.Runtime
             var version = rawProject.Value("version") as JsonString;
             if (version == null)
             {
-                project.Version = new SemanticVersion("1.0.0");
+                project.Version = SemanticVersion.Create("1.0.0");
             }
             else
             {
@@ -325,7 +325,7 @@ namespace Microsoft.Dnx.Runtime
                 }
             }
 
-            return new SemanticVersion(version);
+            return SemanticVersion.Create(version);
         }
 
         private static void PopulateDependencies(

--- a/src/Microsoft.Dnx.Runtime/Servicing/ServicingIndex.cs
+++ b/src/Microsoft.Dnx.Runtime/Servicing/ServicingIndex.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Dnx.Runtime.Servicing
                             continue;
                         }
                         SemanticVersion version;
-                        if (!SemanticVersion.TryParseStrict(fields[2], out version))
+                        if (!SemanticVersion.TryParse(fields[2], strict: true, result: out version))
                         {
                             Logger.TraceInformation("[{0}]. Line {1}: malformed servicing version ", GetType().Name, lineNumber);
                             continue;

--- a/src/Microsoft.Dnx.Tooling/Commands/AddCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/Commands/AddCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Dnx.Tooling
             }
 
             // Only for version validation
-            SemanticVersion.Parse(Version);
+            SemanticVersion.Create(Version);
 
             ProjectDir = ProjectDir ?? Directory.GetCurrentDirectory();
 

--- a/src/Microsoft.Dnx.Tooling/Commands/InstallCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/Commands/InstallCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Dnx.Tooling
             SemanticVersion version = null;
             if (!string.IsNullOrEmpty(_addCommand.Version))
             {
-                version = SemanticVersion.Parse(_addCommand.Version);
+                version = SemanticVersion.Create(_addCommand.Version);
             }
 
             // Create source provider from solution settings

--- a/src/Microsoft.Dnx.Tooling/Install/AppCommandsFolderRepository.cs
+++ b/src/Microsoft.Dnx.Tooling/Install/AppCommandsFolderRepository.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Dnx.Tooling
 
                 var packageId = pathParts[2];
                 SemanticVersion packageVersion;
-                if (!SemanticVersion.TryParse(pathParts[3], out packageVersion))
+                if (!SemanticVersion.TryCreate(pathParts[3], out packageVersion))
                 {
                     continue;
                 }

--- a/src/Microsoft.Dnx.Tooling/Install/InstallGlobalCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/Install/InstallGlobalCommand.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Dnx.Tooling
 
             var packageFullPath = Path.Combine(
                 _commandsRepository.PackagesRoot.Root,
-                _commandsRepository.PathResolver.GetPackageDirectory(packageId, new SemanticVersion(packageVersion)));
+                _commandsRepository.PathResolver.GetPackageDirectory(packageId, SemanticVersion.Create(packageVersion)));
 
             if (OverwriteCommands)
             {

--- a/src/Microsoft.Dnx.Tooling/NuGet/Authoring/ManifestReader.cs
+++ b/src/Microsoft.Dnx.Tooling/NuGet/Authoring/ManifestReader.cs
@@ -73,7 +73,7 @@ namespace NuGet
                     manifestMetadata.Id = value;
                     break;
                 case "version":
-                    manifestMetadata.Version = new SemanticVersion(value);
+                    manifestMetadata.Version = SemanticVersion.Create(value);
                     break;
                 case "authors":
                     manifestMetadata.Authors = value?.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Microsoft.Dnx.Tooling/NuGet/Core/Repository/LocalPackageRepository.cs
+++ b/src/Microsoft.Dnx.Tooling/NuGet/Core/Repository/LocalPackageRepository.cs
@@ -330,7 +330,7 @@ namespace NuGet
             // When matching by pattern, we will always have a version token. Packages without versions would be matched early on by the version-less path resolver 
             // when doing an exact match.
             return name.Length > packageId.Length &&
-                   SemanticVersion.TryParse(name.Substring(packageId.Length + 1), out parsedVersion) &&
+                   SemanticVersion.TryCreate(name.Substring(packageId.Length + 1), out parsedVersion) &&
                    parsedVersion == version;
         }
 

--- a/src/Microsoft.Dnx.Tooling/Restore/LockFileFormat.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/LockFileFormat.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Dnx.Tooling
 
                 var parts = property.Key.Split(new[] { '/' }, 2);
                 var name = parts[0];
-                var version = parts.Length == 2 ? SemanticVersion.Parse(parts[1]) : null;
+                var version = parts.Length == 2 ? SemanticVersion.Create(parts[1]) : null;
 
                 var type = value["type"]?.Value<string>();
 
@@ -243,7 +243,7 @@ namespace Microsoft.Dnx.Tooling
             library.Name = parts[0];
             if (parts.Length == 2)
             {
-                library.Version = SemanticVersion.Parse(parts[1]);
+                library.Version = SemanticVersion.Create(parts[1]);
             }
 
             var type = json["type"];
@@ -513,7 +513,7 @@ namespace Microsoft.Dnx.Tooling
             {
                 throw new Exception(string.Format("TODO: lock file missing required property {0}", property));
             }
-            return SemanticVersion.Parse(valueToken.Value<string>());
+            return SemanticVersion.Create(valueToken.Value<string>());
         }
 
         private void WriteBool(JToken token, string property, bool value)

--- a/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Dnx.Tooling.Restore.NuGet
                 // Otherwise, use the value of 'title' if it exist
                 // Use the given Id as final fallback if all elements above don't exist
                 Id = idElement?.Value ?? titleElement?.Value ?? id,
-                Version = SemanticVersion.Parse(properties.Element(_xnameVersion).Value),
+                Version = SemanticVersion.Create(properties.Element(_xnameVersion).Value),
                 ContentUri = element.Element(_xnameContent).Attribute("src").Value,
                 Listed = listed
             };

--- a/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv3Feed.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv3Feed.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Dnx.Tooling.Restore.NuGet
                 // Otherwise, use the value of 'title' if it exist
                 // Use the given Id as final fallback if all elements above don't exist
                 Id = id,
-                Version = SemanticVersion.Parse(version),
+                Version = SemanticVersion.Create(version),
                 ContentUri = $"{_baseUri}{lowerInvariantId}/{lowerInvariantVersion}/{lowerInvariantId}.{lowerInvariantVersion}{Constants.PackageExtension}",
 
                 // v3 feed doesn't indicate if listed?

--- a/src/Microsoft.Dnx.Tooling/Restore/NuGet/PackageRepository.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/NuGet/PackageRepository.cs
@@ -78,7 +78,7 @@ namespace NuGet
 
                     // Get the version part and parse it
                     SemanticVersion version;
-                    if (!SemanticVersion.TryParse(versionPart, out version))
+                    if (!SemanticVersion.TryCreate(versionPart, out version))
                     {
                         continue;
                     }

--- a/test/Microsoft.Dnx.Runtime.FunctionalTests/ServiceBreadcrumbsFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.FunctionalTests/ServiceBreadcrumbsFacts.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             Assert.Empty(Directory.GetFiles(TempFolderPath));
 
             var breadcrumbs = new Servicing.Breadcrumbs(TempFolderPath);
-            breadcrumbs.AddBreadcrumb("Test", new NuGet.SemanticVersion("1.0.0"));
+            breadcrumbs.AddBreadcrumb("Test", NuGet.SemanticVersion.Create("1.0.0"));
             breadcrumbs.WriteAllBreadcrumbs();
 
             Assert.True(File.Exists(Path.Combine(TempFolderPath, "Test.1.0.0")));
@@ -46,7 +46,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             directory.SetAccessControl(security);
 
             var breadcrumbs = new Servicing.Breadcrumbs(TempFolderPath);
-            breadcrumbs.AddBreadcrumb("Test", new NuGet.SemanticVersion("1.0.0"));
+            breadcrumbs.AddBreadcrumb("Test", NuGet.SemanticVersion.Create("1.0.0"));
             breadcrumbs.WriteAllBreadcrumbs();
 
             Assert.Empty(Directory.GetFiles(TempFolderPath));
@@ -62,7 +62,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             }
 
             var breadcrumbs = new Servicing.Breadcrumbs(nonExistingBreadcrumbsFolder);
-            breadcrumbs.AddBreadcrumb("Test", new NuGet.SemanticVersion("1.0.0"));
+            breadcrumbs.AddBreadcrumb("Test", NuGet.SemanticVersion.Create("1.0.0"));
             breadcrumbs.WriteAllBreadcrumbs();
 
             Assert.False(Directory.Exists(nonExistingBreadcrumbsFolder));
@@ -74,7 +74,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             Assert.Empty(Directory.GetFiles(TempFolderPath));
 
             var breadcrumbs = new Servicing.Breadcrumbs(TempFolderPath);
-            breadcrumbs.AddBreadcrumb("Test", new NuGet.SemanticVersion("1.0.0"));
+            breadcrumbs.AddBreadcrumb("Test", NuGet.SemanticVersion.Create("1.0.0"));
 
             Assert.False(File.Exists(Path.Combine(TempFolderPath, "Test.1.0.0")));
         }

--- a/test/Microsoft.Dnx.Runtime.Tests/DependencyManagement/GacDependencyResolverFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/DependencyManagement/GacDependencyResolverFacts.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             if (found)
             {
                 Assert.NotNull(library);
-                Assert.Equal(SemanticVersion.Parse(version), library.Identity.Version);
+                Assert.Equal(SemanticVersion.Create(version), library.Identity.Version);
                 Assert.Equal(Environment.ExpandEnvironmentVariables(path), library.Path);
             }
             else

--- a/test/Microsoft.Dnx.Runtime.Tests/DependencyManagement/PackageDependencyProviderFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/DependencyManagement/PackageDependencyProviderFacts.cs
@@ -30,22 +30,22 @@ namespace Microsoft.Dnx.Runtime.Tests
                     new LockFileTargetLibrary
                     {
                         Name = "MetaPackage",
-                        Version = SemanticVersion.Parse("1.0.0"),
+                        Version = SemanticVersion.Create("1.0.0"),
                     },
                     new LockFileTargetLibrary
                     {
                         Name = "Net451LibPackage",
-                        Version = SemanticVersion.Parse("1.0.0"),
+                        Version = SemanticVersion.Create("1.0.0"),
                     },
                     new LockFileTargetLibrary
                     {
                         Name = "Net451RefPackage",
-                        Version = SemanticVersion.Parse("1.0.0"),
+                        Version = SemanticVersion.Create("1.0.0"),
                     },
                     new LockFileTargetLibrary
                     {
                         Name = "AssemblyPlaceholderPackage",
-                        Version = SemanticVersion.Parse("1.0.0"),
+                        Version = SemanticVersion.Create("1.0.0"),
                         CompileTimeAssemblies = new List<LockFileItem> { Path.Combine("ref", "net45", "_._") },
                         RuntimeAssemblies = new List<LockFileItem> { Path.Combine("lib", "net45", "_._") }
                     }
@@ -60,25 +60,25 @@ namespace Microsoft.Dnx.Runtime.Tests
                     new LockFileTargetLibrary
                     {
                         Name = "MetaPackage",
-                        Version = SemanticVersion.Parse("1.0.0")
+                        Version = SemanticVersion.Create("1.0.0")
                     },
                     new LockFileTargetLibrary
                     {
                         Name = "Net451LibPackage",
-                        Version = SemanticVersion.Parse("1.0.0"),
+                        Version = SemanticVersion.Create("1.0.0"),
                         CompileTimeAssemblies = new List<LockFileItem> { Path.Combine("lib", "net451", "Net451LibPackage.dll") },
                         RuntimeAssemblies = new List<LockFileItem> { Path.Combine("lib", "net451", "Net451LibPackage.dll") }
                     },
                     new LockFileTargetLibrary
                     {
                         Name = "Net451RefPackage",
-                        Version = SemanticVersion.Parse("1.0.0"),
+                        Version = SemanticVersion.Create("1.0.0"),
                         CompileTimeAssemblies = new List<LockFileItem> { Path.Combine("ref", "net451", "Net451LibPackage.dll") }
                     },
                     new LockFileTargetLibrary
                     {
                         Name = "AssemblyPlaceholderPackage",
-                        Version = SemanticVersion.Parse("1.0.0")
+                        Version = SemanticVersion.Create("1.0.0")
                     }
                 }
             };
@@ -86,13 +86,13 @@ namespace Microsoft.Dnx.Runtime.Tests
             var metaPackageLibrary = new LockFilePackageLibrary
             {
                 Name = "MetaPackage",
-                Version = SemanticVersion.Parse("1.0.0")
+                Version = SemanticVersion.Create("1.0.0")
             };
 
             var net451LibPackageLibrary = new LockFilePackageLibrary
             {
                 Name = "Net451LibPackage",
-                Version = SemanticVersion.Parse("1.0.0"),
+                Version = SemanticVersion.Create("1.0.0"),
                 Files = new List<string>
                 {
                     Path.Combine("lib", "net451", "Net451LibPackage.dll"),
@@ -103,7 +103,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             var net451RefPackageLibrary = new LockFilePackageLibrary
             {
                 Name = "Net451RefPackage",
-                Version = SemanticVersion.Parse("1.0.0"),
+                Version = SemanticVersion.Create("1.0.0"),
                 Files = new List<string>
                 {
                     Path.Combine("ref", "net451", "Net451LibPackage.dll")
@@ -113,7 +113,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             var assemblyPlaceholderPackageLibrary = new LockFilePackageLibrary
             {
                 Name = "AssemblyPlaceholderPackage",
-                Version = SemanticVersion.Parse("1.0.0"),
+                Version = SemanticVersion.Create("1.0.0"),
                 Files = new List<string>
                 {
                     Path.Combine("lib", "net45", "_._"),

--- a/test/Microsoft.Dnx.Runtime.Tests/LibraryManagerFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/LibraryManagerFacts.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Dnx.Runtime.Tests
 
         private static LibraryDescription CreateRuntimeLibrary(string name, IEnumerable<string> dependencies)
         {
-            var version = new SemanticVersion("1.0.0");
+            var version = SemanticVersion.Create("1.0.0");
             return new LibraryDescription(
                 new LibraryRange(name, frameworkReference: false),
                 new LibraryIdentity(name, version, isGacOrFrameworkReference: false),

--- a/test/Microsoft.Dnx.Runtime.Tests/LockFileReaderFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/LockFileReaderFacts.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             Assert.Equal(1, lockFile.Targets.Count);
             var library = lockFile.Targets[0].Libraries[0];
             Assert.Equal("WindowsAzure.ServiceBus", library.Name);
-            Assert.Equal(SemanticVersion.Parse("2.6.7"), library.Version);
+            Assert.Equal(SemanticVersion.Create("2.6.7"), library.Version);
             Assert.Equal(1, library.Dependencies.Count);
             var dependency = library.Dependencies[0];
             Assert.Equal(dependency.Id, "Microsoft.WindowsAzure.ConfigurationManager");

--- a/test/Microsoft.Dnx.Runtime.Tests/NuGet/SemanticVersionTest.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/NuGet/SemanticVersionTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using NuGet;
 using Xunit;
@@ -13,17 +14,21 @@ namespace Microsoft.Dnx.Runtime.Tests.NuGet
         {
             get
             {
-                yield return new object[] { new SemanticVersion(1, 0, 0, 0), "1.0.0" };
-                yield return new object[] { new SemanticVersion(1, 5, 0, 0), "1.5.0" };
-                yield return new object[] { new SemanticVersion(1, 5, 1, 0), "1.5.1" };
-                yield return new object[] { new SemanticVersion(1, 5, 1, 1), "1.5.1.1" };
-                yield return new object[] { new SemanticVersion("1.0"), "1.0.0" };
-                yield return new object[] { new SemanticVersion("1.0.0"), "1.0.0" };
-                yield return new object[] { new SemanticVersion("1.0.0.0"), "1.0.0" };
-                yield return new object[] { new SemanticVersion("1.0.0.2"), "1.0.0.2" };
-                yield return new object[] { new SemanticVersion("1.0.0.2-beta"), "1.0.0.2-beta" };
-                yield return new object[] { new SemanticVersion("1.0.0.0-beta"), "1.0.0-beta" };
-                yield return new object[] { new SemanticVersion("1.0.0-beta"), "1.0.0-beta" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 0, 0, 0)), "1.0.0" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 5, 0, 0)), "1.5.0" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 5, 1, 0)), "1.5.1" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 5, 1, 1)), "1.5.1.1" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 0, 0, 0), "beta"), "1.0.0-beta" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 5, 0, 0), "charli"), "1.5.0-charli" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 5, 1, 0), "delta"), "1.5.1-delta" };
+                yield return new object[] { SemanticVersion.Create(new Version(1, 5, 1, 1), "echo"), "1.5.1.1-echo" };
+                yield return new object[] { SemanticVersion.Create("1.0"), "1.0.0" };
+                yield return new object[] { SemanticVersion.Create("1.0.0"), "1.0.0" };
+                yield return new object[] { SemanticVersion.Create("1.0.0.0"), "1.0.0" };
+                yield return new object[] { SemanticVersion.Create("1.0.0.2"), "1.0.0.2" };
+                yield return new object[] { SemanticVersion.Create("1.0.0.2-beta"), "1.0.0.2-beta" };
+                yield return new object[] { SemanticVersion.Create("1.0.0.0-beta"), "1.0.0-beta" };
+                yield return new object[] { SemanticVersion.Create("1.0.0-beta"), "1.0.0-beta" };
             }
         }
 

--- a/test/Microsoft.Dnx.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/ProjectFacts.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         {
             var project = ProjectUtilities.GetProject(@"{ ""version"": ""1.2.3"" }", @"foo", @"C:\Foo\Project.json");
 
-            Assert.Equal(new SemanticVersion("1.2.3"), project.Version);
+            Assert.Equal(SemanticVersion.Create("1.2.3"), project.Version);
         }
 
         [Fact]
@@ -270,17 +270,17 @@ namespace Microsoft.Dnx.Runtime.Tests
             Assert.Equal("A", d1.Name);
             Assert.Null(d1.LibraryRange.VersionRange);
             Assert.Equal("B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
             Assert.True(d2.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
             Assert.False(d3.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
             Assert.False(d4.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("E", d5.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d5.LibraryRange.VersionRange.MinVersion);
-            Assert.Equal(SemanticVersion.Parse("1.1.0"), d5.LibraryRange.VersionRange.MaxVersion);
+            Assert.Equal(SemanticVersion.Create("1.0.0"), d5.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("1.1.0"), d5.LibraryRange.VersionRange.MaxVersion);
             Assert.False(d5.LibraryRange.VersionRange.IsMaxInclusive);
             Assert.Equal("F", d6.Name);
             Assert.Null(d6.LibraryRange.VersionRange);
@@ -316,13 +316,13 @@ namespace Microsoft.Dnx.Runtime.Tests
             Assert.Equal("A", d1.Name);
             Assert.Null(d1.LibraryRange.VersionRange);
             Assert.Equal("B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
             Assert.True(d2.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
             Assert.False(d3.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
             Assert.False(d4.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
         }
 
@@ -356,15 +356,15 @@ namespace Microsoft.Dnx.Runtime.Tests
             Assert.Null(d1.LibraryRange.VersionRange);
             Assert.True(d1.LibraryRange.IsGacOrFrameworkReference);
             Assert.Equal("fx/B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
             Assert.True(d2.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.True(d2.LibraryRange.IsGacOrFrameworkReference);
             Assert.Equal("fx/C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
             Assert.False(d3.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.True(d3.LibraryRange.IsGacOrFrameworkReference);
             Assert.Equal("fx/D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Create("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
             Assert.False(d4.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.True(d4.LibraryRange.IsGacOrFrameworkReference);
         }

--- a/test/Microsoft.Dnx.Runtime.Tests/SemanticVersionRangeFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/SemanticVersionRangeFacts.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Dnx.Runtime.Tests
         {
             var range = new SemanticVersionRange
             {
-                MinVersion = new SemanticVersion("1.0.0-beta"),
-                MaxVersion = new SemanticVersion("1.0.0-beta")
+                MinVersion = SemanticVersion.Create("1.0.0-beta"),
+                MaxVersion = SemanticVersion.Create("1.0.0-beta")
             };
 
             Assert.Equal("1.0.0-beta", range.ToString());

--- a/test/Microsoft.Dnx.Runtime.Tests/ServicingFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/ServicingFacts.cs
@@ -28,7 +28,7 @@ nupkg|NonExisting|1.0.0|lib/dnxcore50/NonExisting.dll=patches/NonExisting/1.0.0-
 
                 bool foundReplacement = index.TryGetReplacement(
                     "NonExistingPatch",
-                    new SemanticVersion("1.0.0"),
+                    SemanticVersion.Create("1.0.0"),
                     @"lib\dnxcore50\NonExistingPatch.dll",
                     out replacementPath);
 
@@ -51,7 +51,7 @@ nupkg|PatchedLib|1.0.2|lib/dnxcore50/PatchedLib.dll=patches/PatchedLib/1.0.2-pat
                 bool foundReplacement = index.TryGetReplacement(
                     "PatchedLib",
                     // The version here doesn't match any patch
-                    new SemanticVersion("1.1.0"),
+                    SemanticVersion.Create("1.1.0"),
                     @"lib\dnxcore50\PatchedLib.dll",
                     out replacementPath);
 
@@ -72,7 +72,7 @@ nupkg|PatchedLib|1.0.0|lib/dnxcore50/PatchedLib.dll=patches/PatchedLib/1.0.0-pat
 
                 bool foundReplacement = index.TryGetReplacement(
                     "PatchedLib",
-                    new SemanticVersion("1.0.0"),
+                    SemanticVersion.Create("1.0.0"),
                     @"lib\dnxcore50\PatchedLib.dll",
                     out replacementPath);
 
@@ -99,7 +99,7 @@ nupkg|PatchedLib|1.0.1|lib/dnxcore50/PatchedLib.dll=patches/PatchedLib/1.0.1-pat
 
                 bool foundReplacement = index.TryGetReplacement(
                     "PatchedLib",
-                    new SemanticVersion("1.0.0"),
+                    SemanticVersion.Create("1.0.0"),
                     @"lib\dnxcore50\PatchedLib.dll",
                     out replacementPath);
 

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuCommandsTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuCommandsTests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Dnx.Tooling.FunctionalTests
                     new LockFilePackageLibrary
                     {
                         Name = libName,
-                        Version = new SemanticVersion(version),
+                        Version = SemanticVersion.Create(version),
                         Sha512 = "TestSha"
                     }
                 }

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackagesAddTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackagesAddTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Dnx.Tooling
     public class DnuPackagesAddTests
     {
         private static readonly string ProjectName = "HelloWorld";
-        private static readonly SemanticVersion ProjectVersion = new SemanticVersion("0.1-beta");
+        private static readonly SemanticVersion ProjectVersion = SemanticVersion.Create("0.1-beta");
         private static readonly string Configuration = "Release";
         private static readonly string PackagesDirName = "packages";
         private static readonly string OutputDirName = "output";

--- a/test/Microsoft.Dnx.Tooling.Tests/NuGet/Authoring/ManifestTests.cs
+++ b/test/Microsoft.Dnx.Tooling.Tests/NuGet/Authoring/ManifestTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Dnx.Runtime.Tests.NuGet.Authoring
         public void Save()
         {
             var id = "TestId";
-            var version = new SemanticVersion("0.1.0");
+            var version = SemanticVersion.Create("0.1.0");
             var authors = new string[] { "Alice", "Bob" };
 
             var manifest = new Manifest(new ManifestMetadata


### PR DESCRIPTION
Reuse the same copy of the SemanticVersion when the given verison is same.

Example: open MVC solution and build
Before:
![image](https://cloud.githubusercontent.com/assets/1329240/9398557/24dd5c48-475d-11e5-8e34-0302030e5864.png)


After:
![image](https://cloud.githubusercontent.com/assets/1329240/9398565/42224020-475d-11e5-9739-ced12c842059.png)
