### PR TITLE
Update DTH tests to reduce time spent on timeout

### DIFF
--- a/test/Microsoft.Dnx.DesignTimeHost.FunctionalTests/Infrastructure/DthTestClient.cs
+++ b/test/Microsoft.Dnx.DesignTimeHost.FunctionalTests/Infrastructure/DthTestClient.cs
@@ -105,6 +105,18 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests.Infrastructure
             SendPayLoad(0, ProtocolManager.NegotiationMessageTypeName, new { Version = version });
         }
 
+        public List<DthMessage> DrainMessage(int count)
+        {
+            var result = new List<DthMessage>();
+            while (count > 0)
+            {
+                result.Add(GetResponse(timeout: TimeSpan.FromSeconds(10)));
+                count--;
+            }
+
+            return result;
+        }
+
         public List<DthMessage> DrainAllMessages()
         {
             return DrainAllMessages(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
Further cut back time spent on timeout. The locally running time reduced to 200s from 300s.

/cc @davidfowl 
/review @JunTaoLuo @victorhurdugaci @BrennanConroy 