### PR TITLE
Add MONO_THREADS_PER_CPU to dnu.sh to workaround restore timeouts on Mono

### DIFF
--- a/scripts/dnu.sh
+++ b/scripts/dnu.sh
@@ -8,5 +8,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
+# work around restore timeouts on Mono
+[ -z "$MONO_THREADS_PER_CPU" ] && export MONO_THREADS_PER_CPU=50
 
 exec "$DIR/dnx" "$DIR/lib/Microsoft.Dnx.Tooling/Microsoft.Dnx.Tooling.dll" "$@"


### PR DESCRIPTION
This is troubling a lot of people and I honestly don't expect it to be fixed for Mono 4.2.
Adding the workaround to dnu.sh seems like a better solution for now instead of telling everyone to add it themselves.