### PR TITLE
improve type safety by using nameof operator

### DIFF
--- a/test/Microsoft.Dnx.Compilation.Tests/FileWatcherFacts.cs
+++ b/test/Microsoft.Dnx.Compilation.Tests/FileWatcherFacts.cs
@@ -187,7 +187,7 @@ namespace Loader.Tests
         }
 
         [Theory]
-        [MemberData("TestPaths")]
+        [MemberData(nameof(TestPaths))]
         public void IsAlreadyWatched(string newPath, bool expectedResult)
         {
             var watcher = new FileWatcher();


### PR DESCRIPTION
Improve type safety in test project by using nameof operator. No contribution is too small?