### PR TITLE
Add a Override property to each DependencyItem

### DIFF
--- a/misc/DependencyOverrideNearest/global.json
+++ b/misc/DependencyOverrideNearest/global.json
@@ -1,0 +1,3 @@
+{
+  "projects": ["src"]
+}

--- a/misc/DependencyOverrideNearest/src/Library/project.json
+++ b/misc/DependencyOverrideNearest/src/Library/project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1"
+  }
+}

--- a/misc/DependencyOverrideNearest/src/Main/project.json
+++ b/misc/DependencyOverrideNearest/src/Main/project.json
@@ -1,0 +1,9 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Library": "",
+    "Newtonsoft.Json": "6.0.8"
+  }
+}

--- a/misc/DependencyOverrideSibling/global.json
+++ b/misc/DependencyOverrideSibling/global.json
@@ -1,0 +1,3 @@
+{
+  "projects": ["src"]
+}

--- a/misc/DependencyOverrideSibling/src/Library1/project.json
+++ b/misc/DependencyOverrideSibling/src/Library1/project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "5.0.1"
+  }
+}

--- a/misc/DependencyOverrideSibling/src/Library2/project.json
+++ b/misc/DependencyOverrideSibling/src/Library2/project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "6.0.8"
+  }
+}

--- a/misc/DependencyOverrideSibling/src/Main/project.json
+++ b/misc/DependencyOverrideSibling/src/Main/project.json
@@ -1,0 +1,9 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Library1": "",
+    "Library2": ""
+  }
+}

--- a/src/Microsoft.Dnx.DesignTimeHost/Models/OutgoingMessages/DependencyItem.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/Models/OutgoingMessages/DependencyItem.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Dnx.DesignTimeHost.Models.OutgoingMessages
 
         public string Version { get; set; }
 
+        public bool Override { get; set; }
+
         public override bool Equals(object obj)
         {
             var other = obj as DependencyItem;

--- a/test/Microsoft.Dnx.Testing.Framework/DnxSdk/Dth/DthMessageCollectionExtension.cs
+++ b/test/Microsoft.Dnx.Testing.Framework/DnxSdk/Dth/DthMessageCollectionExtension.cs
@@ -42,6 +42,30 @@ namespace Microsoft.Dnx.Testing.Framework.DesignTimeHost
             return result;
         }
 
+        public static DthMessage RetrieveSingleMessage(this IEnumerable<DthMessage> messages,
+                                                       string typename,
+                                                       int contextId)
+        {
+            var result = messages.SingleOrDefault(msg => contextId == msg.ContextId &&
+                                                         string.Equals(msg.MessageType, typename, StringComparison.Ordinal));
+
+            if (result == null)
+            {
+                if (messages.FirstOrDefault(msg => contextId == msg.ContextId && 
+                                                   string.Equals(msg.MessageType, typename, StringComparison.Ordinal)) != null)
+                {
+                    Assert.False(true, $"More than one {typename} messages from context {contextId} exist.");
+                }
+                else
+                {
+                    Assert.False(true, $"{typename} message from context {contextId} doesn't exists.");
+                }
+            }
+
+            return result;
+        }
+
+
         public static IEnumerable<DthMessage> ContainsMessage(this IEnumerable<DthMessage> messages,
                                                               string typename)
         {

--- a/test/Microsoft.Dnx.Testing.Framework/DnxSdk/Dth/DthMessageTypes.cs
+++ b/test/Microsoft.Dnx.Testing.Framework/DnxSdk/Dth/DthMessageTypes.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Dnx.Testing.Framework.DesignTimeHost
     {
         // requests
         public const string GetDiagnostics = nameof(GetDiagnostics);
+        public const string Dependencies = nameof(Dependencies);
+        public const string AllDiagnostics = nameof(AllDiagnostics);
         public const string ProtocolVersion = nameof(ProtocolVersion);
         public const string ChangeConfiguration = nameof(ChangeConfiguration);
         public const string EnumerateProjectContexts = nameof(EnumerateProjectContexts);


### PR DESCRIPTION
Issue: #2744 
Reviewer: @davidfowl @abpiskunov 
CC: @victorhurdugaci @muratg @moozzyk @BrennanConroy 

This change add a new information to the __Dependencies__ message about if one dependency is overridden by different version of the same package from different source.

Here's a sample in which the Library1's `Newstonsoft.Json` dependencies is overridden.
```
{{
  "Framework": {
    "FrameworkName": "DNX,Version=v4.5.1",
    "FriendlyName": "DNX 4.5.1",
    "ShortName": "dnx451",
    "RedistListPath": "C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v4.5.1\\RedistList\\FrameworkList.xml"
  },
  "RootDependency": "Main",
  "Dependencies": {
    "Main": {
      "Name": "Main",
      "DisplayName": "Main",
      "Version": "1.0.0",
      "Path": "C:\\code\\DNX\\artifacts\\TestOut\\DthTestServer.DthDependencies_HighestOverride\\dnx-clr-win-x86.1.0.0-dev\\src\\Main\\project.json",
      "Type": "Project",
      "Resolved": true,
      "Dependencies": [
        {
          "Name": "Library1",
          "Version": "1.0.0",
          "Override": false
        },
        {
          "Name": "Library2",
          "Version": "1.0.0",
          "Override": false
        },
        {
          "Name": "fx/mscorlib",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/System",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/System.Core",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/Microsoft.CSharp",
          "Version": "4.0.0",
          "Override": false
        }
      ],
      "Errors": [],
      "Warnings": []
    },
    "Library1": {
      "Name": "Library1",
      "DisplayName": "Library1",
      "Version": "1.0.0",
      "Path": "C:\\code\\DNX\\artifacts\\TestOut\\DthTestServer.DthDependencies_HighestOverride\\dnx-clr-win-x86.1.0.0-dev\\src\\Library1\\project.json",
      "Type": "Project",
      "Resolved": true,
      "Dependencies": [
        {
          "Name": "Newtonsoft.Json",
          "Version": "6.0.8",
          "Override": true
        },
        {
          "Name": "fx/mscorlib",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/System",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/System.Core",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/Microsoft.CSharp",
          "Version": "4.0.0",
          "Override": false
        }
      ],
      "Errors": [],
      "Warnings": []
    },
    "Library2": {
      "Name": "Library2",
      "DisplayName": "Library2",
      "Version": "1.0.0",
      "Path": "C:\\code\\DNX\\artifacts\\TestOut\\DthTestServer.DthDependencies_HighestOverride\\dnx-clr-win-x86.1.0.0-dev\\src\\Library2\\project.json",
      "Type": "Project",
      "Resolved": true,
      "Dependencies": [
        {
          "Name": "Newtonsoft.Json",
          "Version": "6.0.8",
          "Override": false
        },
        {
          "Name": "fx/mscorlib",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/System",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/System.Core",
          "Version": "4.0.0",
          "Override": false
        },
        {
          "Name": "fx/Microsoft.CSharp",
          "Version": "4.0.0",
          "Override": false
        }
      ],
      "Errors": [],
      "Warnings": []
    },
// Remaining part of the message are omitted.
```