### PR TITLE
Check for min runtime version at application start

### DIFF
--- a/src/Microsoft.Dnx.Runtime.Sources/Impl/EnvironmentNames.cs
+++ b/src/Microsoft.Dnx.Runtime.Sources/Impl/EnvironmentNames.cs
@@ -23,5 +23,6 @@ namespace Microsoft.Dnx.Runtime
         public const string PortablePdb = "DNX_BUILD_PORTABLE_PDB";
         public const string DnxIsWindows = "DNX_IS_WINDOWS";
         public const string AspNetLoaderPath = "DNX_ASPNET_LOADER_PATH";
+        public const string DnxDisableMinVersionCheck = "DNX_NO_MIN_VERSION_CHECK";
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/aspnet/dnx/issues/2197

- The error shows up only on run
- The error doesn't show up on build so you can build with an older runtime
- No tests because this is super hard to test
- Most of the change is passing IRuntimeEnvironment up the stack

please review @davidfowl @anurse 

