### PR TITLE
Special casing "runtimes" folder to prevent pruning it during publish

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
@@ -354,7 +354,8 @@ namespace Microsoft.Dnx.Tooling.Publish
             var specialFolders = new List<string> {
                 "native",
                 "InteropAssemblies",
-                "redist"
+                "redist",
+                "runtimes"
             };
 
             if (!root.NoSource)


### PR DESCRIPTION
This "fixes" #2858 

This should be fixed properly with #2628