### PR TITLE
Sleep for 1 second before try deleting the directory

### DIFF
--- a/test/Microsoft.Dnx.CommonTestUtils/TestUtils.cs
+++ b/test/Microsoft.Dnx.CommonTestUtils/TestUtils.cs
@@ -12,6 +12,7 @@ using Microsoft.Dnx.Tooling;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Infrastructure;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 
 namespace Microsoft.Dnx.CommonTestUtils
 {
@@ -358,6 +359,8 @@ namespace Microsoft.Dnx.CommonTestUtils
                     {
                         throw;
                     }
+
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
                 }
             }
         }


### PR DESCRIPTION
Address a test failure on CI.

The exception was thrown when deleting the temporarily folder for test project. The failure happened randomly and can't be repo locally. The process held the folder was killed before, but whether the process was terminated timely before the deletion was undetermined. 

This change is expected to gives the file system more time to respond.

I'll merge this change soon since it is supposed to fix build break.

/cc @BrennanConroy @victorhurdugaci @davidfowl @muratg 