### PR TITLE
Fix a single invalid lock file causing relock of all following lock files

### DIFF
--- a/misc/ThreeLockedProjects/global.json
+++ b/misc/ThreeLockedProjects/global.json
@@ -1,0 +1,3 @@
+{
+  "projects": ["src"]
+}

--- a/misc/ThreeLockedProjects/src/Project1/project.json
+++ b/misc/ThreeLockedProjects/src/Project1/project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1"
+  }
+}

--- a/misc/ThreeLockedProjects/src/Project1/project.lock.json
+++ b/misc/ThreeLockedProjects/src/Project1/project.lock.json
@@ -1,0 +1,69 @@
+{
+  "locked": true,
+  "version": 2,
+  "targets": {
+    "DNX,Version=v4.5.1": {
+      "Newtonsoft.Json/7.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    },
+    "DNX,Version=v4.5.1/win7-x86": {
+      "Newtonsoft.Json/7.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    },
+    "DNX,Version=v4.5.1/win7-x64": {
+      "Newtonsoft.Json/7.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Newtonsoft.Json/7.0.1": {
+      "type": "package",
+      "sha512": "q3V4KLetMLnt1gpAVWgtXnHjKs0UG/RalBc29u2ZKxd5t5Ze4JBL5WiiYIklJyK/5CRiIiNwigVQUo0FgbsuWA==",
+      "files": [
+        "lib/net20/Newtonsoft.Json.dll",
+        "lib/net20/Newtonsoft.Json.xml",
+        "lib/net35/Newtonsoft.Json.dll",
+        "lib/net35/Newtonsoft.Json.xml",
+        "lib/net40/Newtonsoft.Json.dll",
+        "lib/net40/Newtonsoft.Json.xml",
+        "lib/net45/Newtonsoft.Json.dll",
+        "lib/net45/Newtonsoft.Json.xml",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.dll",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.xml",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.xml",
+        "Newtonsoft.Json.7.0.1.nupkg",
+        "Newtonsoft.Json.7.0.1.nupkg.sha512",
+        "Newtonsoft.Json.nuspec",
+        "tools/install.ps1"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Newtonsoft.Json >= 7.0.1"
+    ],
+    "DNX,Version=v4.5.1": []
+  }
+}

--- a/misc/ThreeLockedProjects/src/Project2/project.json
+++ b/misc/ThreeLockedProjects/src/Project2/project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1"
+  }
+}

--- a/misc/ThreeLockedProjects/src/Project2/project.lock.json
+++ b/misc/ThreeLockedProjects/src/Project2/project.lock.json
@@ -1,0 +1,71 @@
+{
+  "locked": false,
+  "version": 2,
+  "targets": {
+    "DNX,Version=v4.5.1": {
+      "Newtonsoft.Json/6.0.8": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    },
+    "DNX,Version=v4.5.1/win7-x86": {
+      "Newtonsoft.Json/6.0.8": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    },
+    "DNX,Version=v4.5.1/win7-x64": {
+      "Newtonsoft.Json/6.0.8": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Newtonsoft.Json/6.0.8": {
+      "type": "package",
+      "sha512": "7ut47NDedTW19EbL0JpFDYUP62fcuz27hJrehCDNajdCS5NtqL+E39+7Um3OkNc2wl2ym7K8Ln5eNuLus6mVGQ==",
+      "files": [
+        "lib/net20/Newtonsoft.Json.dll",
+        "lib/net20/Newtonsoft.Json.xml",
+        "lib/net35/Newtonsoft.Json.dll",
+        "lib/net35/Newtonsoft.Json.xml",
+        "lib/net40/Newtonsoft.Json.dll",
+        "lib/net40/Newtonsoft.Json.xml",
+        "lib/net45/Newtonsoft.Json.dll",
+        "lib/net45/Newtonsoft.Json.xml",
+        "lib/netcore45/Newtonsoft.Json.dll",
+        "lib/netcore45/Newtonsoft.Json.xml",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.dll",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.xml",
+        "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.dll",
+        "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.xml",
+        "Newtonsoft.Json.6.0.8.nupkg",
+        "Newtonsoft.Json.6.0.8.nupkg.sha512",
+        "Newtonsoft.Json.nuspec",
+        "tools/install.ps1"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Newtonsoft.Json >= 6.0.8"
+    ],
+    "DNX,Version=v4.5.1": []
+  }
+}

--- a/misc/ThreeLockedProjects/src/Project2/project.lock.json
+++ b/misc/ThreeLockedProjects/src/Project2/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": 2,
   "targets": {
     "DNX,Version=v4.5.1": {

--- a/misc/ThreeLockedProjects/src/Project3/project.json
+++ b/misc/ThreeLockedProjects/src/Project3/project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1"
+  }
+}

--- a/misc/ThreeLockedProjects/src/Project3/project.lock.json
+++ b/misc/ThreeLockedProjects/src/Project3/project.lock.json
@@ -1,0 +1,69 @@
+{
+  "locked": true,
+  "version": 2,
+  "targets": {
+    "DNX,Version=v4.5.1": {
+      "Newtonsoft.Json/7.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    },
+    "DNX,Version=v4.5.1/win7-x86": {
+      "Newtonsoft.Json/7.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    },
+    "DNX,Version=v4.5.1/win7-x64": {
+      "Newtonsoft.Json/7.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Newtonsoft.Json/7.0.1": {
+      "type": "package",
+      "sha512": "q3V4KLetMLnt1gpAVWgtXnHjKs0UG/RalBc29u2ZKxd5t5Ze4JBL5WiiYIklJyK/5CRiIiNwigVQUo0FgbsuWA==",
+      "files": [
+        "lib/net20/Newtonsoft.Json.dll",
+        "lib/net20/Newtonsoft.Json.xml",
+        "lib/net35/Newtonsoft.Json.dll",
+        "lib/net35/Newtonsoft.Json.xml",
+        "lib/net40/Newtonsoft.Json.dll",
+        "lib/net40/Newtonsoft.Json.xml",
+        "lib/net45/Newtonsoft.Json.dll",
+        "lib/net45/Newtonsoft.Json.xml",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.dll",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.xml",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.xml",
+        "Newtonsoft.Json.7.0.1.nupkg",
+        "Newtonsoft.Json.7.0.1.nupkg.sha512",
+        "Newtonsoft.Json.nuspec",
+        "tools/install.ps1"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Newtonsoft.Json >= 7.0.1"
+    ],
+    "DNX,Version=v4.5.1": []
+  }
+}

--- a/src/Microsoft.Dnx.Tooling/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/RestoreCommand.cs
@@ -220,8 +220,10 @@ namespace Microsoft.Dnx.Tooling
 
             var lockFile = await ReadLockFile(projectLockFilePath);
 
+            bool relock = Lock;
+
             var useLockFile = false;
-            if (Lock == false &&
+            if (relock == false &&
                 Unlock == false &&
                 lockFile != null &&
                 lockFile.Islocked)
@@ -235,7 +237,7 @@ namespace Microsoft.Dnx.Tooling
                 Reports.Information.WriteLine("Updating the invalid lock file with {0}",
                     "dnu restore --lock".Yellow().Bold());
                 useLockFile = false;
-                Lock = true;
+                relock = true;
             }
 
             Func<string, string> getVariable = key =>
@@ -515,7 +517,8 @@ namespace Microsoft.Dnx.Tooling
                               graphItems,
                               repository,
                               projectResolver,
-                              targetContexts);
+                              targetContexts,
+                              relock);
             }
 
             if (!SkipRestoreEvents)
@@ -821,13 +824,14 @@ namespace Microsoft.Dnx.Tooling
                                    List<GraphItem> graphItems,
                                    PackageRepository repository,
                                    IProjectResolver projectResolver,
-                                   IEnumerable<TargetContext> contexts)
+                                   IEnumerable<TargetContext> contexts,
+                                   bool relock)
         {
             var resolver = new DefaultPackagePathResolver(repository.RepositoryRoot.Root);
             var previousPackageLibraries = previousLockFile?.PackageLibraries.ToDictionary(l => Tuple.Create(l.Name, l.Version));
 
             var lockFile = new LockFile();
-            lockFile.Islocked = Lock;
+            lockFile.Islocked = relock;
 
             // Use empty string as the key of dependencies shared by all frameworks
             lockFile.ProjectFileDependencyGroups.Add(new ProjectFileDependencyGroup(

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuRestoreTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuRestoreTests.cs
@@ -98,5 +98,22 @@ B: This is Package B
 
             Assert.Equal(0, result.ExitCode);
         }
+
+        [Theory, TraceTest]
+        [MemberData(nameof(DnxSdks))]
+        public void Restore_OnlyRewriteInvalidLockfiles(DnxSdk sdk)
+        {
+            var solution = TestUtils.GetSolution<DnuRestoreTests>(
+                sdk,
+                "ThreeLockedProjects",
+                appendSolutionNameToTestFolder: true);
+
+            var result = sdk.Dnu.Restore(solution.SourcePath).EnsureSuccess();
+
+            var outputLines = result.StandardOutput.Split('\n');
+            Assert.Contains(outputLines, line => line.Contains("Following lock file") && line.Contains("Project1"));
+            Assert.Contains(outputLines, line => line.Contains("Writing lock file") && line.Contains("Project2"));
+            Assert.Contains(outputLines, line => line.Contains("Following lock file") && line.Contains("Project3"));
+        }
     }
 }


### PR DESCRIPTION
A quick fix for #2771.

I added a local variable `relock` to store whether or not a relock should happen. This is instead of using the `Lock` property. `Lock` seems to be intended to override validity and force relocking, so `relock` is initialized with `Lock`'s value.

I also passed `relock` to `WriteLockFile` to replace a usage of `Lock`.