### PR TITLE
fix potential nullref in ProjectAssemblyLoader when using DTH plugins

### DIFF
--- a/src/Microsoft.Dnx.DesignTimeHost/DesignTimeAssemblyLoadContextFactory.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/DesignTimeAssemblyLoadContextFactory.cs
@@ -5,6 +5,8 @@ using System;
 using Microsoft.Dnx.Compilation;
 using Microsoft.Dnx.Compilation.Caching;
 using Microsoft.Dnx.Runtime;
+using Microsoft.Dnx.Runtime.Common.DependencyInjection;
+using Microsoft.Dnx.Runtime.Compilation;
 using Microsoft.Dnx.Runtime.Infrastructure;
 using Microsoft.Dnx.Runtime.Loader;
 
@@ -50,7 +52,17 @@ namespace Microsoft.Dnx.DesignTimeHost
 
                 // Add a cache dependency on restore complete to reevaluate dependencies
                 ctx.Monitor(_compilationFactory.CompilationCache.NamedCacheDependencyProvider.GetNamedDependency(_project.Name + "_Dependencies"));
-                
+
+                // Create compilation engine and add it to the services
+                var compilationEngine = _compilationFactory.CreateEngine(new CompilationEngineContext(
+                    applicationHostContext.LibraryManager,
+                    applicationHostContext.ProjectGraphProvider,
+                    NoopWatcher.Instance,
+                    applicationHostContext.ServiceProvider,
+                    _appEnv.RuntimeFramework,
+                    _appEnv.Configuration));
+                applicationHostContext.AddService(typeof(ICompilationEngine), compilationEngine);
+
                 return applicationHostContext;
             });
 


### PR DESCRIPTION
Without this fix, Razor Tag Helpers within the current project are not properly recognized.

@ToddGrun tried out a private build of the fix and it did indeed fix the issue. I believe this meets the beta7 bar.

/review @davidfowl @NTaylorMullen
/fyi @danroth27 @DamianEdwards @Eilon @muratg @ToddGrun 