### PR TITLE
Fixed nuget version casing mismatch

### DIFF
--- a/misc/MismatchedVersionCasing/global.json
+++ b/misc/MismatchedVersionCasing/global.json
@@ -1,0 +1,4 @@
+{
+  "projects": [ "src" ],
+  "packages": "packages"
+}

--- a/misc/MismatchedVersionCasing/src/A/project.json
+++ b/misc/MismatchedVersionCasing/src/A/project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Contentful.NET": "0.0.5-Alpha"
+  }
+}

--- a/src/Microsoft.Dnx.Tooling/Utils/NuGetPackageUtils.cs
+++ b/src/Microsoft.Dnx.Tooling/Utils/NuGetPackageUtils.cs
@@ -77,23 +77,21 @@ namespace Microsoft.Dnx.Tooling
                     // Fixup the casing of the nuspec on disk to match what we expect
                     var nuspecFile = Directory.EnumerateFiles(targetPath, "*" + NuGet.Constants.ManifestExtension).Single();
 
-                    if (!string.Equals(nuspecFile, targetNuspec, StringComparison.Ordinal))
+                    Manifest manifest = null;
+                    using (var nuspecStream = File.OpenRead(nuspecFile))
                     {
-                        Manifest manifest = null;
-                        using (var nuspecStream = File.OpenRead(nuspecFile))
-                        {
-                            manifest = Manifest.ReadFrom(nuspecStream, validateSchema: false);
-                            manifest.Metadata.Id = library.Name;
-                        }
+                        manifest = Manifest.ReadFrom(nuspecStream, validateSchema: false);
+                        manifest.Metadata.Id = library.Name;
+                        manifest.Metadata.Version = library.Version;
+                    }
 
-                        // Delete the previous nuspec file
-                        File.Delete(nuspecFile);
+                    // Delete the previous nuspec file
+                    File.Delete(nuspecFile);
 
-                        // Write the new manifest
-                        using (var targetNuspecStream = File.OpenWrite(targetNuspec))
-                        {
-                            manifest.Save(targetNuspecStream);
-                        }
+                    // Write the new manifest
+                    using (var targetNuspecStream = File.OpenWrite(targetNuspec))
+                    {
+                        manifest.Save(targetNuspecStream);
                     }
 
                     // Note: PackageRepository relies on the hash file being written out as the final operation as part of a package install

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuRestoreTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuRestoreTests.cs
@@ -87,5 +87,16 @@ B: This is Package B
             Assert.Equal(1, lockFiles.Length);
             Assert.Equal("Main", Path.GetFileName(Path.GetDirectoryName(lockFiles[0])));
         }
+
+        [Theory, TraceTest]
+        [MemberData(nameof(DnxSdks))]
+        public void Restore_NormalizesVersionCasing(DnxSdk sdk)
+        {
+            var solution = TestUtils.GetSolution<DnuRestoreTests>(sdk, "MismatchedVersionCasing");
+
+            var result = sdk.Dnu.Restore(solution.GetProject("A"));
+
+            Assert.Equal(0, result.ExitCode);
+        }
     }
 }


### PR DESCRIPTION
- Always update the nuspec with the resolved version and id on
install.

#2970