### PR TITLE
Build hangs on Linux when tests running in parallel on CoreClr on TeamCity

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -753,14 +753,13 @@ var CI_DARWIN_DROP_PATH = '${Environment.GetEnvironmentVariable("CI_DARWIN_DROP_
             foreach (var target in group.GroupBy(t => t.Arch).First())
             {
                 var testArgs = string.Empty;
-                if (target.Flavor == "mono")
+                if (IsLinux)
                 {
-                    if (IsLinux)
-                    {
-                        // Work around issue with testing in parallel on Mono.
-                        testArgs = " -parallel none";
-                    }
-                    else
+                    testArgs = " -parallel none";
+                }
+                else
+                {
+                    if (target.Flavor == "mono")
                     {
                         // Skip Mono if we're not running on Linux or Mac.
                         continue;


### PR DESCRIPTION
Note Travis is passing and I was not able to repro the hang on my Linux box but the TeamCity Linux CI is consistently hanging and the difference between the build when it passed and when it started hanging is the parallel test execution. Disabling parallel test execution on CoreClr on Linux should unblock the CI for now but it would be good to understand why TeamCity fails on parallel execution at all.

/cc @dougbu @cesarbs @BrennanConroy 