### PR TITLE
Adding support for CommandLineArguments to IRuntimeEnvironment

### DIFF
--- a/src/Microsoft.Dnx.Host.Clr/RuntimeBootstrapper.cs
+++ b/src/Microsoft.Dnx.Host.Clr/RuntimeBootstrapper.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Dnx.Host.Clr
             var bootstrapperType = bootstrapperContext.GetType().Assembly.GetType("Microsoft.Dnx.Host.RuntimeBootstrapper");
 
             var executeMethodInfo = bootstrapperType.GetMethod("Execute", BindingFlags.Static | BindingFlags.Public, null,
-                    new[] { typeof(string[]), bootstrapperContext.GetType() }, null);
+                    new[] { typeof(string[]), bootstrapperContext.GetType() }, argv);
 
             return (int)executeMethodInfo.Invoke(null, new object[] { argv, bootstrapperContext });
         }
 
-        private static object GetBootstrapperContext(FrameworkName targetFramework, DomainManager.ApplicationMainInfo info)
+        private static object GetBootstrapperContext(FrameworkName targetFramework, DomainManager.ApplicationMainInfo info, string[] argv)
         {
             var dnxHost = Assembly.Load("Microsoft.Dnx.Host");
             var contextType = dnxHost.GetType("Microsoft.Dnx.Host.BootstrapperContext");
@@ -30,6 +30,7 @@ namespace Microsoft.Dnx.Host.Clr
             contextType.GetProperty("ApplicationBase").SetValue(bootstrapperContext, info.ApplicationBase);
             contextType.GetProperty("TargetFramework").SetValue(bootstrapperContext, targetFramework);
             contextType.GetProperty("RuntimeType").SetValue(bootstrapperContext, "Clr");
+            contextType.GetProperty("CommandLineArguments").SetValue(bootstrapperContext, argv);
 
             return bootstrapperContext;
         }

--- a/src/Microsoft.Dnx.Host.Clr/RuntimeBootstrapper.cs
+++ b/src/Microsoft.Dnx.Host.Clr/RuntimeBootstrapper.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Dnx.Host.Clr
     {
         public static int Execute(string[] argv, FrameworkName targetFramework, DomainManager.ApplicationMainInfo info)
         {
-            var bootstrapperContext = GetBootstrapperContext(targetFramework, info);
+            var bootstrapperContext = GetBootstrapperContext(targetFramework, info, argv);
             var bootstrapperType = bootstrapperContext.GetType().Assembly.GetType("Microsoft.Dnx.Host.RuntimeBootstrapper");
 
             var executeMethodInfo = bootstrapperType.GetMethod("Execute", BindingFlags.Static | BindingFlags.Public, null,
-                    new[] { typeof(string[]), bootstrapperContext.GetType() }, argv);
+                    new[] { typeof(string[]), bootstrapperContext.GetType() }, null);
 
             return (int)executeMethodInfo.Invoke(null, new object[] { argv, bootstrapperContext });
         }

--- a/src/Microsoft.Dnx.Host.CoreClr/DomainManager.cs
+++ b/src/Microsoft.Dnx.Host.CoreClr/DomainManager.cs
@@ -47,6 +47,7 @@ sealed class DomainManager
             bootstrapperContext.ApplicationBase = new string(context->ApplicationBase);
             bootstrapperContext.TargetFramework = new FrameworkName(FrameworkNames.LongNames.DnxCore, new Version(5, 0));
             bootstrapperContext.RuntimeType = "CoreClr";
+            bootstrapperContext.CommandLineArguments = arguments;
 
             return RuntimeBootstrapper.Execute(arguments, bootstrapperContext);
         }

--- a/src/Microsoft.Dnx.Host.Mono/EntryPoint.cs
+++ b/src/Microsoft.Dnx.Host.Mono/EntryPoint.cs
@@ -76,7 +76,8 @@ public class EntryPoint
             ApplicationBase = appBase,
             // NOTE(anurse): Mono is always "dnx451" (for now).
             TargetFramework = new FrameworkName("DNX", new Version(4, 5, 1)),
-            RuntimeType = "Mono"
+            RuntimeType = "Mono",
+            CommandLineArguments = arguments
         };
 
         return RuntimeBootstrapper.Execute(arguments, bootstrapperContext);

--- a/src/Microsoft.Dnx.Host/BootstrapperContext.cs
+++ b/src/Microsoft.Dnx.Host/BootstrapperContext.cs
@@ -20,5 +20,7 @@ namespace Microsoft.Dnx.Host
         public FrameworkName TargetFramework { get; set; }
 
         public string RuntimeType { get; set; }
+        
+        public string[] CommandLineArguments { get; set; }
     }
 }

--- a/src/Microsoft.Dnx.Host/RuntimeEnvironment.cs
+++ b/src/Microsoft.Dnx.Host/RuntimeEnvironment.cs
@@ -46,5 +46,7 @@ namespace Microsoft.Dnx.Runtime
         }
 
         public string RuntimePath { get; }
+    
+        public string[] CommandLineArguments { get; }
     }
 }

--- a/src/Microsoft.Dnx.Runtime.Abstractions/IRuntimeEnvironment.cs
+++ b/src/Microsoft.Dnx.Runtime.Abstractions/IRuntimeEnvironment.cs
@@ -37,8 +37,14 @@ namespace Microsoft.Dnx.Runtime
         string RuntimeVersion { get; }
 
         /// <summary>
-        /// Gets the path to the runtime foler.
+        /// Gets the path to the runtime folder.
         /// </summary>
         string RuntimePath { get; }
+        
+        
+        /// <summary>
+        /// Gets the arguments supplied from os commandline.
+        /// </summary>
+        string[] CommandLineArguments { get; }
     }
 }

--- a/test/Microsoft.Dnx.Host.Tests/RuntimeEnvironmentTests.cs
+++ b/test/Microsoft.Dnx.Host.Tests/RuntimeEnvironmentTests.cs
@@ -169,6 +169,7 @@ namespace dnx.hostTests
             public string RuntimeType { get; set; }
             public string RuntimeVersion { get; set; }
             public string RuntimePath { get; set; }
+            public string[] CommandLineArguments { get; set;}
         }
     }
 }


### PR DESCRIPTION
The idea behind this change is to allow any/all applications hosted by dnx read access to the commandline arguments passed to dnx from an instance of the IRuntimeEnvironment