### PR TITLE
Shortening runtime names

### DIFF
--- a/test/Microsoft.Dnx.Testing.Framework/Constants/TestConstants.cs
+++ b/test/Microsoft.Dnx.Testing.Framework/Constants/TestConstants.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.Dnx.Testing
 {
@@ -11,5 +13,19 @@ namespace Microsoft.Dnx.Testing
         public static readonly string TestSolutionsDirectory = "misc";
         public static readonly string SaveFilesAll = "all";
         public static readonly string SaveFilesNone = "none";
+        public static readonly ReadOnlyDictionary<string, string> RuntimeAcronyms = 
+            new ReadOnlyDictionary<string, string>(
+                new Dictionary<string, string>()
+                {
+                    { "clr", "c" },
+                    { "coreclr", "cc" },
+                    { "mono", "m" },
+                    { "win", "w" },
+                    { "darwin", "d" },
+                    { "linux", "l" },
+                    { "x64", "6" },
+                    { "x86", "8" },
+                    { "arm", "a" },
+                });
     }
 }

--- a/test/Microsoft.Dnx.Testing.Framework/DnxSdk/DnxSdk.cs
+++ b/test/Microsoft.Dnx.Testing.Framework/DnxSdk/DnxSdk.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Dnx.Testing.Framework
 
         public string FullName { get; set; }
 
+        public string ShortName { get; set; }
+
         public FrameworkName TargetFramework { get; set; }
 
         public Dnu Dnu => new Dnu(Location);
@@ -43,7 +45,7 @@ namespace Microsoft.Dnx.Testing.Framework
                     basePath = Environment.GetEnvironmentVariable("USERPROFILE");
                 }
 
-                homePath = System.IO.Path.Combine(basePath, ".dnx");
+                homePath = Path.Combine(basePath, ".dnx");
             }
 
             return homePath;
@@ -61,12 +63,14 @@ namespace Microsoft.Dnx.Testing.Framework
 
         public static DnxSdk GetRuntime(string basePath, string version, string flavor, string os, string arch)
         {
-            var fullName = GetRuntimeName(flavor, os, arch) + $".{version}";
+            var fullName =  $"{GetRuntimeName(flavor, os, arch)}.{version}";
+            var shortName = $"{GetShortRuntimeName(flavor, os, arch)}.{version}";
             return new DnxSdk
             {
                 FullName = fullName,
+                ShortName = shortName,
                 TargetFramework = TestUtils.GetFrameworkForRuntimeFlavor(flavor),
-                Location = System.IO.Path.Combine(basePath, "runtimes", fullName),
+                Location = Path.Combine(basePath, "runtimes", fullName),
                 Architecture = arch,
                 Flavor = flavor,
                 OperationSystem = os,
@@ -83,6 +87,19 @@ namespace Microsoft.Dnx.Testing.Framework
             }
 
             return $"dnx-{flavor}-{os}-{architecture}";
+        }
+
+        public static string GetShortRuntimeName(string flavor, string os, string architecture)
+        {
+            var ra = TestConstants.RuntimeAcronyms;
+
+            // Mono ignores os and architecture
+            if (string.Equals(flavor, "mono", StringComparison.OrdinalIgnoreCase))
+            {
+                return ra["mono"];
+            }
+
+            return $"{ra[flavor]}{ra[os]}{ra[architecture]}";
         }
 
         public override string ToString()

--- a/test/Microsoft.Dnx.Testing.Framework/TestUtils.cs
+++ b/test/Microsoft.Dnx.Testing.Framework/TestUtils.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Dnx.Testing.Framework
 
         public static string GetTestFolder<T>(DnxSdk sdk, [CallerMemberName]string testName = null)
         {
-            var tempFolderPath = Path.Combine(RootTestFolder, $"{typeof(T).Name}.{testName}", sdk.FullName);
+            var tempFolderPath = Path.Combine(RootTestFolder, $"{typeof(T).Name}.{testName}", sdk.ShortName);
             Directory.CreateDirectory(tempFolderPath);
             return tempFolderPath;
         }


### PR DESCRIPTION
Reduce the chance of getting into long path issue, number 9 of #2825. This change will shorten the path names by 12-18 characters for non-mono runtimes.