### PR TITLE
Apply compatible target conversion logic also to restore

### DIFF
--- a/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/packages.config
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/src/ClassLibrary/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="4.0.1" targetFramework="net451" />
+</packages>

--- a/misc/DnuWrapTestSolutions/WrapAndPublish/wrap/ClassLibrary/project.json
+++ b/misc/DnuWrapTestSolutions/WrapAndPublish/wrap/ClassLibrary/project.json
@@ -6,6 +6,9 @@
       "bin": {
         "assembly": "../../src/ClassLibrary/obj/{configuration}/ClassLibrary.dll",
         "pdb": "../../src/ClassLibrary/obj/{configuration}/ClassLibrary.pdb"
+      },
+      "dependencies": {
+        "Newtonsoft.Json": "4.0.1"
       }
     }
   }

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
@@ -13,40 +13,6 @@ namespace Microsoft.Dnx.Tooling.FunctionalTests
 {
     public class DnuPublishTests : DnxSdkFunctionalTestBase
     {
-        [ConditionalTheory, TraceTest]
-        [OSSkipCondition(OperatingSystems.Linux)] // This needs msbuild to run
-        [OSSkipCondition(OperatingSystems.MacOSX)] // This needs msbuild to run
-        [MemberData(nameof(DnxSdks))]
-        public void PublishWrappedProjectForSpecificFramework(DnxSdk sdk)
-        {
-            var solutionName = Path.Combine("DnuWrapTestSolutions", "WrapAndPublish");
-            var solution = TestUtils.GetSolution<DnuPublishTests>(sdk, solutionName);
-
-            // Restore the wrapper project
-            sdk.Dnu.Restore(solution.GetWrapperProjectPath("ClassLibrary")).EnsureSuccess();
-            sdk.Dnu.Restore(solution.GetProject("DnxConsoleApp")).EnsureSuccess();
-
-            // Build the console app in Debug mode (we specify the config explicitly since dnx here defaults to a Debug 
-            // build but on the CI we might have the Configuration environment variable set so that MSBuild builds as Release by default).
-            var msbuild = CommonTestUtils.TestUtils.ResolveMSBuildPath();
-            Exec.Run(msbuild, "/p:Configuration=Debug", workingDir: Path.Combine(solution.SourcePath, "ClassLibrary")).EnsureSuccess(); ;
-
-            // Publish the console app
-            sdk.Dnu.Publish(solution.GetProject("DnxConsoleApp").ProjectFilePath, solution.ArtifactsPath, "--framework dnx451").EnsureSuccess();
-
-            // Get an SDK we can use the RUN the wrapped project (it has to be CLR because the project only supports dnx451)
-            var clrSdk = GetRuntime("clr", "win", "x86");
-
-            // Run it
-            var outputPath = Path.Combine(solution.ArtifactsPath, "approot", "src", "DnxConsoleApp");
-            var result = clrSdk.Dnx.Execute(
-                commandLine: $"--project \"{outputPath}\" --configuration Debug DnxConsoleApp run")
-                .EnsureSuccess();
-            Assert.Contains($"Hello from the wrapped project{Environment.NewLine}", result.StandardOutput);
-
-            TestUtils.CleanUpTestDir<DnuPublishTests>(sdk);
-        }
-
         [Theory, TraceTest]
         [MemberData(nameof(DnxSdks))]
         public void GlobalJsonInProjectDir(DnxSdk sdk)

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishWrappedTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishWrappedTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.AspNet.Testing.xunit;
+using Microsoft.Dnx.Testing.Framework;
+using Xunit;
+
+namespace Microsoft.Dnx.Tooling.FunctionalTests
+{
+    // This needs msbuild to run
+    public class DnuPublishWrappedTests : DnxSdkFunctionalTestBase
+    {
+        [ConditionalTheory, TraceTest]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [MemberData(nameof(DnxSdks))]
+        public void PublishWrappedProjectForSpecificFramework(DnxSdk sdk)
+        {
+            DoPublish(sdk, "--framework dnx451");
+        }
+
+        [ConditionalTheory, TraceTest]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [MemberData(nameof(DnxSdks))]
+        public void PublishWrappedProject(DnxSdk sdk)
+        {
+            DoPublish(sdk);
+        }
+
+        [ConditionalTheory, TraceTest]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [MemberData(nameof(ClrDnxSdks))] // project only supports dnx451
+        public void PublishWrappedProjectForSpecificRuntime(DnxSdk sdk)
+        {
+            DoPublish(sdk, $"--runtime {sdk.FullName}");
+        }
+
+        private static void DoPublish(DnxSdk sdk, string arguments = null)
+        {
+            var solutionName = Path.Combine("DnuWrapTestSolutions", "WrapAndPublish");
+            var solution = TestUtils.GetSolution<DnuPublishWrappedTests>(sdk, solutionName);
+
+            // Restore the wrapper project
+            sdk.Dnu.Restore(solution.GetWrapperProjectPath("ClassLibrary")).EnsureSuccess();
+            sdk.Dnu.Restore(solution.GetProject("DnxConsoleApp")).EnsureSuccess();
+
+            // Build the console app in Debug mode (we specify the config explicitly since dnx here defaults to a Debug
+            // build but on the CI we might have the Configuration environment variable set so that MSBuild builds as Release by default).
+            var msbuild = CommonTestUtils.TestUtils.ResolveMSBuildPath();
+            Exec.Run(msbuild, "/p:Configuration=Debug", workingDir: Path.Combine(solution.SourcePath, "ClassLibrary"))
+                .EnsureSuccess();
+
+            // Publish the console app
+            var publishResult = sdk.Dnu.Publish(solution.GetProject("DnxConsoleApp").ProjectFilePath, solution.ArtifactsPath, arguments);
+            publishResult.EnsureSuccess();
+
+            // Get an SDK we can use the RUN the wrapped project (it has to be CLR because the project only supports dnx451)
+            var clrSdk = GetRuntime("clr", "win", "x86");
+
+            // Run it
+            var outputPath = Path.Combine(solution.ArtifactsPath, "approot", "src", "DnxConsoleApp");
+            var result = clrSdk.Dnx.Execute(
+                commandLine: $"--project \"{outputPath}\" --configuration Debug DnxConsoleApp run")
+                .EnsureSuccess();
+            Assert.Contains($"Hello from the wrapped project{Environment.NewLine}", result.StandardOutput);
+
+            TestUtils.CleanUpTestDir<DnuPublishWrappedTests>(sdk);
+        }
+    }
+}


### PR DESCRIPTION
Fix build failing during publish, because we restored with one set of frameworks and built with another.

Targets #2954

/cc @anurse @davidfowl @JunTaoLuo @troydai @moozzyk 