### PR TITLE
Added magic environment variable for azure deployments

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
@@ -551,9 +551,12 @@ namespace Microsoft.Dnx.Tooling.Publish
             root.Reports.Information.WriteLine($"Using command '{command}' as the entry point for web.config.");
 
             var azurePublishValue = Environment.GetEnvironmentVariable("DNU_PUBLISH_AZURE");
-            var basePath = string.Equals(azurePublishValue, "true", StringComparison.Ordinal) ||
-                           string.Equals(azurePublishValue, "1", StringComparison.Ordinal)
-                           ? @"%home%\site" : "..";
+            var publishingToAzure = string.Equals(azurePublishValue, "true", StringComparison.Ordinal) ||
+                                    string.Equals(azurePublishValue, "1", StringComparison.Ordinal) ||
+                                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"));
+
+            var basePath = publishingToAzure ? @"%home%\site" : "..";
+            var baseLogPath = publishingToAzure ? @"\\?\%home%\LogFiles" : @"..\logs";
 
             var targetDocument = XDocument.Parse($@"<configuration><system.webServer>
   <handlers>
@@ -562,7 +565,7 @@ namespace Microsoft.Dnx.Tooling.Publish
   <httpPlatform processPath=""{basePath}\approot\{command}.cmd""
                 arguments="""" 
                 stdoutLogEnabled=""true"" 
-                stdoutLogFile=""..\logs\stdout.log"">
+                stdoutLogFile=""{baseLogPath}\stdout.log"">
   </httpPlatform>
 </system.webServer></configuration>");
 

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishProject.cs
@@ -550,11 +550,16 @@ namespace Microsoft.Dnx.Tooling.Publish
 
             root.Reports.Information.WriteLine($"Using command '{command}' as the entry point for web.config.");
 
+            var azurePublishValue = Environment.GetEnvironmentVariable("DNU_PUBLISH_AZURE");
+            var basePath = string.Equals(azurePublishValue, "true", StringComparison.Ordinal) ||
+                           string.Equals(azurePublishValue, "1", StringComparison.Ordinal)
+                           ? @"%home%\site" : "..";
+
             var targetDocument = XDocument.Parse($@"<configuration><system.webServer>
   <handlers>
     <add name=""httpplatformhandler"" path=""*"" verb=""*"" modules=""httpPlatformHandler"" resourceType=""Unspecified"" />
   </handlers>
-  <httpPlatform processPath=""..\approot\{command}.cmd""
+  <httpPlatform processPath=""{basePath}\approot\{command}.cmd""
                 arguments="""" 
                 stdoutLogEnabled=""true"" 
                 stdoutLogFile=""..\logs\stdout.log"">
@@ -564,9 +569,7 @@ namespace Microsoft.Dnx.Tooling.Publish
             var attributesToOverwrite = new[]
             {
                 "processPath",
-                "arguments",
-                "stdoutLogEnabled",
-                "stdoutLogFile"
+                "arguments"
             };
 
             var result = xDoc.Root.MergeWith(targetDocument.Root, (name, sourceChild, targetChild) =>

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
@@ -1353,7 +1353,7 @@ exec ""{1}{2}"" --project ""$DIR/src/{0}"" --configuration {3} {4} ""$@""".Repla
     <handlers>
       <add name=""httpplatformhandler"" path=""*"" verb=""*"" modules=""httpPlatformHandler"" resourceType=""Unspecified"" />
     </handlers>
-    <httpPlatform processPath=""..\approot\web.cmd"" arguments="""" stdoutLogEnabled=""true"" stdoutLogFile=""..\logs\stdout.log"" rapidFailsPerMinute=""5""></httpPlatform>
+    <httpPlatform processPath=""..\approot\web.cmd"" arguments="""" stdoutLogEnabled=""false"" stdoutLogFile=""..\logs\stdout.log"" rapidFailsPerMinute=""5""></httpPlatform>
   </system.webServer>
 </configuration>";
 


### PR DESCRIPTION
- This command will instruct publish to use "%home%\site" as the base path instead of a relative
one for azure deployments in "web.config". It will not be required once azure gets the new
http platform handler module.

/cc @davidebbo @vijayrkn @sayedihashimi 