### PR TITLE
Generate an unresolved ProjectDescription for unresolved path

### DIFF
--- a/misc/DthTestProjects/BrokenProjectPathSample/project.json
+++ b/misc/DthTestProjects/BrokenProjectPathSample/project.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": {
+        "EmptyLibrary": ""
+    },
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/src/Microsoft.Dnx.Compilation/LibraryExporter.cs
+++ b/src/Microsoft.Dnx.Compilation/LibraryExporter.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Dnx.Compilation
                 {
                     var childNode = new Node
                     {
-                        Library =  dependency.Library,
+                        Library = dependency.Library,
                         Parent = node
                     };
 
@@ -234,10 +234,9 @@ namespace Microsoft.Dnx.Compilation
                 // Create the compilation context
                 var compilationContext = project.Project.ToCompilationContext(project.Framework, _configuration, aspect);
 
-                if (!string.IsNullOrEmpty(project.TargetFrameworkInfo.AssemblyPath))
+                if (!string.IsNullOrEmpty(project.TargetFrameworkInfo?.AssemblyPath))
                 {
                     // Project specifies a pre-compiled binary. We're done!
-
                     var assemblyPath = ResolvePath(project.Project, _configuration, project.TargetFrameworkInfo.AssemblyPath);
                     var pdbPath = ResolvePath(project.Project, _configuration, project.TargetFrameworkInfo.PdbPath);
 

--- a/src/Microsoft.Dnx.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/ApplicationContext.cs
@@ -1041,6 +1041,11 @@ namespace Microsoft.Dnx.DesignTimeHost
                 // Add shared files from projects
                 foreach (var reference in dependencyInfo.ProjectReferences)
                 {
+                    if (reference.Project == null)
+                    {
+                        continue;
+                    }
+
                     // Only add direct dependencies as sources
                     if (!project.Dependencies.Any(d => string.Equals(d.Name, reference.Name, StringComparison.OrdinalIgnoreCase)))
                     {
@@ -1161,10 +1166,11 @@ namespace Microsoft.Dnx.DesignTimeHost
                         var targetFrameworkInformation = referencedProject.TargetFrameworkInfo;
 
                         // If this is an assembly reference then treat it like a file reference
-                        if (!string.IsNullOrEmpty(targetFrameworkInformation.AssemblyPath) &&
-                            string.IsNullOrEmpty(targetFrameworkInformation.WrappedProject))
+                        if (!string.IsNullOrEmpty(targetFrameworkInformation?.AssemblyPath) &&
+                             string.IsNullOrEmpty(targetFrameworkInformation?.WrappedProject))
                         {
-                            string assemblyPath = GetProjectRelativeFullPath(referencedProject.Project, targetFrameworkInformation.AssemblyPath);
+                            string assemblyPath = GetProjectRelativeFullPath(referencedProject.Project,
+                                                                             targetFrameworkInformation.AssemblyPath);
                             info.References.Add(assemblyPath);
 
                             description.Path = assemblyPath;
@@ -1174,7 +1180,8 @@ namespace Microsoft.Dnx.DesignTimeHost
                         {
                             string wrappedProjectPath = null;
 
-                            if (!string.IsNullOrEmpty(targetFrameworkInformation.WrappedProject))
+                            if (!string.IsNullOrEmpty(targetFrameworkInformation?.WrappedProject) &&
+                                referencedProject.Project != null)
                             {
                                 wrappedProjectPath = GetProjectRelativeFullPath(referencedProject.Project, targetFrameworkInformation.WrappedProject);
                             }

--- a/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Dnx.Runtime
             var packageResolver = new PackageDependencyProvider(context.PackagesDirectory);
             var projectResolver = new ProjectDependencyProvider();
 
-            context.MainProject = projectResolver.GetDescription(context.TargetFramework, context.Project); ;
+            context.MainProject = projectResolver.GetDescription(context.TargetFramework, context.Project);
 
             // Add the main project
             libraries.Add(context.MainProject);
@@ -194,7 +194,7 @@ namespace Microsoft.Dnx.Runtime
 
                             var path = Path.GetFullPath(Path.Combine(context.ProjectDirectory, projectLibrary.Path));
 
-                            var projectDescription = projectResolver.GetDescription(path, library);
+                            var projectDescription = projectResolver.GetDescription(library.Name, path, library);
 
                             libraries.Add(projectDescription);
                         }

--- a/src/Microsoft.Dnx.Runtime/Compilation/CompilerOptionsProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/Compilation/CompilerOptionsProvider.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Dnx.Runtime.Compilation
             ProjectDescription projectDescription;
             if (_projects.TryGetValue(projectName, out projectDescription))
             {
-                return projectDescription.Project.GetCompilerOptions(targetFramework, configurationName);
+                if (projectDescription.Resolved)
+                {
+                    return projectDescription.Project.GetCompilerOptions(targetFramework, configurationName);
+                }
             }
 
             return new CompilerOptions();

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDependencyProvider.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using NuGet;
@@ -12,14 +10,14 @@ namespace Microsoft.Dnx.Runtime
 {
     public class ProjectDependencyProvider
     {
-        public ProjectDescription GetDescription(string path, LockFileTargetLibrary targetLibrary)
+        public ProjectDescription GetDescription(string name, string path, LockFileTargetLibrary targetLibrary)
         {
             Project project;
 
             // Can't find a project file with the name so bail
             if (!Project.TryGetProject(path, out project))
             {
-                return null;
+                return new ProjectDescription(name, path);
             }
 
             return GetDescription(targetLibrary.TargetFramework, project);

--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDescription.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/ProjectDescription.cs
@@ -1,10 +1,31 @@
-﻿using System.Collections.Generic;
-using System.Runtime.Versioning;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Dnx.Runtime
 {
     public class ProjectDescription : LibraryDescription
     {
+        /// <summary>
+        /// Constructs a unresolved project description
+        /// </summary>
+        public ProjectDescription(string name, string path)
+            : base(new LibraryRange(name, frameworkReference: false),
+                   new LibraryIdentity(name, new NuGet.SemanticVersion("1.0.0"), isGacOrFrameworkReference: false),
+                   path: path,
+                   type: LibraryTypes.Project,
+                   dependencies: Enumerable.Empty<LibraryDependency>(),
+                   assemblies: Enumerable.Empty<string>(),
+                   framework: null)
+        {
+            Project = null;
+            Resolved = false;
+            Compatible = false;
+            TargetFrameworkInfo = null;
+        }
+
         public ProjectDescription(
             LibraryRange libraryRange,
             Project project,
@@ -28,6 +49,7 @@ namespace Microsoft.Dnx.Runtime
         }
 
         public Project Project { get; }
+
         public TargetFrameworkInformation TargetFrameworkInfo { get; }
     }
 }

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Dnx.Tooling.Publish
             }
             else
             {
-                EmitSource(root);
+                success = EmitSource(root);
             }
 
             root.Reports.Quiet.WriteLine();
@@ -54,12 +54,17 @@ namespace Microsoft.Dnx.Tooling.Publish
             return success;
         }
 
-        private void EmitSource(PublishRoot root)
+        private bool EmitSource(PublishRoot root)
         {
             root.Reports.Quiet.WriteLine("  Copying source code from {0} dependency {1}",
                 _projectDescription.Type, _projectDescription.Identity.Name);
 
             var project = GetCurrentProject();
+            if (project == null)
+            {
+                return false;
+            }
+
             var targetName = project.Name;
             TargetPath = Path.Combine(
                 root.OutputPath,
@@ -85,6 +90,8 @@ namespace Microsoft.Dnx.Tooling.Publish
 
             _relativeAppBase = Path.Combine("..", appBase);
             ApplicationBasePath = Path.Combine(root.OutputPath, appBase);
+
+            return true;
         }
 
         private bool EmitNupkg(PublishRoot root)
@@ -95,6 +102,11 @@ namespace Microsoft.Dnx.Tooling.Publish
             IsPackage = true;
 
             var project = GetCurrentProject();
+            if (project == null)
+            {
+                return false;
+            }
+
             var resolver = new DefaultPackagePathResolver(root.TargetPackagesPath);
             var targetNupkg = resolver.GetPackageFileName(project.Name, project.Version);
             TargetPath = resolver.GetInstallPath(project.Name, project.Version);


### PR DESCRIPTION
/review @anurse @davidfowl 
/cc @rynowak @victorhurdugaci 

Addressing issue #2729 

The change is kind of patchy, but it does fix the problem. The type `ProjectDescription` and `LibraryDescription` can be potentially optimized in the future to simplify the creation. Otherwise for adding a unresolved project I need to add an additional constructor.

The fix solves the issue in both VS and Console.

I'm working on a functional test to cover the case.