### PR TITLE
Don't throw from TryGetProject when it cannot get the project

### DIFF
--- a/src/Microsoft.Dnx.Runtime/Project.cs
+++ b/src/Microsoft.Dnx.Runtime/Project.cs
@@ -134,6 +134,11 @@ namespace Microsoft.Dnx.Runtime
             var projectName = PathUtility.GetDirectoryName(path);
             projectPath = Path.GetFullPath(projectPath);
 
+            if (!File.Exists(projectPath))
+            {
+                return false;
+            }
+
             try
             {
                 using (var stream = File.OpenRead(projectPath))

--- a/test/Microsoft.Dnx.Runtime.FunctionalTests/ProjectFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.FunctionalTests/ProjectFacts.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Dnx.Runtime.FunctionalTests
+{
+    public class ProjectFacts
+    {
+        [Fact]
+        public void TryGetProject_FileDoesntExist()
+        {
+            Project project;
+            bool gotProject = Project.TryGetProject(@"c:\thispathshouldnotexist\project.json", out project);
+            Assert.False(gotProject);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aspnet/dnx/issues/2214

`TryGetProject` was throwing when the project file was not found. Probably a recent regression.

Please review @BrennanConroy @anurse or @davidfowl 
