### PR TITLE
allow additional files to be included in the nupkg

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -64,6 +64,7 @@ var PROGRAM_FILES_X86 = '${Environment.GetFolderPath(Environment.SpecialFolder.P
 var MSBUILD = '${Path.Combine(PROGRAM_FILES_X86, "MSBuild", "14.0", "Bin", "MSBuild.exe")}'
 var VS_REDIST_ROOT = '${Path.Combine(PROGRAM_FILES_X86, @"Microsoft Visual Studio 14.0\VC\redist")}'
 var WIN10_SDK_LIB = '${Path.Combine(PROGRAM_FILES_X86, @"Windows Kits\10\Lib")}'
+var VS_ONECORE_ROOT = '${Path.Combine(PROGRAM_FILES_X86, @"Microsoft Visual Studio 14.0\VC\lib\onecore")}'
 var CLANG = '${SearchForClang()}'
 
 var MANAGED_PROJECTS = '${FindAllProjects(
@@ -93,7 +94,7 @@ var WIN_MANAGED_PROJECTS = '${FindAllProjects(
 
 var RUNTIME_TARGETS='${new List<RuntimeTarget>()}'
 
-var CAN_BUILD_ONECORE = '${Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles(WIN10_SDK_LIB, "onecore.lib", SearchOption.AllDirectories).Any()}'
+var CAN_BUILD_ONECORE = '${Directory.Exists(VS_ONECORE_ROOT) && Directory.GetFiles(VS_ONECORE_ROOT, "vcruntime.lib", SearchOption.AllDirectories).Any() && Directory.Exists(WIN10_SDK_LIB) && Directory.GetFiles(WIN10_SDK_LIB, "onecore.lib", SearchOption.AllDirectories).Any()}'
 
 @{
     // Always build mono

--- a/src/Microsoft.Dnx.Runtime.Json.Sources/JsonArray.cs
+++ b/src/Microsoft.Dnx.Runtime.Json.Sources/JsonArray.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Dnx.Runtime.Json
 {
@@ -20,14 +21,8 @@ namespace Microsoft.Dnx.Runtime.Json
             _array = array;
         }
 
-        public int Length
-        {
-            get { return _array.Length; }
-        }
-
-        public JsonValue this[int index]
-        {
-            get { return _array[index]; }
-        }
+        public int Length => _array.Length;
+        public IEnumerable<JsonValue> Values => _array;
+        public JsonValue this[int index] => _array[index];
     }
 }

--- a/src/Microsoft.Dnx.Runtime.Json.Sources/JsonObject.cs
+++ b/src/Microsoft.Dnx.Runtime.Json.Sources/JsonObject.cs
@@ -97,5 +97,10 @@ namespace Microsoft.Dnx.Runtime.Json
 
             return result;
         }
+
+        internal object ValueAsJsonObject(object packIncludePropertyName)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.Dnx.Runtime/PackIncludeEntry.cs
+++ b/src/Microsoft.Dnx.Runtime/PackIncludeEntry.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Dnx.Runtime.Json;
+
+namespace Microsoft.Dnx.Runtime
+{
+    public class PackIncludeEntry
+    {
+        public string Target { get; }
+        public string[] SourceGlobs { get; }
+        public int Line { get; }
+        public int Column { get; }
+
+        internal PackIncludeEntry(string target, JsonValue json)
+            : this(target, ExtractValues(json), json.Line, json.Column)
+        {
+        }
+
+        public PackIncludeEntry(string target, string[] sourceGlobs, int line, int column)
+        {
+            Target = target;
+            SourceGlobs = sourceGlobs;
+            Line = line;
+            Column = column;
+        }
+
+        private static string[] ExtractValues(JsonValue json)
+        {
+            var valueAsString = json as JsonString;
+            if (valueAsString != null)
+            {
+                return new string[] { valueAsString.Value };
+            }
+
+            var valueAsArray = json as JsonArray;
+            if(valueAsArray != null)
+            {
+                return valueAsArray.Values.Select(v => v.ToString()).ToArray();
+            }
+            return new string[0];
+        }
+    }
+}

--- a/src/Microsoft.Dnx.Runtime/project.json
+++ b/src/Microsoft.Dnx.Runtime/project.json
@@ -19,6 +19,7 @@
         "Microsoft.Dnx.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Compilation.CSharp.Abstractions": { "version": "1.0.0-*", "type": "build" },
+        "Microsoft.Framework.HashCodeCombiner.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.CodeAnalysis.CSharp": "1.1.0-beta1-*"
     },
     "frameworks": {

--- a/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
@@ -241,6 +241,7 @@ namespace Microsoft.Dnx.Tooling
                             AddPackageFiles(_currentProject.ProjectDirectory, _currentProject.Files.PackInclude, packageBuilder, packDiagnostics);
                         }
                         success &= !packDiagnostics.HasErrors();
