### PR TITLE
add code to determine the runtime ID for a DNX

### DIFF
--- a/src/Microsoft.Dnx.Host/RuntimeEnvironment.cs
+++ b/src/Microsoft.Dnx.Host/RuntimeEnvironment.cs
@@ -17,17 +17,17 @@ namespace Microsoft.Dnx.Runtime
         public RuntimeEnvironment()
         {
 #if DNXCORE50
-            RuntimeType = "CoreCLR";
-            RuntimeArchitecture = IntPtr.Size == 8 ? "x64" : "x86";
+            RuntimeType = RuntimeTypes.CoreCLR;
+            RuntimeArchitecture = IntPtr.Size == 8 ? RuntimeArchitectures.X64 : RuntimeArchitectures.X86;
 #else
-            RuntimeType = Type.GetType("Mono.Runtime") == null ? "CLR" : "Mono";
-            RuntimeArchitecture = Environment.Is64BitProcess ? "x64" : "x86";
+            RuntimeType = Type.GetType("Mono.Runtime") == null ? RuntimeTypes.CLR : RuntimeTypes.Mono;
+            RuntimeArchitecture = Environment.Is64BitProcess ? RuntimeArchitectures.X64 : RuntimeArchitectures.X86;
 #endif
 
             // This is a temporary workaround until we pass a struct with OS information from native code
             if (Environment.GetEnvironmentVariable(EnvironmentNames.DnxIsWindows) == "1")
             {
-                _osName = "Windows";
+                _osName = RuntimeOperatingSystems.Windows;
             }
         }
 
@@ -38,7 +38,7 @@ namespace Microsoft.Dnx.Runtime
                 if (_osName == null)
                 {
                     string uname = NativeMethods.Uname();
-                    _osName = string.IsNullOrEmpty(uname) ? "Windows" : uname;
+                    _osName = string.IsNullOrEmpty(uname) ? RuntimeOperatingSystems.Windows : uname;
                 }
 
                 return _osName;
@@ -49,7 +49,7 @@ namespace Microsoft.Dnx.Runtime
         {
             get
             {
-                if (OperatingSystem != "Windows")
+                if (OperatingSystem != RuntimeOperatingSystems.Windows)
                 {
                     return null;
                 }

--- a/src/Microsoft.Dnx.Runtime.Abstractions/Microsoft.Dnx.Runtime.Abstractions.xproj
+++ b/src/Microsoft.Dnx.Runtime.Abstractions/Microsoft.Dnx.Runtime.Abstractions.xproj
@@ -11,7 +11,7 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <RootNamespace>Microsoft.Framework.Runtime</RootNamespace>
+    <RootNamespace>Microsoft.Dnx.Runtime</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Microsoft.Dnx.Runtime.Internals/Constants.cs
+++ b/src/Microsoft.Dnx.Runtime.Internals/Constants.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Dnx.Runtime
+{
+    internal static class RuntimeTypes
+    {
+        public static readonly string CoreCLR = nameof(CoreCLR);
+        public static readonly string CLR = nameof(CLR);
+        public static readonly string Mono = nameof(Mono);
+    }
+
+    internal static class RuntimeArchitectures
+    {
+        public static readonly string X86 = "x86";
+        public static readonly string X64 = "x64";
+    }
+
+    internal static class RuntimeOperatingSystems
+    {
+        public static readonly string Windows = nameof(Windows);
+    }
+}

--- a/src/Microsoft.Dnx.Runtime.Internals/RuntimeEnvironmentExtensions.cs
+++ b/src/Microsoft.Dnx.Runtime.Internals/RuntimeEnvironmentExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Text;
 
 namespace Microsoft.Dnx.Runtime
@@ -20,12 +21,49 @@ namespace Microsoft.Dnx.Runtime
                 str.AppendLine($" OS Version:   {env.OperatingSystemVersion}");
             }
 
+            str.AppendLine($" Runtime Id:   {env.GetRuntimeIdentifier()}");
+
             return str.ToString();
         }
 
         public static string GetShortVersion(this IRuntimeEnvironment env)
         {
             return $"{env.RuntimeType}-{env.RuntimeArchitecture}-{env.RuntimeVersion}";
+        }
+
+        public static string GetRuntimeIdentifier(this IRuntimeEnvironment env)
+        {
+            string os = env.OperatingSystem;
+            string ver = env.OperatingSystemVersion;
+            if (string.Equals(os, RuntimeOperatingSystems.Windows, StringComparison.Ordinal))
+            {
+                os = "win";
+
+                // Convert 6.x to the correct branding version for the RID
+                var parsedVersion = Version.Parse(ver);
+                if(parsedVersion.Major == 6 && parsedVersion.Minor == 1)
+                {
+                    ver = "7";
+                }
+                else if(parsedVersion.Major == 6 && parsedVersion.Minor == 2)
+                {
+                    ver = "8";
+                }
+                else if(parsedVersion.Major == 6 && parsedVersion.Minor == 3)
+                {
+                    ver = "81";
+                }
+                else if(parsedVersion.Major == 10 && parsedVersion.Minor == 0)
+                {
+                    ver = "10";
+                }
+            }
+            else
+            {
+                os = os.ToLower(); // Just use the lower-case full name of the OS as the RID OS
+            }
+
+            return $"{os}{ver}-{env.RuntimeArchitecture.ToLower()}";
         }
     }
 }

