### PR TITLE
fix #2467 by selecting appropriate project frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ project.lock.json
 version.h
 
 # Profiler result files, just in case they are left lying around :)
-/.vs/
+.vs/

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/NuGet.Config
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/NuGet.Config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/WrapAndPublish.sln
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/WrapAndPublish.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FBCDEF69-25F8-4FD2-9DBE-F6EE381626EC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D18DB967-84D6-48EF-ABE4-3EC6D44ECAFB}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		NuGet.Config = NuGet.Config
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DnxConsoleApp", "src\DnxConsoleApp\DnxConsoleApp.xproj", "{2C0376F3-9F4C-492A-A3AE-C2BE5DF07CB5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "src\ClassLibrary\ClassLibrary.csproj", "{568302CD-EF88-4920-95FB-0F3839EFB8D1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2C0376F3-9F4C-492A-A3AE-C2BE5DF07CB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C0376F3-9F4C-492A-A3AE-C2BE5DF07CB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C0376F3-9F4C-492A-A3AE-C2BE5DF07CB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C0376F3-9F4C-492A-A3AE-C2BE5DF07CB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{568302CD-EF88-4920-95FB-0F3839EFB8D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{568302CD-EF88-4920-95FB-0F3839EFB8D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{568302CD-EF88-4920-95FB-0F3839EFB8D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{568302CD-EF88-4920-95FB-0F3839EFB8D1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2C0376F3-9F4C-492A-A3AE-C2BE5DF07CB5} = {FBCDEF69-25F8-4FD2-9DBE-F6EE381626EC}
+		{568302CD-EF88-4920-95FB-0F3839EFB8D1} = {FBCDEF69-25F8-4FD2-9DBE-F6EE381626EC}
+	EndGlobalSection
+EndGlobal

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/global.json
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/global.json
@@ -1,0 +1,7 @@
+{
+  "projects": [
+    "src",
+    "test",
+    "wrap"
+  ]
+}

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/ClassLibrary.csproj
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/ClassLibrary.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{568302CD-EF88-4920-95FB-0F3839EFB8D1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ClassLibrary</RootNamespace>
+    <AssemblyName>ClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Helper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/Helper.cs
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/Helper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ClassLibrary
+{
+    public static class Helper
+    {
+        public static string GetMessage()
+        {
+            return "Hello from the wrapped project";
+        }
+    }
+}

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/Properties/AssemblyInfo.cs
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("568302cd-ef88-4920-95fb-0f3839efb8d1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/src/DnxConsoleApp/DnxConsoleApp.xproj
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/src/DnxConsoleApp/DnxConsoleApp.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2c0376f3-9f4c-492a-a3ae-c2be5df07cb5</ProjectGuid>
+    <RootNamespace>DnxConsoleApp</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/src/DnxConsoleApp/Program.cs
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/src/DnxConsoleApp/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ClassLibrary;
+
+namespace DnxConsoleApp
+{
+    public class Program
+    {
+        public void Main(string[] args)
+        {
+            Console.WriteLine(Helper.GetMessage());
+        }
+    }
+}

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/src/DnxConsoleApp/project.json
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/src/DnxConsoleApp/project.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0.0-*",
+  "description": "DnxConsoleApp Console Application",
+  "authors": [ "anurse" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+
+  "dependencies": {
+  },
+
+  "commands": {
+    "DnxConsoleApp": "DnxConsoleApp"
+  },
+
+  "frameworks": {
+    "dnx451": {
+        "dependencies": {
+            "ClassLibrary": "1.0.0-*"
+        }
+    }
+  }
+}

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/wrap/ClassLibrary/project.json
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/wrap/ClassLibrary/project.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0-*",
+  "frameworks": {
+    "net451": {
+      "wrappedProject": "../../src/ClassLibrary/ClassLibrary.csproj",
+      "bin": {
+        "assembly": "../../src/ClassLibrary/obj/{configuration}/ClassLibrary.dll",
+        "pdb": "../../src/ClassLibrary/obj/{configuration}/ClassLibrary.pdb"
+      }
+    }
+  }
+}

--- a/test/Microsoft.Dnx.Testing.CommonUtils/DnxSdk/Dnu.cs
+++ b/test/Microsoft.Dnx.Testing.CommonUtils/DnxSdk/Dnu.cs
@@ -34,6 +34,15 @@ namespace Microsoft.Dnx.Testing
         }
 
         public ExecResult Restore(
+            Project project,
+            string packagesDir = null,
+            IEnumerable<string> feeds = null,
+            string additionalArguments = null)
+        {
+            return Restore(project.ProjectDirectory, packagesDir, feeds, additionalArguments);
+        }
+
+        public ExecResult Restore(
             string restoreDir,
             string packagesDir = null,
             IEnumerable<string> feeds = null,

--- a/test/Microsoft.Dnx.Testing.CommonUtils/DnxSdkFunctionalTestBase.cs
+++ b/test/Microsoft.Dnx.Testing.CommonUtils/DnxSdkFunctionalTestBase.cs
@@ -59,8 +59,7 @@ namespace Microsoft.Dnx.Testing
             }
         }
 
