### PR TITLE
Use the project.lock.json to determine the compatible framework for projects

### DIFF
--- a/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Dnx.Runtime
 
                             var path = Path.GetFullPath(Path.Combine(context.ProjectDirectory, projectLibrary.Path));
 
-                            var projectDescription = projectResolver.GetDescription(context.TargetFramework, path, library);
+                            var projectDescription = projectResolver.GetDescription(path, library);
 
                             libraries.Add(projectDescription);
                         }

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDependencyProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Dnx.Runtime
 {
     public class ProjectDependencyProvider
     {
-        public ProjectDescription GetDescription(FrameworkName targetFramework, string path, LockFileTargetLibrary targetLibrary)
+        public ProjectDescription GetDescription(string path, LockFileTargetLibrary targetLibrary)
         {
             Project project;
 
@@ -22,7 +22,7 @@ namespace Microsoft.Dnx.Runtime
                 return null;
             }
 
-            return GetDescription(targetFramework, project);
+            return GetDescription(targetLibrary.TargetFramework, project);
         }
 
         public ProjectDescription GetDescription(FrameworkName targetFramework, Project project)
@@ -71,8 +71,7 @@ namespace Microsoft.Dnx.Runtime
 
             // Mark the library as unresolved if there were specified frameworks
             // and none of them resolved
-            bool unresolved = targetFrameworkInfo.FrameworkName == null &&
-                              project.GetTargetFrameworks().Any();
+            bool unresolved = targetFramework == null;
 
             return new ProjectDescription(
                 new LibraryRange(project.Name, frameworkReference: false),

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDependencyProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Dnx.Runtime
             var targetFrameworkInfo = project.GetTargetFramework(targetFramework);
             var targetFrameworkDependencies = new List<LibraryDependency>(targetFrameworkInfo.Dependencies);
 
-            if (VersionUtility.IsDesktop(targetFramework))
+            if (targetFramework != null && VersionUtility.IsDesktop(targetFramework))
             {
                 targetFrameworkDependencies.Add(new LibraryDependency
                 {
@@ -71,7 +71,7 @@ namespace Microsoft.Dnx.Runtime
 
             // Mark the library as unresolved if there were specified frameworks
             // and none of them resolved
-            bool unresolved = targetFramework == null;
+            bool unresolved = targetFrameworkInfo.FrameworkName == null;
 
             return new ProjectDescription(
                 new LibraryRange(project.Name, frameworkReference: false),

--- a/src/Microsoft.Dnx.Runtime/Project.cs
+++ b/src/Microsoft.Dnx.Runtime/Project.cs
@@ -169,17 +169,10 @@ namespace Microsoft.Dnx.Runtime
 
         public TargetFrameworkInformation GetTargetFramework(FrameworkName targetFramework)
         {
-            TargetFrameworkInformation targetFrameworkInfo;
-            if (_targetFrameworks.TryGetValue(targetFramework, out targetFrameworkInfo))
+            TargetFrameworkInformation targetFrameworkInfo = null;
+            if (targetFramework != null && _targetFrameworks.TryGetValue(targetFramework, out targetFrameworkInfo))
             {
                 return targetFrameworkInfo;
-            }
-
-            IEnumerable<TargetFrameworkInformation> compatibleConfigurations;
-            if (VersionUtility.GetNearest(targetFramework, GetTargetFrameworks(), out compatibleConfigurations) &&
-                compatibleConfigurations.Any())
-            {
-                targetFrameworkInfo = compatibleConfigurations.FirstOrDefault();
             }
 
             return targetFrameworkInfo ?? _defaultTargetFrameworkConfiguration;

--- a/src/Microsoft.Dnx.Tooling/ProjectExtensions.cs
+++ b/src/Microsoft.Dnx.Tooling/ProjectExtensions.cs
@@ -18,7 +18,10 @@ namespace Microsoft.Dnx.Tooling
                 return targets.FirstOrDefault();
             }
 
-            return null;
+            return new TargetFrameworkInformation
+            {
+                Dependencies = new List<LibraryDependency>()
+            };
         }
     }
 }

--- a/src/Microsoft.Dnx.Tooling/ProjectExtensions.cs
+++ b/src/Microsoft.Dnx.Tooling/ProjectExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using Microsoft.Dnx.Runtime;
+using NuGet;
+
+namespace Microsoft.Dnx.Tooling
+{
+    public static class ProjectExtensions
+    {
+        public static TargetFrameworkInformation GetCompatibleTargetFramework(this Runtime.Project project, FrameworkName targetFramework)
+        {
+            IEnumerable<TargetFrameworkInformation> targets;
+            if (VersionUtility.GetNearest(targetFramework, project.GetTargetFrameworks(), out targets) &&
+                targets.Any())
+            {
+                return targets.FirstOrDefault();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Dnx.Tooling/Restore/ProjectReferenceDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/ProjectReferenceDependencyProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Dnx.Tooling
             }
 
             // This never returns null
-            var targetFrameworkInfo = project.GetTargetFramework(targetFramework);
+            var targetFrameworkInfo = project.GetCompatibleTargetFramework(targetFramework);
 
             var dependencies = project.Dependencies.Concat(targetFrameworkInfo.Dependencies).ToList();
 

--- a/src/Microsoft.Dnx.Tooling/Utils/LockFileUtils.cs
+++ b/src/Microsoft.Dnx.Tooling/Utils/LockFileUtils.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Dnx.Tooling.Utils
         public static LockFileTargetLibrary CreateLockFileTargetLibrary(Runtime.Project projectDependency,
                                                                         RestoreContext context)
         {
-            var targetFrameworkInfo = projectDependency.GetTargetFramework(context.FrameworkName);
+            var targetFrameworkInfo = projectDependency.GetCompatibleTargetFramework(context.FrameworkName);
 
             var lockFileLib = new LockFileTargetLibrary
             {

--- a/test/Microsoft.Dnx.ApplicationHost.FunctionalTests/AppHostTests.cs
+++ b/test/Microsoft.Dnx.ApplicationHost.FunctionalTests/AppHostTests.cs
@@ -112,7 +112,14 @@ namespace Microsoft.Dnx.ApplicationHost
 
             using (var projectPath = TestUtils.CreateTempDir())
             {
-                DirTree.CreateFromJson(projectStructure).WriteTo(projectPath);
+                DirTree.CreateFromJson(projectStructure)
+                       .WithFileContents("project.json", @"
+{
+    ""frameworks"": {
+        ""dnx451"": { },
+        ""dnxcore50"": { }
+    }
+}").WriteTo(projectPath);
 
                 string stdOut, stdErr;
                 var exitCode = TestUtils.ExecBootstrapper(

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackTests.cs
@@ -287,6 +287,10 @@ public class TestClass : BaseClass {
         {
             var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
             var projectJson = @"{
+  ""frameworks"": {
+      ""dnx451"": { },
+      ""dnxcore50"": { }
+  },
   ""scripts"": {
     ""postbuild"": ""echo POST_BUILD_SCRIPT_OUTPUT"",
     ""postpack"": ""echo POST_PACK_SCRIPT_OUTPUT""

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/PackageManagerFunctionalTestFixture.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/PackageManagerFunctionalTestFixture.cs
@@ -60,7 +60,12 @@ namespace Microsoft.Dnx.Tooling.FunctionalTests
                 var outputDir = dir.CreateSubdirectory("output");
                 var projectJson = Path.Combine(projectDir.FullName, "project.json");
 
-                File.WriteAllText(projectJson, "{\"version\": \"" + version + "\"}");
+                File.WriteAllText(projectJson, $@"{{
+  ""version"": ""{version}"",
+  ""frameworks"": {{ 
+      ""dnx451"": {{ }}
+  }}
+}}");
                 DnuTestUtils.ExecDnu(runtimeHomePath, "restore", projectJson);
                 DnuTestUtils.ExecDnu(runtimeHomePath, "pack", projectJson + " --out " + outputDir.FullName, environment: null, workingDir: null);
 


### PR DESCRIPTION
This removes the last set of nuget code that the runtime uses to determine compatibility. All compatibility moves to restore and the runtime just reads the lock file to build a model. This is the final part of #2622

/cc @anurse 