+                        allDiagnostics.AddRange(packDiagnostics);
 
                         foreach (var path in _currentProject.Files.SourceFiles)
                         {

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackAdditionalFilesTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackAdditionalFilesTests.cs
@@ -1,0 +1,430 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Microsoft.Dnx.CommonTestUtils;
+using Xunit;
+
+namespace Microsoft.Dnx.Tooling.FunctionalTests
+{
+    public class DnuPackAdditionalFilesTests
+    {
+        public static IEnumerable<object[]> RuntimeComponents
+        {
+            get
+            {
+                return TestUtils.GetRuntimeComponentsCombinations();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_SimpleGlobs(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools/"": ""packageTools/**/*.ps1""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "ProjectName.nuspec",
+                "lib/dnx451/ProjectName.dll",
+                "lib/dnx451/ProjectName.xml",
+                "tools/install.ps1",
+                "tools/sub/support.ps1"
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_FileToFile(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools/install.ps1"": ""packageTools/install.ps1"",
+        ""tools/different/support.ps1"": ""packageTools/sub/support.ps1""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "ProjectName.nuspec",
+                "lib/dnx451/ProjectName.dll",
+                "lib/dnx451/ProjectName.xml",
+                "tools/install.ps1",
+                "tools/different/support.ps1"
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_SingleFileToDirectory(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools/"": ""packageTools/install.ps1""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "ProjectName.nuspec",
+                "lib/dnx451/ProjectName.dll",
+                "lib/dnx451/ProjectName.xml",
+                "tools/install.ps1"
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_FileArray_RootFiles(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json"", ""root.txt""]
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""/"" : ""root.txt""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "ProjectName.nuspec",
+                "lib/dnx451/ProjectName.dll",
+                "lib/dnx451/ProjectName.xml",
+                "root.txt"
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_FileArray_DotFiles(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json"", "".someconfigfile""]
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        "".someconfigfile"" : "".someconfigfile""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "ProjectName.nuspec",
+                "lib/dnx451/ProjectName.dll",
+                "lib/dnx451/ProjectName.xml",
+                ".someconfigfile"
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_FileArray(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools/"": [ ""packageTools/install.ps1"", ""packageTools/sub/support.ps1"" ]
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "ProjectName.nuspec",
+                "lib/dnx451/ProjectName.dll",
+                "lib/dnx451/ProjectName.xml",
+                "tools/install.ps1",
+                "tools/support.ps1"
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_MissingFile(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools/"": ""nope.ps1""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "ProjectName.nuspec",
+                "lib/dnx451/ProjectName.dll",
+                "lib/dnx451/ProjectName.xml"
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput, shouldFail: false);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_ArityMismatch_Glob(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools"": ""packageTools/**/*.ps1""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "PROJECTJSONPATH(5,18): error: Invalid 'packInclude' section. The target 'tools' refers to a single file, but the pattern \"packageTools/**/*.ps1\" produces multiple files. To mark the target as a directory, suffix it with '/'."
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput, shouldFail: true);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_ArityMismatch_Array(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools"": [ ""packageTools/install.ps1"", ""packageTools/sub/support.ps1"" ]
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "PROJECTJSONPATH(5,18): error: Invalid 'packInclude' section. The target 'tools' refers to a single file, but the pattern [\"packageTools/install.ps1\",\"packageTools/sub/support.ps1\"] produces multiple files. To mark the target as a directory, suffix it with '/'."
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput, shouldFail: true);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_PathTraversal(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools/../"": [ ""packageTools/install.ps1"", ""packageTools/sub/support.ps1"" ]
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "PROJECTJSONPATH(5,22): error: Invalid 'packInclude' section. The target 'tools/../' contains path-traversal characters ('.' or '..'). These characters are not permitted in target paths."
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput, shouldFail: true);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_PathTraversal_EmptyTarget(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        """": ""packageTools/install.ps1""
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "PROJECTJSONPATH(5,13): error: Invalid 'packInclude' section. The target '' is invalid, targets must either be a file name or a directory suffixed with '/'. The root directory of the package can be specified by using a single '/' character."
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput, shouldFail: true);
+        }
+
+        [Theory]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_AddFilesToNupkg_PathTraversal_SingleDot(string flavor, string os, string architecture)
+        {
+            const string dirTree = @"{
+    ""."": [""project.json""],
+    ""packageTools"": {
+        ""."": [""install.ps1""],
+        ""sub"": [""support.ps1""]
+    }
+}";
+
+            const string projectJson = @"{
+    ""version"": ""1.0.0"",
+    ""frameworks"": { ""dnx451"": {} },
+    ""packInclude"": {
+        ""tools/./"": [ ""packageTools/install.ps1"", ""packageTools/sub/support.ps1"" ]
+    }   
+}";
+
+            var expectedOutput = new[]
+            {
+                "PROJECTJSONPATH(5,21): error: Invalid 'packInclude' section. The target 'tools/./' contains path-traversal characters ('.' or '..'). These characters are not permitted in target paths."
+            };
+
+            RunAdditionalFilesTest(flavor, os, architecture, dirTree, projectJson, expectedOutput, shouldFail: true);
+        }
+
+        private void RunAdditionalFilesTest(string flavor, string os, string architecture, string dirTree, string projectJson, string[] expectedOutput, bool shouldFail = false)
+        {
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            using (var testEnv = new DnuTestEnvironment(runtimeHomeDir))
+            {
+                int exitCode;
+                string stdOut;
+                string stdErr;
+
+                DirTree.CreateFromJson(dirTree)
+                    .WithFileContents("project.json", projectJson)
+                    .WriteTo(testEnv.ProjectPath);
+
+                DnuTestUtils.ExecDnu(runtimeHomeDir, "restore", "", workingDir: testEnv.RootDir);
+                exitCode = DnuTestUtils.ExecDnu(runtimeHomeDir, "pack", $"--out {testEnv.PublishOutputDirPath}", out stdOut, out stdErr, workingDir: testEnv.ProjectPath);
+
+                var packageOutputPath = Path.Combine(testEnv.PublishOutputDirPath, "Debug", $"{testEnv.ProjectName}.1.0.0.nupkg");
+
+                // Check it
+                if (shouldFail)
+                {
+                    Assert.NotEqual(0, exitCode);
+                    foreach (var message in expectedOutput)
+                    {
+                        Assert.Contains(
+                            message.Replace("PROJECTJSONPATH", Path.Combine(testEnv.ProjectPath, "project.json")),
+                            stdErr.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
+                    }
+                    Assert.False(File.Exists(packageOutputPath));
+                }
+                else
+                {
+                    Assert.True(File.Exists(packageOutputPath));
+
+                    string[] entries;
+                    using (var archive = ZipFile.OpenRead(packageOutputPath))
+                    {
+                        entries = archive.Entries.Select(e => e.FullName).Where(IsNotOpcMetadata).ToArray();
+                    }
+
+                    Assert.Equal(0, exitCode);
+                    Assert.Equal(expectedOutput, entries);
+                }
+            }
+        }
+
+        private static readonly HashSet<string> OpcMetadataPaths = new HashSet<string>()
+        {
+            "_rels/.rels",
+            "[Content_Types].xml"
+        };
+
+        private bool IsNotOpcMetadata(string arg)
+        {
+            return !OpcMetadataPaths.Contains(arg);
+        }
+    }
+}

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackTests.cs
@@ -279,7 +279,7 @@ public class TestClass : BaseClass {
                 Assert.NotEmpty(stdErr);
                 var unresolvedDependencyErrorCount = stdErr
                     .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(line => line.Contains("The dependency NonexistentPackages >= 1.0.0 could not be resolved"))
+                    .Where(line => line.Contains("The dependency NonexistentPackage >= 1.0.0 could not be resolved"))
                     .Count();
                 Assert.Equal(1, unresolvedDependencyErrorCount);
             }


### PR DESCRIPTION
fixes #848 

blocked on https://github.com/aspnet/FileSystem/pull/120 ... still waiting for a squirrel there ;). Anyone on this review should feel free to go review that and give me a squirrel there :P

With this change, the project.json can have a new `packageFiles` section, for example:

```json
{
    "packageFiles": {
        "destination1/": "source1/**",
        "destination2/": "source2/**",
        "destination2/some_additional_file.txt": "source2a/somefile.txt",
        "destination3/": ["source3/a.txt", "source3/b.txt", "source4/c/**/*.ps1"]
    }
}
```

The value is a JSON object. Keys in this object (`destination1`, etc. in the above example) are destinations relative to the package root. P. If they end with a `/`, they are treated as directories, otherwise they are files. The associated value is one or more globbing patterns. If the globs end up pulling in multiple files, the destination on the left must be a directory, otherwise an error is reported (see tests for example). If the destination is a directory, the file name for each file is calculated using the stem of the globbing match (see aspnet/FileSystem#120).

Open Questions:

1. Name of `PackageFilesSource` class is weird, but I want to keep the Line/Column info around for error reporting...
2. Handling the "arity" of the source/destination pairs is still a little icky. Requiring that directories end with "/" seemed like the easiest because it allows us to have a clear error. Thoughts? That part can be tweaked both now, and after receiving user feedback in the remaining beta.

/cc @davidfowl @Tratcher @BrennanConroy @halter73 @lodejard 