### PR TITLE
Copy and restore the common used test projects once

### DIFF
--- a/test/Microsoft.Dnx.DesignTimeHost.FunctionalTests/DthStartupTests.cs
+++ b/test/Microsoft.Dnx.DesignTimeHost.FunctionalTests/DthStartupTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests
             using (var server = DthTestServer.Create(sdk))
             using (var client = new DthTestClient(server))
             {
-                var solution = TestUtils.GetSolution<DthStartupTests>(sdk, "DthTestProjects");
+                var solution = TestProjectsRepository.EnsureRestoredSolution("DthTestProjects");
                 var project = solution.GetProject("EmptyConsoleApp");
 
                 sdk.Dnu.Restore(project).EnsureSuccess();
@@ -152,10 +152,8 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests
             using (var server = DthTestServer.Create(sdk))
             using (var client = server.CreateClient())
             {
-                var solution = TestUtils.GetSolution<DthStartupTests>(sdk, "DthTestProjects");
+                var solution = TestProjectsRepository.EnsureRestoredSolution("DthTestProjects");
                 var project = solution.GetProject("EmptyConsoleApp");
-
-                sdk.Dnu.Restore(project).EnsureSuccess();
 
                 // Drain the inital messages
                 client.Initialize(project.ProjectDirectory, protocolVersion);
@@ -220,10 +218,8 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests
             using (var server = DthTestServer.Create(sdk))
             using (var client = server.CreateClient())
             {
-                var solution = TestUtils.GetSolution<DthStartupTests>(sdk, "DthTestProjects");
+                var solution = TestProjectsRepository.EnsureRestoredSolution("DthTestProjects");
                 var project = solution.GetProject(testProjectName);
-
-                sdk.Dnu.Restore(project);
 
                 client.Initialize(project.ProjectDirectory, protocolVersion);
 
@@ -280,18 +276,15 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests
         public void DthNegative_BrokenProjectPathInLockFile_V1(DnxSdk sdk)
         {
             var projectName = "BrokenProjectPathSample";
-            var solution = TestUtils.GetSolution<DthStartupTests>(sdk, "DthTestProjects");
+            var solution = TestProjectsRepository.EnsureRestoredSolution("DthTestProjects");
             var project = solution.GetProject(projectName);
 
-            sdk.Dnu.Restore(project).EnsureSuccess();
-
-            using (var disposableDir = new DisposableDir())
             using (var server = DthTestServer.Create(sdk))
             using (var client = server.CreateClient())
             {
                 // After restore the project is copied to another place so that
                 // the relative path in project lock file is invalid.
-                var movedProjectPath = Path.Combine(disposableDir, projectName);
+                var movedProjectPath = Path.Combine(TestUtils.GetTempTestFolder<DthStartupTests>(sdk), projectName);
                 TestUtils.CopyFolder(project.ProjectDirectory, movedProjectPath);
 
                 client.Initialize(movedProjectPath, protocolVersion: 1);
@@ -316,18 +309,15 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests
         public void DthNegative_BrokenProjectPathInLockFile_V2(DnxSdk sdk)
         {
             var projectName = "BrokenProjectPathSample";
-            var solution = TestUtils.GetSolution<DthStartupTests>(sdk, "DthTestProjects");
+            var solution = TestProjectsRepository.EnsureRestoredSolution("DthTestProjects");
             var project = solution.GetProject(projectName);
 
-            sdk.Dnu.Restore(project).EnsureSuccess();
-
-            using (var disposableDir = new DisposableDir())
             using (var server = DthTestServer.Create(sdk))
             using (var client = server.CreateClient())
             {
                 // After restore the project is copied to another place so that
                 // the relative path in project lock file is invalid.
-                var movedProjectPath = Path.Combine(disposableDir, projectName);
+                var movedProjectPath = Path.Combine(TestUtils.GetTempTestFolder<DthStartupTests>(sdk), projectName);
                 TestUtils.CopyFolder(project.ProjectDirectory, movedProjectPath);
 
                 client.Initialize(movedProjectPath, protocolVersion: 2);
@@ -418,14 +408,12 @@ namespace Microsoft.Dnx.DesignTimeHost.FunctionalTests
         public void CompileModuleWithDeps(DnxSdk sdk)
         {
             // Arrange
-            var solution = TestUtils.GetSolution<DthStartupTests>(sdk, "CompileModuleWithDependencies");
+            var solution = TestProjectsRepository.EnsureRestoredSolution("CompileModuleWithDependencies");
             var project = solution.GetProject("A");
 
             using (var server = DthTestServer.Create(sdk))
             using (var client = server.CreateClient())
             {
-                sdk.Dnu.Restore(solution.RootPath).EnsureSuccess();
-
                 client.Initialize(project.ProjectDirectory);
 
                 client.SendPayLoad(project, "GetDiagnostics");

--- a/test/Microsoft.Dnx.Testing.Framework/TestProjectsRepository.cs
+++ b/test/Microsoft.Dnx.Testing.Framework/TestProjectsRepository.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Dnx.Testing.Framework
+{
+    public static class TestProjectsRepository
+    {
+        private static readonly string _root;
+        private static readonly Dictionary<string, Lazy<Solution>> _solutions;
+
+        static TestProjectsRepository()
+        {
+            _root = Path.Combine(TestUtils.RootTestFolder, "SharedSolutions");
+
+            _solutions = Directory.GetDirectories(TestUtils.GetTestSolutionsDirectory())
+                                  .Select(CreateLazySolution)
+                                  .ToDictionary(pair => pair.Key, pair => pair.Value);
+        }
+
+        /// <summary>
+        /// Find a readonly copy of the test project according to the given name.
+        ///
+        /// The test project is copied and restored for single test run. The content
+        /// of the test project must not be modified otherwise other tests will be
+        /// impacted.
+        /// </summary>
+        public static Solution EnsureRestoredSolution(string solutionName)
+        {
+            Lazy<Solution> solution;
+            if (_solutions.TryGetValue(solutionName, out solution))
+            {
+                return solution.Value;
+            }
+
+            return null;
+        }
+
+        private static KeyValuePair<string, Lazy<Solution>> CreateLazySolution(string sourceDirectory)
+        {
+            var solutionName = Path.GetFileName(sourceDirectory);
+
+            var lasySolution = new Lazy<Solution>(() =>
+            {
+                var target = Path.Combine(_root, solutionName);
+                TestUtils.CopyFolder(sourceDirectory, target);
+
+                var solution = new Solution(target);
+
+                var sdk = (DnxSdk)DnxSdkFunctionalTestBase.ClrDnxSdks.First()[0];
+                sdk.Dnu.Restore(solution);
+
+                return solution;
+            }, isThreadSafe: true);
+
+            return new KeyValuePair<string, Lazy<Solution>>(solutionName, lasySolution);
+        }
+    }
+}


### PR DESCRIPTION
Save time spent on restoring readonly test projects by limit the restore to once per test run.

/cc @davidfowl @JunTaoLuo 