### PR TITLE
Prune packages with --framework

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Building/BuildOptions.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/BuildOptions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Versioning;
+using Microsoft.Dnx.Runtime.Helpers;
 
 namespace Microsoft.Dnx.Tooling
 {
@@ -14,7 +16,7 @@ namespace Microsoft.Dnx.Tooling
 
         public IList<string> Configurations { get; set; }
 
-        public IList<string> TargetFrameworks { get;set; }
+        public IDictionary<FrameworkName, string> TargetFrameworks { get; private set; } = new Dictionary<FrameworkName, string>();
 
         public bool GeneratePackages { get; set; }
 
@@ -23,8 +25,18 @@ namespace Microsoft.Dnx.Tooling
         public BuildOptions()
         {
             Configurations = new List<string>();
-            TargetFrameworks = new List<string>();
             ProjectPatterns = new List<string>();
+        }
+
+        public void AddFrameworkMonikers(IEnumerable<string> monikers)
+        {
+            if (monikers != null)
+            {
+                foreach (var moniker in monikers.Distinct())
+                {
+                    TargetFrameworks.Add(FrameworkNameHelper.ParseFrameworkName(moniker), moniker);
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.Dnx.Tooling/ConsoleCommands/BuildConsoleCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/ConsoleCommands/BuildConsoleCommand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Dnx.Tooling
                         buildOptions.ProjectPatterns.Add(Path.Combine(Directory.GetCurrentDirectory(), "project.json"));
                     }
                     buildOptions.Configurations = optionConfiguration.Values;
-                    buildOptions.TargetFrameworks = optionFramework.Values;
+                    buildOptions.AddFrameworkMonikers(optionFramework.Values);
                     buildOptions.GeneratePackages = false;
                     buildOptions.Reports = reportsFactory.CreateReports(optionQuiet.HasValue());
 

--- a/src/Microsoft.Dnx.Tooling/ConsoleCommands/ListConsoleCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/ConsoleCommands/ListConsoleCommand.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Dnx.Tooling
 
                     var options = new DependencyListOptions(reportsFactory.CreateReports(verbose: true, quiet: false), argProject)
                     {
-                        TargetFrameworks = frameworks.Values,
                         ShowAssemblies = showAssemblies.HasValue(),
                         RuntimeFolder = runtimeFolder.Value(),
                         Details = details.HasValue(),
                         ResultsFilter = resultsFilter.Value()
                     };
+                    options.AddFrameworkMonikers(frameworks.Values);
 
                     if (!options.Valid)
                     {

--- a/src/Microsoft.Dnx.Tooling/ConsoleCommands/PackConsoleCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/ConsoleCommands/PackConsoleCommand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Dnx.Tooling
                         buildOptions.ProjectPatterns.Add(Path.Combine(Directory.GetCurrentDirectory(), "project.json"));
                     }
                     buildOptions.Configurations = optionConfiguration.Values;
-                    buildOptions.TargetFrameworks = optionFramework.Values;
+                    buildOptions.AddFrameworkMonikers(optionFramework.Values);
                     buildOptions.GeneratePackages = true;
                     buildOptions.Reports = reportsFactory.CreateReports(optionQuiet.HasValue());
 

--- a/src/Microsoft.Dnx.Tooling/List/DependencyListOptions.cs
+++ b/src/Microsoft.Dnx.Tooling/List/DependencyListOptions.cs
@@ -3,7 +3,10 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
+using Microsoft.Dnx.Runtime.Helpers;
 
 namespace Microsoft.Dnx.Tooling.List
 {
@@ -37,12 +40,23 @@ namespace Microsoft.Dnx.Tooling.List
 
         public bool ShowAssemblies { get; set; }
 
-        public IEnumerable<string> TargetFrameworks { get; set; }
+        public IDictionary<FrameworkName, string> TargetFrameworks { get; private set; } = new Dictionary<FrameworkName, string>();
 
         public bool Details { get; set; }
 
         public string ResultsFilter { get; set; }
 
         public Reports Reports { get; }
+
+        public void AddFrameworkMonikers(IEnumerable<string> monikers)
+        {
+            if (monikers != null)
+            {
+                foreach (var moniker in monikers.Distinct())
+                {
+                    TargetFrameworks.Add(FrameworkNameHelper.ParseFrameworkName(moniker), moniker);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishOptions.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishOptions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Versioning;
+using Microsoft.Dnx.Runtime.Helpers;
 
 namespace Microsoft.Dnx.Tooling.Publish
 {
@@ -18,16 +20,29 @@ namespace Microsoft.Dnx.Tooling.Publish
 
         public string WwwRootOut { get; set; }
 
-        public FrameworkName RuntimeTargetFramework { get; set; }
+        public FrameworkName RuntimeActiveFramework { get; set; }
 
         public bool NoSource { get; set; }
 
         public IList<string> Runtimes { get; set; }
+
+        public IDictionary<FrameworkName, string> TargetFrameworks { get; private set; } = new Dictionary<FrameworkName, string>();
 
         public bool Native { get; set; }
 
         public bool IncludeSymbols { get; set; }
 
         public Reports Reports { get; set; }
+
+        public void AddFrameworkMonikers(IEnumerable<string> monikers)
+        {
+            if (monikers != null)
+            {
+                foreach (var moniker in monikers.Distinct())
+                {
+                    TargetFrameworks.Add(FrameworkNameHelper.ParseFrameworkName(moniker), moniker);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
@@ -126,6 +126,12 @@ namespace Microsoft.Dnx.Tooling.Publish
             buildOptions.GeneratePackages = true;
             buildOptions.Reports = root.Reports.ShallowCopy();
 
+            if (root.Frameworks.Any())
+            {
+                // Make sure we only emit the nupkgs for the specified frameworks
+                buildOptions.TargetFrameworks.AddRange(root.Frameworks);
+            }
+
             // Mute "dnu pack" completely if it is invoked by "dnu publish --quiet"
             buildOptions.Reports.Information = root.Reports.Quiet;
 
@@ -421,9 +427,9 @@ namespace Microsoft.Dnx.Tooling.Publish
 
             var restoreCommand = new RestoreCommand(appEnv);
 
-            foreach (var runtime in root.Runtimes)
+            foreach (var framework in root.Frameworks)
             {
-                restoreCommand.TargetFrameworks.Add(publishProject.SelectFrameworkForRuntime(runtime));
+                restoreCommand.TargetFrameworks.Add(framework.Key);
             }
 
             restoreCommand.SkipRestoreEvents = true;

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishRoot.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishRoot.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.Dnx.Runtime;
 using Newtonsoft.Json.Linq;
@@ -25,6 +26,7 @@ namespace Microsoft.Dnx.Tooling.Publish
             Projects = new List<PublishProject>();
             Packages = new List<PublishPackage>();
             Runtimes = new List<PublishRuntime>();
+            Frameworks = new Dictionary<FrameworkName, string>();
             OutputPath = outputPath;
             HostServices = hostServices;
             TargetPackagesPath = Path.Combine(outputPath, AppRootName, "packages");
@@ -42,6 +44,7 @@ namespace Microsoft.Dnx.Tooling.Publish
         public string Configuration { get; set; }
 
         public IList<PublishRuntime> Runtimes { get; set; }
+        public IDictionary<FrameworkName, string> Frameworks { get; set; }
         public IList<PublishProject> Projects { get; private set; }
         public IList<PublishPackage> Packages { get; private set; }
 
@@ -120,7 +123,7 @@ namespace Microsoft.Dnx.Tooling.Publish
 
                 File.WriteAllText(
                     Path.Combine(OutputPath, commandName + ".cmd"),
-                    string.Format(template, 
+                    string.Format(template,
                                   runtimeFolder,
                                   Runtime.Constants.BootstrapperExeName,
                                   relativeAppBase,
@@ -167,11 +170,11 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Dnx.ApplicationHost --configuration
 
                 var scriptPath = Path.Combine(OutputPath, commandName);
                 File.WriteAllText(scriptPath,
-                    string.Format(template, 
+                    string.Format(template,
                                   EnvironmentNames.AppBase,
                                   relativeAppBase,
                                   runtimeFolder,
-                                  Runtime.Constants.BootstrapperExeName, 
+                                  Runtime.Constants.BootstrapperExeName,
                                   Configuration,
                                   commandName).Replace("\r\n", "\n"));
 

--- a/src/Microsoft.Dnx.Tooling/Utils/FrameworkSelectionHelper.cs
+++ b/src/Microsoft.Dnx.Tooling/Utils/FrameworkSelectionHelper.cs
@@ -12,12 +12,10 @@ namespace Microsoft.Dnx.Tooling.Utils
     public static class FrameworkSelectionHelper
     {
         public static IEnumerable<FrameworkName> SelectFrameworks(Runtime.Project project,
-                                                                  IEnumerable<string> userSelection,
+                                                                  IDictionary<FrameworkName, string> specifiedFrameworks,
                                                                   FrameworkName fallbackFramework,
                                                                   out string errorMessage)
         {
-            var specifiedFrameworks = userSelection.ToDictionary(f => f, FrameworkNameHelper.ParseFrameworkName);
-
             var projectFrameworks = new HashSet<FrameworkName>(
                 project.GetTargetFrameworks()
                        .Select(c => c.FrameworkName));
@@ -32,7 +30,7 @@ namespace Microsoft.Dnx.Tooling.Utils
                     return null;
                 }
 
-                frameworks = specifiedFrameworks.Count > 0 ? specifiedFrameworks.Values : (IEnumerable<FrameworkName>)projectFrameworks;
+                frameworks = specifiedFrameworks.Count > 0 ? specifiedFrameworks.Keys : (IEnumerable<FrameworkName>)projectFrameworks;
             }
             else
             {
@@ -44,14 +42,14 @@ namespace Microsoft.Dnx.Tooling.Utils
         }
 
         private static bool ValidateFrameworks(HashSet<FrameworkName> projectFrameworks,
-                                               IDictionary<string, FrameworkName> specifiedFrameworks,
+                                               IDictionary<FrameworkName, string> specifiedFrameworks,
                                                out string errorMessage)
         {
             foreach (var framework in specifiedFrameworks)
             {
-                if (!projectFrameworks.Contains(framework.Value))
+                if (!projectFrameworks.Contains(framework.Key))
                 {
-                    errorMessage = framework.Key + " is not specified in project.json";
+                    errorMessage = framework.Value + " is not specified in project.json";
                     return false;
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/aspnet/dnx/issues/2640
Fixes https://github.com/aspnet/dnx/issues/2428

- Dnu publish should have an option to prune packages when the runtime flag is not passed.
- Dnu publish --no-source doesn't remove tfms for the projects being compiled 

Similar to `--runtime` but allows publishing just a set of target frameworks without runtime.

Also fixed a publish bug when you run `--no-source` and you get too many frameworks.

Please review: @BrennanConroy @davidfowl @anurse 
