### PR TITLE
fix #2604 by making source path absolute

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Dnx.Tooling
                     {
                         yield return new PhysicalPackageFile()
                         {
-                            SourcePath = PathUtility.GetPathWithDirectorySeparator(file.Path),
+                            SourcePath = Path.Combine(rootDirectory.FullName, PathUtility.GetPathWithDirectorySeparator(file.Path)),
                             TargetPath = Path.Combine(dir, PathUtility.GetPathWithDirectorySeparator(file.Stem))
                         };
                     }
@@ -392,7 +392,7 @@ namespace Microsoft.Dnx.Tooling
                     {
                         yield return new PhysicalPackageFile()
                         {
-                            SourcePath = files[0].Path,
+                            SourcePath = Path.Combine(rootDirectory.FullName, files[0].Path),
                             TargetPath = PathUtility.GetPathWithDirectorySeparator(entry.Target)
                         };
                     }

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackAdditionalFilesTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackAdditionalFilesTests.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Dnx.Tooling.FunctionalTests
                     .WriteTo(testEnv.ProjectPath);
 
                 DnuTestUtils.ExecDnu(runtimeHomeDir, "restore", "", workingDir: testEnv.RootDir);
-                exitCode = DnuTestUtils.ExecDnu(runtimeHomeDir, "pack", $"--out {testEnv.PublishOutputDirPath}", out stdOut, out stdErr, workingDir: testEnv.ProjectPath);
+                exitCode = DnuTestUtils.ExecDnu(runtimeHomeDir, "pack", $"{testEnv.ProjectPath} --out {testEnv.PublishOutputDirPath}", out stdOut, out stdErr, workingDir: testEnv.RootDir);
 
                 var packageOutputPath = Path.Combine(testEnv.PublishOutputDirPath, "Debug", $"{testEnv.ProjectName}.1.0.0.nupkg");
 


### PR DESCRIPTION
I incorrectly assumed that globbing was returning absolute paths (since we gave it the root directory).

I also made the tests always run under these conditions (working dir != project dir) to ensure this doesn't reoccur.

Fixes #2604 

/cc @bricelam