### PR TITLE
Using OSS signing on Mono if project json requires real signing

### DIFF
--- a/src/Microsoft.Dnx.Compilation.CSharp/RoslynDiagnostics.cs
+++ b/src/Microsoft.Dnx.Compilation.CSharp/RoslynDiagnostics.cs
@@ -11,5 +11,21 @@ namespace Microsoft.Dnx.Compilation.CSharp
             category: "StrongNaming",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+        internal static readonly DiagnosticDescriptor SnkNotSupportedOnMono = new DiagnosticDescriptor(
+            id: "DNX1002",
+            title: "Signing assemblies using a key file is not supported on Mono",
+            messageFormat: "Signing assemblies using a key file is not supported on Mono. Using OSS signing instead.",
+            category: "StrongNaming",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        internal static readonly DiagnosticDescriptor OssAndSnkSigningAreExclusive = new DiagnosticDescriptor(
+            id: "DNX1003",
+            title: "The \"keyFile\" and \"strongName\" options are mutually exclusive",
+            messageFormat: "The \"keyFile\" and \"strongName\" options are mutually exclusive and cannot be used together.",
+            category: "StrongNaming",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
     }
 }

--- a/test/Microsoft.Dnx.Compilation.CSharp.Tests/SigningFacts.cs
+++ b/test/Microsoft.Dnx.Compilation.CSharp.Tests/SigningFacts.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using Microsoft.AspNet.Testing.xunit;
+using Microsoft.Dnx.Compilation.Caching;
+using Microsoft.Dnx.Runtime;
+using Xunit;
+
+namespace Microsoft.Dnx.Compilation.CSharp.Tests
+{
+    public class SigningFacts
+    {
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono | RuntimeFrameworks.CLR)]
+        public void CompileIgnoresRealStrongNameSigningOnCoreClr()
+        {
+            RoslynCompiler compiler;
+            CompilationProjectContext projectContext;
+            PrepareCompilation(new FakeCompilerOptions { KeyFile = "keyFile.snk" }, out compiler, out projectContext);
+
+            var compilationContext = compiler.CompileProject(projectContext, Enumerable.Empty<IMetadataReference>(),
+                Enumerable.Empty<ISourceReference>(), () => new List<ResourceDescriptor>());
+
+            Assert.Equal(1, compilationContext.Diagnostics.Count);
+            Assert.Equal("DNX1001", compilationContext.Diagnostics[0].Id);
+        }
+
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.CLR | RuntimeFrameworks.CoreCLR)]
+        public void CompileFallsBackToOssSigningIfKeyFileSpecifiedOnMono()
+        {
+            RoslynCompiler compiler;
+            CompilationProjectContext projectContext;
+            PrepareCompilation(new FakeCompilerOptions { KeyFile = "keyFile.snk" }, out compiler, out projectContext);
+
+            var compilationContext = compiler.CompileProject(projectContext, Enumerable.Empty<IMetadataReference>(),
+                Enumerable.Empty<ISourceReference>(), () => new List<ResourceDescriptor>());
+
+            Assert.Equal(1, compilationContext.Diagnostics.Count);
+            Assert.Equal("DNX1002", compilationContext.Diagnostics[0].Id);
+        }
+
+        [Fact]
+        public void OssSigningAndRealSigningAreMutuallyExclusive()
+        {
+            RoslynCompiler compiler;
+            CompilationProjectContext projectContext;
+            PrepareCompilation(new FakeCompilerOptions { KeyFile = "keyFile.snk", StrongName = true }, out compiler, out projectContext);
+
+            var compilationContext = compiler.CompileProject(projectContext, Enumerable.Empty<IMetadataReference>(),
+                Enumerable.Empty<ISourceReference>(), () => new List<ResourceDescriptor>());
+
+            Assert.Equal(1, compilationContext.Diagnostics.Count);
+            Assert.Equal("DNX1003", compilationContext.Diagnostics[0].Id);
+        }
+
+        private static void PrepareCompilation(ICompilerOptions compilerOptions, out RoslynCompiler compiler,
+            out CompilationProjectContext projectContext)
+        {
+            var cacheContextAccessor = new FakeCacheContextAccessor { Current = new CacheContext(null, (d) => { }) };
+            compiler = new RoslynCompiler(null, cacheContextAccessor, new FakeNamedDependencyProvider(), null, new FakeWatcher(), null, null);
+            var compilationTarget = new CompilationTarget("test", new FrameworkName(".NET Framework, Version=4.0"), "Release", null);
+            projectContext = new CompilationProjectContext(
+                compilationTarget, Directory.GetCurrentDirectory(), "project.json", "1.0.0", new System.Version(1, 0), false,
+                new CompilationFiles(Enumerable.Empty<string>(), Enumerable.Empty<string>()), compilerOptions);
+        }
+
+        private class FakeWatcher : IFileWatcher
+        {
+            public event Action<string> OnChanged;
+
+            public void Dispose() { }
+
+            public void WatchDirectory(string path, string extension) { }
+
+            public bool WatchFile(string path)
+            {
+                return false;
+            }
+
+            public void WatchProject(string path) { }
+        }
+
+        private class FakeCacheContextAccessor : ICacheContextAccessor
+        {
+            public CacheContext Current { get; set; }
+        }
+
+        private class FakeCompilerOptions : ICompilerOptions
+        {
+            public bool? AllowUnsafe { get; set; }
+
+            public IEnumerable<string> Defines { get; set; }
+
+            public bool? DelaySign { get; set; }
+
+            public bool? EmitEntryPoint { get; set; }
+
+            public string KeyFile { get; set; }
+
+            public string LanguageVersion { get; set; }
+
+            public bool? Optimize { get; set; }
+
+            public string Platform { get; set; }
+
+            public bool? StrongName { get; set; }
+
+            public bool? WarningsAsErrors { get; set; }
+        }
+
+        private class FakeNamedDependencyProvider : INamedCacheDependencyProvider
+        {
+            public ICacheDependency GetNamedDependency(string name)
+            {
+                return null;
+            }
+
+            public void Trigger(string name)
+            { }
+        }
+    }
+}

--- a/test/Microsoft.Dnx.Compilation.CSharp.Tests/project.json
+++ b/test/Microsoft.Dnx.Compilation.CSharp.Tests/project.json
@@ -2,6 +2,7 @@
     "dependencies": {
         "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*",
         "Microsoft.Dnx.Compilation.CSharp": "1.0.0-*",
+        "Microsoft.AspNet.Testing": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "frameworks": {


### PR DESCRIPTION
If project json contains the `keyFile` property the assembly should
be signed using the provided snk. However real signing is not
supported on Mono. Currently we just error out in this case, after
this change we will fall back to using OSS signing. (Fixes #2558)

Also adding a warning for a case where if both `strongName` and `keyFile`
settings are provided we would just display errors from Roslyn which might
be hard to understand/troubleshoot because the names used in the errors
are different from the names we use in project.json (Fixes #2452)