### PR TITLE
Add support for generating portable pdbs

### DIFF
--- a/src/Microsoft.Dnx.Runtime.Sources/Impl/EnvironmentNames.cs
+++ b/src/Microsoft.Dnx.Runtime.Sources/Impl/EnvironmentNames.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Dnx.Runtime
         public const string DefaultLib = "DNX_DEFAULT_LIB";
         public const string BuildKeyFile = "DNX_BUILD_KEY_FILE";
         public const string BuildDelaySign = "DNX_BUILD_DELAY_SIGN";
+        public const string PortablePdb = "DNX_BUILD_PORTABLE_PDB";
         public const string Sources = "DNX_SOURCES";
         public const string DnxIsWindows = "DNX_IS_WINDOWS";
         public const string AspNetLoaderPath = "DNX_ASPNET_LOADER_PATH";

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPackTests.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Dnx.CommonTestUtils;
+using NuGet;
 using Xunit;
 
 namespace Microsoft.Dnx.Tooling
@@ -162,6 +164,52 @@ public class TestClass : BaseClass {
             }
         }
 
+        [ConditionalTheory]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [MemberData(nameof(RuntimeComponents))]
+        public void DnuPack_PortablePdbsGeneratedWhenEnvVariableSet(string flavor, string os, string architecture)
+        {
+            string stdOut;
+            string stdError;
+            var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);
+            int exitCode;
+
+            using (var testEnv = new DnuTestEnvironment(runtimeHomeDir))
+            {
+                var appName = PathUtility.GetDirectoryName(testEnv.RootDir);
+                File.WriteAllText($"{testEnv.RootDir}/project.json",
+                @"{
+                    ""frameworks"": {
+                        ""dnx451"": {
+                        }
+                    }
+                  }");
+
+                var environment = new Dictionary<string, string> { { "DNX_TRACE", "0" }, { "DNX_BUILD_PORTABLE_PDB", "1" } };
+                DnuTestUtils.ExecDnu(runtimeHomeDir,
+                                     "restore",
+                                     "",
+                                     out stdOut,
+                                     out stdError,
+                                     environment: null,
+                                     workingDir: testEnv.RootDir);
+
+                exitCode = DnuTestUtils.ExecDnu(runtimeHomeDir,
+                                                "pack",
+                                                "",
+                                                out stdOut,
+                                                out stdError,
+                                                environment,
+                                                testEnv.RootDir);
+
+                var outputDir = Path.Combine(testEnv.RootDir, "bin", "Debug", "dnx451");
+                Assert.Equal(0, exitCode);
+                Assert.True(Directory.Exists(outputDir));
+                Assert.True(File.Exists(Path.Combine(outputDir, appName + ".dll")));
+                Assert.True(File.Exists(Path.Combine(outputDir, appName + ".pdb")));
+            }
+        }
+
         [Theory]
         [MemberData(nameof(RuntimeComponents))]
         public void DnuPack_OutPathSpecified(string flavor, string os, string architecture)
@@ -223,7 +271,7 @@ public class TestClass : BaseClass {
                     .WriteTo(testEnv.ProjectPath);
 
                 exitCode = DnuTestUtils.ExecDnu(
-                    runtimeHomeDir, 
+                    runtimeHomeDir,
                     subcommand: "restore",
                     arguments: string.Empty,
                     workingDir: testEnv.ProjectPath);
@@ -275,7 +323,7 @@ public class TestClass : BaseClass {
                     arguments: string.Empty,
                     workingDir: testEnv.ProjectPath);
                 Assert.Equal(0, exitCode);
-                
+
                 Assert.True(File.Exists(Path.Combine(testEnv.ProjectPath, "bin", "Debug", $"{projectName}.1.0.0-beta.nupkg")));
                 Assert.True(File.Exists(Path.Combine(testEnv.ProjectPath, "bin", "Debug", $"{projectName}.1.0.0-beta.symbols.nupkg")));
             }


### PR DESCRIPTION
- Added support for emitting portable PDBs when the pdb generation isn't available
- Added support for env variable DNX_BUILD_PORTABLE_PDB to forcefully turn on ppdb generation

