### PR TITLE
Add build targets to DNX to install dependencies to volatile feeds.

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -667,6 +667,15 @@ var CI_DARWIN_DROP_PATH = '${Environment.GetEnvironmentVariable("CI_DARWIN_DROP_
     }
     nuget-pack packageVersion='${FULL_VERSION}' outputDir='${BUILD_DIR2}' extra='-NoPackageAnalysis -Properties RuntimeNamePrefix=${RUNTIME_NAME_PREFIX}' nugetPath='.nuget/nuget.exe' each='var nuspecFile in Files.Include(Path.Combine(BUILD_DIR2, "*.nuspec"))'
 
+var CI_DEPENDENCIES_PATHS = '${Environment.GetEnvironmentVariable("CI_DEPENDENCIES_PATHS")}'
+
+#nuget-dependencies-install target='install' description='Install dependencies to publish directory' if='!string.IsNullOrEmpty(CI_DEPENDENCIES_PATHS)'
+  - var dependencyPaths = CI_DEPENDENCIES_PATHS.Split(new[] { (char)';' }, StringSplitOptions.RemoveEmptyEntries);
+  - var publishFeed = Environment.GetEnvironmentVariable("NUGET_PUBLISH_FEED");
+  
+  kpm-publish targetPackagesDir='${Environment.GetEnvironmentVariable("PACKAGES_PUBLISH_DIR")}' each='var sourcePackagesDir in dependencyPaths'
+  nuget-resilient-publish nugetFeed='${publishFeed}' each='var sourcePackagesDir in dependencyPaths' if='!string.IsNullOrEmpty(publishFeed)'
+
 - // ===================== TESTING ===================== 
 
 #test-package target='integration-test'


### PR DESCRIPTION
Used to perform gated builds.