### PR TITLE
Add property 'Resolved' to DependencyDescription

### DIFF
--- a/misc/DthTestProjects/IncompatiblePackageSample/project.json
+++ b/misc/DthTestProjects/IncompatiblePackageSample/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "Newtonsoft.Json": "4.5.11"
+  },
+  "frameworks": {
+    "dnxcore50": { }
+  }
+}

--- a/misc/DthTestProjects/UnresolvedPackageSample/project.json
+++ b/misc/DthTestProjects/UnresolvedPackageSample/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": { 
+    "NoSuchPackage": "1.0.0"
+  },
+  "frameworks": {
+    "dnx451": { }
+  }
+}

--- a/misc/DthTestProjects/UnresolvedProjectSample/project.json
+++ b/misc/DthTestProjects/UnresolvedProjectSample/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": { 
+    "EmptyLibrary": ""
+  },
+  "frameworks": {
+    "dnx451": { }
+  }
+}

--- a/src/Microsoft.Dnx.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/ApplicationContext.cs
@@ -1150,14 +1150,8 @@ namespace Microsoft.Dnx.DesignTimeHost
 
                 foreach (var library in applicationHostContext.LibraryManager.GetLibraryDescriptions())
                 {
-                    var description = CreateDependencyDescription(library);
+                    var description = CreateDependencyDescription(library, ProtocolVersion);
                     info.Dependencies[description.Name] = description;
-
-                    // Skip unresolved libraries
-                    if (!library.Resolved)
-                    {
-                        continue;
-                    }
 
                     if (string.Equals(library.Type, LibraryTypes.Project) &&
                        !string.Equals(library.Identity.Name, project.Name))
@@ -1233,14 +1227,15 @@ namespace Microsoft.Dnx.DesignTimeHost
             return Path.GetFullPath(Path.Combine(referencedProject.ProjectDirectory, path));
         }
 
-        private static DependencyDescription CreateDependencyDescription(LibraryDescription library)
+        private static DependencyDescription CreateDependencyDescription(LibraryDescription library, int protocolVersion)
         {
-            return new DependencyDescription
+            var result = new DependencyDescription
             {
                 Name = library.Identity.Name,
                 DisplayName = library.Identity.IsGacOrFrameworkReference ? library.RequestedRange.GetReferenceAssemblyName() : library.Identity.Name,
                 Version = library.Identity.Version?.ToString(),
-                Type = library.Resolved ? library.Type : "Unresolved",
+                Type = library.Type,
+                Resolved = library.Resolved,
                 Path = library.Path,
                 Dependencies = library.Dependencies.Select(dependency => new DependencyItem
                 {
@@ -1248,6 +1243,13 @@ namespace Microsoft.Dnx.DesignTimeHost
                     Version = dependency.Library?.Identity?.Version?.ToString()
                 })
             };
+
+            if (protocolVersion < 3 && !library.Resolved)
+            {
+                result.Type = "Unresolved";
+            }
+
+            return result;
         }
 
         private static string GetValue(JToken token, string name)

--- a/src/Microsoft.Dnx.DesignTimeHost/Models/OutgoingMessages/DependencyDescription.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/Models/OutgoingMessages/DependencyDescription.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Dnx.DesignTimeHost.Models.OutgoingMessages
     public class DependencyDescription
     {
         public string Name { get; set; }
-        
+
         public string DisplayName { get; set; }
 
         public string Version { get; set; }
@@ -18,6 +18,8 @@ namespace Microsoft.Dnx.DesignTimeHost.Models.OutgoingMessages
 
         public string Type { get; set; }
 
+        public bool Resolved { get; set; }
+
         public IEnumerable<DependencyItem> Dependencies { get; set; }
 
         public override bool Equals(object obj)
@@ -25,6 +27,7 @@ namespace Microsoft.Dnx.DesignTimeHost.Models.OutgoingMessages
             var other = obj as DependencyDescription;
 
             return other != null &&
+                   Resolved == other.Resolved &&
                    string.Equals(Name, other.Name) &&
                    object.Equals(Version, other.Version) &&
                    string.Equals(Path, other.Path) &&

--- a/src/Microsoft.Dnx.DesignTimeHost/Program.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/Program.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Dnx.DesignTimeHost
         private async Task OpenChannel(int port, string hostId)
         {
             var contexts = new Dictionary<int, ApplicationContext>();
-            var protocolManager = new ProtocolManager(maxVersion: 2);
+            var protocolManager = new ProtocolManager(maxVersion: 3);
 
             // REVIEW: Should these be on a shared context object that flows?
             var applicationEnvironment = (IApplicationEnvironment)_services.GetService(typeof(IApplicationEnvironment));
@@ -77,7 +77,7 @@ namespace Microsoft.Dnx.DesignTimeHost
             Console.WriteLine($"Process ID {Process.GetCurrentProcess().Id}");
             Console.WriteLine("Listening on port {0}", port);
 
-            for (; ;)
+            while (true)
             {
                 var acceptSocket = await AcceptAsync(listenSocket);
 

--- a/test/Microsoft.Dnx.DesignTimeHost.FunctionalTests/Infrastructure/DthTestClient.cs
+++ b/test/Microsoft.Dnx.DesignTimeHost.FunctionalTests/Infrastructure/DthTestClient.cs
@@ -71,9 +71,24 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests.Infrastructure
             SendPayLoad("Initialize", new { ProjectFolder = projectPath });
         }
 
+        public void Initialize(string projectPath, int protocolVersion)
+        {
+            SendPayLoad("Initialize", new { ProjectFolder = projectPath, Version = protocolVersion });
+        }
+
+        public void Initialize(string projectPath, int protocolVersion, string configuration)
+        {
+            SendPayLoad("Initialize", new { ProjectFolder = projectPath, Version = protocolVersion, Configuration = configuration });
+        }
+
         public void SetProtocolVersion(int version)
         {
             SendPayLoad(ProtocolManager.NegotiationMessageTypeName, new { Version = version });
+        }
+
+        public List<DthMessage> DrainAllMessages()
+        {
+            return DrainAllMessages(TimeSpan.FromSeconds(10));
         }
 
         /// <summary>


### PR DESCRIPTION
Addressing: #2405 

/cc @abpiskunov: this will break current DTH protocol need VS side change.

Add a new boolean property `Resolved` to the dependency description in DTH response. Alter the `Type` property to represent the type of the unresolved dependency. For __project__ dependency the type will become `"Project"`. However for __package__ it is still `"Unresolved"` since the `UnresolvedDependencyResolver` can't determine the actual type.