### PR TITLE
Stop using Title element as a fallback for PackageInfo.Id

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
@@ -208,8 +208,6 @@ namespace Microsoft.Dnx.Tooling.Restore.NuGet
             {
                 // If 'Id' element exist, use its value as accurate package Id
                 // Use the given Id as fallback if Id does not exist.
-                // Sometimes 'title' element is the same as Id and can be used as a fallback,
-                // but this is not always the case so don't use it.
                 Id = idElement?.Value ?? id,
                 Version = SemanticVersion.Parse(properties.Element(_xnameVersion).Value),
                 ContentUri = element.Element(_xnameContent).Attribute("src").Value,

--- a/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
@@ -191,7 +191,6 @@ namespace Microsoft.Dnx.Tooling.Restore.NuGet
         {
             var properties = element.Element(_xnameProperties);
             var idElement = properties.Element(_xnameId);
-            var titleElement = element.Element(_xnameTitle);
             var publishElement = properties.Element(_xnamePublish);
 
             var listed = true;

--- a/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/NuGet/NuGetv2Feed.cs
@@ -208,9 +208,10 @@ namespace Microsoft.Dnx.Tooling.Restore.NuGet
             return new PackageInfo
             {
                 // If 'Id' element exist, use its value as accurate package Id
-                // Otherwise, use the value of 'title' if it exist
-                // Use the given Id as final fallback if all elements above don't exist
-                Id = idElement?.Value ?? titleElement?.Value ?? id,
+                // Use the given Id as fallback if Id does not exist.
+                // Sometimes 'title' element is the same as Id and can be used as a fallback,
+                // but this is not always the case so don't use it.
+                Id = idElement?.Value ?? id,
                 Version = SemanticVersion.Parse(properties.Element(_xnameVersion).Value),
                 ContentUri = element.Element(_xnameContent).Attribute("src").Value,
                 Listed = listed


### PR DESCRIPTION
Title is only sometimes a correct fallback for package id. In some cases it actually causes failure where falling back to the given Id would have worked.

For example, [xunit.netcore.extensions](https://www.myget.org/feed/dotnet-buildtools/package/nuget/xunit.netcore.extensions) has the title "xUnit extensions of .NET Core test projects". Without this change, when pulling from a source that doesn't provide `Id`, `Title` is used and package validation tries to find `xUnit extensions of .NET Core test projects.nuspec` inside the package and fails.

This change allows `dnu restore` to work using Artifactory feeds, which (currently) don't provide Id. I don't know of a scenario where Title is a better fallback than the given Id, but maybe there is one. The fallback was introduced here: https://github.com/aspnet/dnx/pull/638