-
-        private static DnxSdk GetRuntime(string flavor, string os, string arch)
+        public static DnxSdk GetRuntime(string flavor, string os, string arch)
         {
             var dnxSolutionRoot = ProjectRootResolver.ResolveRootDirectory(Directory.GetCurrentDirectory());
             var runtimeHome = Path.Combine(dnxSolutionRoot, "artifacts", "test", DnxSdk.GetRuntimeName(flavor, os, arch));

--- a/test/Microsoft.Dnx.Testing.CommonUtils/Solution.cs
+++ b/test/Microsoft.Dnx.Testing.CommonUtils/Solution.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Dnx.Testing
         public string GetWrapperProjectPath(string name)
         {
             var path = Path.Combine(WrapFolderPath, name, Project.ProjectFileName);
-            if (!Directory.Exists(path))
+            if (!File.Exists(path))
             {
                 throw new InvalidOperationException($"Unable to find wrapper project {path}");
             }

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests2.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests2.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Runtime.Versioning;
+using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Helpers;
 using Microsoft.Dnx.Testing;
@@ -15,6 +17,35 @@ namespace Microsoft.Dnx.Tooling.FunctionalTests
     [Collection(nameof(ToolingFunctionalTestCollection))]
     public class DnuPublishTests2 : DnxSdkFunctionalTestBase
     {
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)] // This needs msbuild to run
+        [MemberData(nameof(DnxSdks))]
+        public void PublishWrappedProjectForSpecificFramework(DnxSdk sdk)
+        {
+            var solutionName = Path.Combine("DnuWrapTestSolutions", "WrapAndPublish");
+            var solution = TestUtils.GetSolution<DnuPublishTests2>(sdk, solutionName);
+
+            // Restore the wrapper project
+            sdk.Dnu.Restore(solution.GetWrapperProjectPath("ClassLibrary")).EnsureSuccess();
+            sdk.Dnu.Restore(solution.GetProject("DnxConsoleApp")).EnsureSuccess();
+
+            // Build the console app
+            Exec.Run("msbuild", "", workingDir: Path.Combine(solution.SourcePath, "ClassLibrary")).EnsureSuccess(); ;
+
+            // Publish the console app
+            sdk.Dnu.Publish(solution.GetProject("DnxConsoleApp").ProjectFilePath, solution.ArtifactsPath, "--framework dnx451").EnsureSuccess();
+
+            // Get an SDK we can use the RUN the wrapped project (it has to be CLR because the project only supports dnx451)
+            var clrSdk = GetRuntime("clr", "win", "x86");
+
+            // Run it
+            var outputPath = Path.Combine(solution.ArtifactsPath, "approot", "src", "DnxConsoleApp");
+            var result = clrSdk.Dnx.Execute(
+                commandLine: $"--appbase \"{outputPath}\" Microsoft.Dnx.ApplicationHost --configuration Debug DnxConsoleApp run")
+                .EnsureSuccess();
+            Assert.Equal($"Hello from the wrapped project{Environment.NewLine}", result.StandardOutput);
+        }
+
         [Theory]
         [MemberData(nameof(DnxSdks))]
         public void GlobalJsonInProjectDir(DnxSdk sdk)


### PR DESCRIPTION
Fixed a bug when publishing with "--framework". Previously we just passed that framework to all projects being built, including those that don't directly support it (but rather support a compatible framework). This change ensures we select an appropriate framework from the project itself before building.

Fixes #2467 

/cc @davidfowl @troydai @halter73 