### PR TITLE
Added the relevant target framework for project references in the lockfile

### DIFF
--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/LockFileReader.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/LockFileReader.cs
@@ -185,6 +185,12 @@ namespace Microsoft.Dnx.Runtime
             }
 
             library.Type = jobject.ValueAsString("type");
+            var framework = jobject.ValueAsString("framework");
+            if (framework != null)
+            {
+                library.TargetFramework = new FrameworkName(framework);
+            }
+
             library.Dependencies = ReadObject(jobject.ValueAsJsonObject("dependencies"), ReadPackageDependency);
             library.FrameworkAssemblies = new HashSet<string>(ReadArray(jobject.Value("frameworkAssemblies"), ReadFrameworkAssemblyReference), StringComparer.OrdinalIgnoreCase);
             library.RuntimeAssemblies = ReadObject(jobject.ValueAsJsonObject("runtime"), ReadFileItem);

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/LockFileTargetLibrary.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/LockFileTargetLibrary.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using NuGet;
 
 namespace Microsoft.Dnx.Runtime
@@ -12,6 +13,8 @@ namespace Microsoft.Dnx.Runtime
         public string Name { get; set; }
 
         public string Type { get; set; }
+
+        public FrameworkName TargetFramework { get; set; }
 
         public SemanticVersion Version { get; set; }
 

--- a/src/Microsoft.Dnx.Tooling/Restore/LockFileFormat.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/LockFileFormat.cs
@@ -252,6 +252,12 @@ namespace Microsoft.Dnx.Tooling
                 library.Type = ReadString(type);
             }
 
+            var framework = json["framework"];
+            if (framework != null)
+            {
+                library.TargetFramework = new FrameworkName(ReadString(framework));
+            }
+
             library.Dependencies = ReadObject(json["dependencies"] as JObject, ReadPackageDependency);
             library.FrameworkAssemblies = new HashSet<string>(ReadArray(json["frameworkAssemblies"] as JArray, ReadFrameworkAssemblyReference), StringComparer.OrdinalIgnoreCase);
             library.RuntimeAssemblies = ReadObject(json["runtime"] as JObject, ReadFileItem);
@@ -267,6 +273,11 @@ namespace Microsoft.Dnx.Tooling
             var json = new JObject();
 
             json["type"] = WriteString(library.Type);
+
+            if (library.TargetFramework != null)
+            {
+                json["framework"] = WriteString(library.TargetFramework.ToString());
+            }
 
             if (library.Dependencies.Count > 0)
             {

--- a/src/Microsoft.Dnx.Tooling/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Dnx.Tooling/Utils/LockFileUtils.cs
@@ -66,34 +66,34 @@ namespace Microsoft.Dnx.Tooling.Utils
             return lockFileLib;
         }
 
-        public static LockFileProjectLibrary CreateLockFileProjectLibrary(LockFileProjectLibrary previousLibrary,
-                                                                          Runtime.Project project,
-                                                                          Runtime.Project library)
+        public static LockFileProjectLibrary CreateLockFileProjectLibrary(Runtime.Project project,
+                                                                          Runtime.Project projectDependency)
         {
             var result = new LockFileProjectLibrary()
             {
-                Name = library.Name,
-                Version = library.Version
+                Name = projectDependency.Name,
+                Version = projectDependency.Version
             };
 
-            result.Path = PathUtility.GetRelativePath(project.ProjectFilePath, library.ProjectFilePath, '/');
+            result.Path = PathUtility.GetRelativePath(project.ProjectFilePath, projectDependency.ProjectFilePath, '/');
 
             return result;
         }
 
-        public static LockFileTargetLibrary CreateLockFileTargetLibrary(LockFileProjectLibrary library,
-                                                                        Runtime.Project projectInfo,
+        public static LockFileTargetLibrary CreateLockFileTargetLibrary(Runtime.Project projectDependency,
                                                                         RestoreContext context)
         {
+            var targetFrameworkInfo = projectDependency.GetTargetFramework(context.FrameworkName);
+
             var lockFileLib = new LockFileTargetLibrary
             {
-                Name = library.Name,
-                Version = library.Version,
+                Name = projectDependency.Name,
+                Version = projectDependency.Version,
+                TargetFramework = targetFrameworkInfo.FrameworkName, // null TFM means it's incompatible
                 Type = "project"
             };
 
-            var targetFrameworkInfo = projectInfo.GetTargetFramework(context.FrameworkName);
-            var dependencies = projectInfo.Dependencies.Concat(targetFrameworkInfo.Dependencies);
+            var dependencies = projectDependency.Dependencies.Concat(targetFrameworkInfo.Dependencies);
 
             foreach (var dependency in dependencies)
             {

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
@@ -671,7 +671,8 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Dnx.ApplicationHost --configuration
   ""targets"": {
     ""DNX,Version=v4.6"": {
       ""Lib/1.0.0"": {
-        ""type"": ""project""
+        ""type"": ""project"",
+        ""framework"": ""DNX,Version=v4.5.1""
       }
     }
   },


### PR DESCRIPTION
- Only a restore change for now so we can have project files with
the framework be generated before taking advantage of it in the runtime.

#2622 

/cc @anurse @BillHiebert @jasonmalinowski @yishaigalatzer 