### PR TITLE
Fix NullRef caused by Sources response

### DIFF
--- a/src/Microsoft.Dnx.Compilation.DesignTime/DesignTimeHostCompiler.cs
+++ b/src/Microsoft.Dnx.Compilation.DesignTime/DesignTimeHostCompiler.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Dnx.Compilation.DesignTime
             _queue.ProjectCompiled += OnProjectCompiled;
             _queue.ProjectsInitialized += ProjectContextsInitialized;
             _queue.ProjectChanged += _ => { };
+            _queue.ProjectSources += _ => { };
             _queue.Error += OnError;
 
             _queue.Closed += OnClosed;

--- a/src/Microsoft.Dnx.Compilation.DesignTime/ProcessingQueue.cs
+++ b/src/Microsoft.Dnx.Compilation.DesignTime/ProcessingQueue.cs
@@ -98,8 +98,11 @@ namespace Microsoft.Dnx.Compilation.DesignTime
                             //    "MessageType": "Sources",
                             //    "Files": [],
                             //}
-                            var files = obj.ValueAsStringArray("Files");
-                            ProjectSources(files);
+                            if (ProjectSources != null)
+                            {
+                                var files = obj.ValueAsStringArray("Files");
+                                ProjectSources(files);
+                            }
                             break;
                         case "ProjectContexts":
                             //{


### PR DESCRIPTION
Addressing: #2982 

In [the removal of `IFileWatcher`](https://github.com/aspnet/dnx/commit/1a222049e0973ae3971b57d8ea8cffbb9ca34bd0), the code of initializing `ProjectSources` property was [removed](https://github.com/aspnet/dnx/commit/1a222049e0973ae3971b57d8ea8cffbb9ca34bd0?diff=unified#diff-177e2f2da3a478ae5072533e84a39961L26). The `null` property cause an `NullRef` exception to be thrown when `DesignTimeHostProjectCompiler` [talks to DTH](https://github.com/aspnet/dnx/blob/dev/src/Microsoft.Dnx.Compilation.DesignTime/ProcessingQueue.cs#L102). The exception eventually causes the `Close` [event](https://github.com/aspnet/dnx/blob/dev/src/Microsoft.Dnx.Compilation.DesignTime/ProcessingQueue.cs#L154) and consequently [cancels all the unfinished `Task` waiting for response](https://github.com/aspnet/dnx/blob/dev/src/Microsoft.Dnx.Compilation.DesignTime/DesignTimeHostCompiler.cs#L54).

There are a few problems make the issue difficult to detect:
1) DesignTime compiler's `ProcessQueue` is different from DTH. It is not well guarded.
2) The `ProcessQueue` [doesn't print the error message](https://github.com/aspnet/dnx/blob/dev/src/Microsoft.Dnx.Compilation.DesignTime/ProcessingQueue.cs#L154) in this scenario.