### PR TITLE
Ensure MetadataReference instances created from AssemblyMetadata include assembly path.

### DIFF
--- a/src/Microsoft.Dnx.Compilation.CSharp/RoslynCompiler.cs
+++ b/src/Microsoft.Dnx.Compilation.CSharp/RoslynCompiler.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Dnx.Compilation.CSharp
                 Environment.GetEnvironmentVariable(EnvironmentNames.BuildKeyFile) ??
                 compilationContext.Compilation.Options.CryptoKeyFile;
 
-            if(!string.IsNullOrEmpty(keyFile) && !RuntimeEnvironmentHelper.IsMono)
+            if (!string.IsNullOrEmpty(keyFile) && !RuntimeEnvironmentHelper.IsMono)
             {
 #if DNX451
                 var delaySignString = Environment.GetEnvironmentVariable(EnvironmentNames.BuildDelaySign);
@@ -441,7 +441,7 @@ namespace Microsoft.Dnx.Compilation.CSharp
                 }
             });
 
-            return metadata.GetReference();
+            return metadata.GetReference(filePath: path);
         }
 
         private class CompilationModules


### PR DESCRIPTION
This ensures we get better diagnostics:

Old:
`error CS1703: Multiple assemblies with equivalent identity have been imported: '<in-memory assembly>' and '<in-memory assembly>'. Remove one of the duplicate references.`

Fixed:
`error CS1703: Multiple assemblies with equivalent identity have been imported: 'D:\temp\DnxVersionIssues\packages\System.Runtime\4.0.20-beta-22816\lib\net45\System.Runtime.dll' and 'C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1\Facades\System.Runtime.dll'. Remove one of the duplicate references.`

See: https://github.com/aspnet/Mvc/issues/2959


