### PR TITLE
Remove SkipLockFileValidation from ApplicationContext

### DIFF
--- a/src/Microsoft.Dnx.Compilation/CompilationEngine.cs
+++ b/src/Microsoft.Dnx.Compilation/CompilationEngine.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Dnx.Compilation
             return null;
         }
 
-        public LibraryExporter CreateProjectExporter(Project project, FrameworkName targetFramework, string configuration, bool skipLockfileValidation = false)
+        public LibraryExporter CreateProjectExporter(Project project, FrameworkName targetFramework, string configuration)
         {
             // This library manager represents the graph that will be used to resolve
             // references (compiler /r in csc terms)
@@ -54,13 +54,12 @@ namespace Microsoft.Dnx.Compilation
             var context = new ApplicationHostContext
             {
                 Project = project,
-                TargetFramework = targetFramework,
-                SkipLockfileValidation = skipLockfileValidation
+                TargetFramework = targetFramework
             };
 
             ApplicationHostContext.Initialize(context);
 
-            return new LibraryExporter(context.LibraryManager, this, configuration, skipLockfileValidation);
+            return new LibraryExporter(context.LibraryManager, this, configuration);
         }
 
         public IAssemblyLoadContext CreateBuildLoadContext(Project project)

--- a/src/Microsoft.Dnx.Compilation/LibraryExporter.cs
+++ b/src/Microsoft.Dnx.Compilation/LibraryExporter.cs
@@ -16,14 +16,12 @@ namespace Microsoft.Dnx.Compilation
     {
         private readonly CompilationEngine _compilationEngine;
         private readonly string _configuration;
-        private readonly bool _skipLockfileValidation;
 
-        public LibraryExporter(LibraryManager manager, CompilationEngine compilationEngine, string configuration, bool skipLockfileValidation)
+        public LibraryExporter(LibraryManager manager, CompilationEngine compilationEngine, string configuration)
         {
             LibraryManager = manager;
             _compilationEngine = compilationEngine;
             _configuration = configuration;
-            _skipLockfileValidation = skipLockfileValidation;
         }
 
         public LibraryManager LibraryManager { get; }
@@ -239,7 +237,7 @@ namespace Microsoft.Dnx.Compilation
                     var compilerTypeInfo = project.Project.CompilerServices?.ProjectCompiler ?? Project.DefaultCompiler;
 
                     // Create the project exporter
-                    var exporter = _compilationEngine.CreateProjectExporter(project.Project, project.Framework, _configuration, _skipLockfileValidation);
+                    var exporter = _compilationEngine.CreateProjectExporter(project.Project, project.Framework, _configuration);
                     context.LoadContext = _compilationEngine.CreateBuildLoadContext(project.Project);
 
                     // Get the exports for the project dependencies

--- a/src/Microsoft.Dnx.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/ApplicationContext.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Dnx.DesignTimeHost
 
         private bool UpdateProjectCompilation(ProjectWorld project, out ProjectCompilation compilation)
         {
-            var exporter = _compilationEngine.CreateProjectExporter(_local.Project, project.TargetFramework, _configuration.Value, skipLockfileValidation: true);
+            var exporter = _compilationEngine.CreateProjectExporter(_local.Project, project.TargetFramework, _configuration.Value);
             var export = exporter.GetExport(_local.ProjectInformation.Name);
 
             ProjectCompilation oldCompilation;
@@ -995,8 +995,7 @@ namespace Microsoft.Dnx.DesignTimeHost
                 Project = project,
                 TargetFramework = frameworkName,
                 RuntimeIdentifiers = runtimeIdentifiers,
-                FrameworkResolver = _frameworkResolver,
-                SkipLockfileValidation = true
+                FrameworkResolver = _frameworkResolver
             };
 
             ApplicationHostContext.Initialize(applicationHostContext);

--- a/src/Microsoft.Dnx.DesignTimeHost/ProjectStateResolver.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/ProjectStateResolver.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Dnx.DesignTimeHost
             {
                 var applicationHostContext = _applicationHostContextCreator(ctx, project, frameworkName);
                 var libraryManager = applicationHostContext.LibraryManager;
-                var libraryExporter = _compilationEngine.CreateProjectExporter(project, frameworkName, configuration, skipLockfileValidation: true);
+                var libraryExporter = _compilationEngine.CreateProjectExporter(project, frameworkName, configuration);
 
                 var info = new DependencyInfo
                 {

--- a/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Dnx.Runtime/ApplicationHostContext.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Dnx.Runtime
 
         public string PackagesDirectory { get; set; }
 
-        public bool SkipLockfileValidation { get; set; }
-
         public FrameworkReferenceResolver FrameworkResolver { get; set; }
 
         public LibraryManager LibraryManager { get; private set; }
@@ -152,22 +150,13 @@ namespace Microsoft.Dnx.Runtime
             }
 
             var validLockFile = true;
-            var skipLockFileValidation = context.SkipLockfileValidation;
             string lockFileValidationMessage = null;
 
             if (context.LockFile != null)
             {
-                validLockFile = context.LockFile.IsValidForProject(context.Project, out lockFileValidationMessage);
+                validLockFile = (context.LockFile.Version == Constants.LockFileVersion) && context.LockFile.IsValidForProject(context.Project, out lockFileValidationMessage);
 
-                // When the only invalid part of a lock file is version number,
-                // we shouldn't skip lock file validation because we want to leave all dependencies unresolved, so that
-                // VS can be aware of this version mismatch error and automatically do restore
-                skipLockFileValidation = context.SkipLockfileValidation && (context.LockFile.Version == Constants.LockFileVersion);
-
-                if (validLockFile || skipLockFileValidation)
-                {
-                    lockFileLookup = new LockFileLookup(context.LockFile);
-                }
+                lockFileLookup = new LockFileLookup(context.LockFile);
             }
 
             var libraries = new List<LibraryDescription>();

--- a/test/Microsoft.Dnx.Runtime.Tests/Host/RuntimeSelectionFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/Host/RuntimeSelectionFacts.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Dnx.Runtime.Tests.Host
                 Project = CreateDummyProject(),
                 TargetFramework = Dnx451,
                 RuntimeIdentifiers = new[] { "win7-x64" },
-                SkipLockfileValidation = true,
                 LockFile = new LockFile()
                 {
                     Version = Constants.LockFileVersion,
@@ -86,7 +85,6 @@ namespace Microsoft.Dnx.Runtime.Tests.Host
             {
                 Project = CreateDummyProject(),
                 TargetFramework = Dnx451,
-                SkipLockfileValidation = true,
                 LockFile = new LockFile()
                 {
                     Version = Constants.LockFileVersion,
@@ -151,7 +149,6 @@ namespace Microsoft.Dnx.Runtime.Tests.Host
                 Project = CreateDummyProject(),
                 TargetFramework = Dnx451,
                 RuntimeIdentifiers = new[] { "win10-x64", "win8-x64", "win7-x64" },
-                SkipLockfileValidation = true,
                 LockFile = new LockFile()
                 {
                     Version = Constants.LockFileVersion,


### PR DESCRIPTION
- Always validate the lock file but don't skip resolving dependencies
because of it. Diagnostics will still show up but there'll never
be a case where nothing was resolved (unless there is no lock file to
begin with)

Related to #2831