--- a/test/Microsoft.Dnx.Host.Tests/RuntimeEnvironmentTests.cs
+++ b/test/Microsoft.Dnx.Host.Tests/RuntimeEnvironmentTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Dnx.Runtime;
 using Xunit;
 
@@ -53,6 +55,76 @@ namespace dnx.hostTests
             var runtime = Type.GetType("Mono.Runtime") == null ? "CLR" : "Mono";
             Assert.Equal(runtime, runtimeEnv.RuntimeType);
 #endif
+        }
+
+        // Test RID generation
+        [Theory]
+        [InlineData("Windows", "6.1.1234", "x86", "win7-x86")] // 1234 => We only care about major and minor
+        [InlineData("Windows", "6.1.1234", "x64", "win7-x64")]
+        [InlineData("Windows", "6.2.1234", "x86", "win8-x86")]
+        [InlineData("Windows", "6.2.1234", "x64", "win8-x64")]
+        [InlineData("Windows", "6.3.1234", "x86", "win81-x86")]
+        [InlineData("Windows", "6.3.1234", "x64", "win81-x64")]
+        [InlineData("Windows", "10.0.1234", "x86", "win10-x86")]
+        [InlineData("Windows", "10.0.1234", "x64", "win10-x64")]
+        [InlineData("Windows", "10.0.1234", "arm", "win10-arm")]
+        [InlineData("Linux", "", "x86", "linux-x86")]
+        [InlineData("Linux", "", "x64", "linux-x64")]
+        [InlineData("Linux", "", "arm", "linux-arm")]
+        [InlineData("Darwin", "", "x86", "darwin-x86")]
+        [InlineData("Darwin", "", "x64", "darwin-x64")]
+        [InlineData("Darwin", "", "arm", "darwin-arm")]
+        public void RuntimeIdIsGeneratedCorrectly(string osName, string version, string architecture, string expectedRid)
+        {
+            var runtimeEnv = new DummyRuntimeEnvironment()
+            {
+                OperatingSystem = osName,
+                OperatingSystemVersion = version,
+                RuntimeArchitecture = architecture
+            };
+            Assert.Equal(expectedRid, runtimeEnv.GetRuntimeIdentifier());
+        }
+
+        // Test live runtime ids
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        public void WindowsRuntimeIdIsCorrect()
+        {
+            // Verifying OS version is difficult in a test
+
+            var expectedArch = RuntimeEnvironmentHelper.RuntimeEnvironment.RuntimeArchitecture.ToLowerInvariant();
+            var rid = RuntimeEnvironmentHelper.RuntimeEnvironment.GetRuntimeIdentifier();
+            var osName = new string(rid.TakeWhile(c => !char.IsDigit(c)).ToArray());
+            var arch = rid.Split('-')[1];
+            Assert.Equal("win", osName);
+            Assert.Equal(expectedArch, arch);
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CLR | RuntimeFrameworks.CoreCLR)] // We don't have an OS skip condition for all Windows yet
+        public void MacRuntimeIdIsCorrect()
+        {
+            var arch = RuntimeEnvironmentHelper.RuntimeEnvironment.RuntimeArchitecture.ToLowerInvariant();
+            Assert.Equal($"darwin-{arch}", RuntimeEnvironmentHelper.RuntimeEnvironment.GetRuntimeIdentifier());
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CLR | RuntimeFrameworks.CoreCLR)] // We don't have an OS skip condition for all Windows yet
+        public void LinuxRuntimeIdIsCorrect()
+        {
+            var arch = RuntimeEnvironmentHelper.RuntimeEnvironment.RuntimeArchitecture.ToLowerInvariant();
+            Assert.Equal($"linux-{arch}", RuntimeEnvironmentHelper.RuntimeEnvironment.GetRuntimeIdentifier());
+        }
+
+        private class DummyRuntimeEnvironment : IRuntimeEnvironment
+        {
+            public string OperatingSystem { get; set; }
+            public string OperatingSystemVersion { get; set; }
+            public string RuntimeArchitecture { get; set; }
+            public string RuntimeType { get; set; }
+            public string RuntimeVersion { get; set; }
         }
     }
 }

--- a/test/Microsoft.Dnx.Host.Tests/project.json
+++ b/test/Microsoft.Dnx.Host.Tests/project.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
         "Microsoft.Dnx.Host": "1.0.0-*",
+        "Microsoft.AspNet.Testing": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
 


### PR DESCRIPTION
**Part** of #2387, but not the whole runtime.json feature.

I wanted to get this in to dev relatively quickly because a) it's benign, nothing will use it yet and b) it will affect @moozzyk 's work on #1970.

In theory, we will need to have the runtime ID itself passed in by the native code, so I wanted to put a place for that to go. For now, it is synthesized by the managed code, but it should live in the native code since that is where we will be pivoting the runtime.

After this, `dnx --version` outputs the runtime ID. For example:

![image](https://cloud.githubusercontent.com/assets/7574/9592475/2ec8d28e-4ff8-11e5-889b-9a75e557e8fb.png)

I had to add an app manifest that enables Windows 10 compatibility in order for [`GetVersionEx`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx) (and thus `Environment.OperatingSystem.Version`) to return higher than `6.2` (Windows 8).

From here it's relatively straight forward to provide the necessary data to restore and during loading.

/cc @ericstj @davidfowl @moozzyk @lodejard 