### PR TITLE
fix #2881 by adding support for RID override

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -127,6 +127,15 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(VS_ONECORE_ROOT) && Directory.GetFil
     {
         RUNTIME_TARGETS.Add(new RuntimeTarget { Name = RUNTIME_CORECLR_DARWIN_x64_NAME, TargetFolder = RUNTIME_CORECLR_DARWIN_x64_BIN, Framework = "dnxcore50",  Arch = "x64", OS = "darwin", Flavor = "coreclr" });
     }
+
+    // Temporary until KoreBuild is updated
+    // It looks like it isn't possible to do this in .travis.yml because we only want
+    // to do it on Linux and I couldn't find an easy way to do that kind of selective
+    // environment variable set.
+    if(E('TRAVIS') == "true" && CanBuildForLinux)
+    {
+        E('DNX_RUNTIME_ID', 'ubuntu.14.04-x64');
+    }
 }
 
 -// Replace repo-initialize with a less greedy restore

--- a/src/Microsoft.Dnx.Tooling/Restore/ImplicitPackagesWalkProvider.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/ImplicitPackagesWalkProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Dnx.Tooling
             new RuntimeSpec("osx.10.10", "osx"),
             new RuntimeSpec("osx.10.10-x64", "osx.10.10", "osx-x64"),
 
-            // Optimistically support Mac OS X El Capitan for now (again, informal support)
+            // Mac OS X El Capitan
             new RuntimeSpec("osx.10.11", "osx.10.10"),
             new RuntimeSpec("osx.10.11-x64", "osx.10.11", "osx.10.10-x64"),
 
@@ -72,15 +72,38 @@ namespace Microsoft.Dnx.Tooling
             new RuntimeSpec("centos.7.1", "centos"),
             new RuntimeSpec("centos.7.1-x64", "centos.7.1", "centos-x64"),
 
+            // CentOS identifies itself as "7", but the BCL packages use "7.1" so we need this weird reversal mapping
+            new RuntimeSpec("centos.7", "centos.7.1"),
+            new RuntimeSpec("centos.7-x64", "centos.7", "centos.7.1-x64"),
+
             new RuntimeSpec("ubuntu", "linux"),
             new RuntimeSpec("ubuntu-x64", "ubuntu", "linux-x64"),
 
             new RuntimeSpec("ubuntu.14.04", "ubuntu"),
             new RuntimeSpec("ubuntu.14.04-x64", "ubuntu.14.04", "ubuntu-x64"),
 
-            // Linux Mint 17.2 is identical to Ubuntu 14.04 for our purposes (though we are not formally supporting it either)
-            new RuntimeSpec("linuxmint.17.2", "ubuntu.14.04"),
-            new RuntimeSpec("linuxmint.17.2-x64", "ubuntu.14.04-x64"));
+
+            // Informally supported RIDS: These are RIDs we believe work, but do not formally support
+
+            // Ubuntu 14.10 exists and is compatible with 14.04
+            new RuntimeSpec("ubuntu.14.10", "ubuntu.14.04"),
+            new RuntimeSpec("ubuntu.14.10-x64", "ubuntu.14.10", "ubuntu.14.04-x64"),
+
+            // Ubuntu 15.04 is believed to be compatible
+            new RuntimeSpec("ubuntu.15.04", "ubuntu.14.10"),
+            new RuntimeSpec("ubuntu.15.04-x64", "ubuntu.15.04", "ubuntu.14.10-x64"),
+
+            // Ubuntu 15.10 is not compatible. It upgraded icu to 55
+            
+            // Linux Mint 17.x is compatible with Ubuntu 14.04
+            new RuntimeSpec("linuxmint.17", "ubuntu.14.04"),
+            new RuntimeSpec("linuxmint.17-x64", "linuxmint.17", "ubuntu.14.04-x64"),
+            new RuntimeSpec("linuxmint.17.1", "linuxmint.17"),
+            new RuntimeSpec("linuxmint.17.1-x64", "linuxmint.17-x64"),
+            new RuntimeSpec("linuxmint.17.2", "linuxmint.17.1"),
+            new RuntimeSpec("linuxmint.17.2-x64", "linuxmint.17.2", "linuxmint.17.1-x64"),
+            new RuntimeSpec("linuxmint.17.3", "linuxmint.17.2"),
+            new RuntimeSpec("linuxmint.17.3-x64", "linuxmint.17.3", "linuxmint.17.2-x64"));
 
         public bool IsHttp
         {

--- a/test/Bootstrapper.FunctionalTests/BootstrapperTests.cs
+++ b/test/Bootstrapper.FunctionalTests/BootstrapperTests.cs
@@ -31,6 +31,14 @@ namespace Bootstrapper.FunctionalTests
 
         [Theory, TraceTest]
         [MemberData(nameof(DnxSdks))]
+        public void OverrideRidWithEnvironmentVariable(DnxSdk sdk)
+        {
+            var result = sdk.Dnx.Execute("--version", envSetup: env => env["DNX_RUNTIME_ID"] = "woozlewuzzle");
+            Assert.Contains("Runtime Id:   woozlewuzzle", result.StandardOutput);
+        }
+
+        [Theory, TraceTest]
+        [MemberData(nameof(DnxSdks))]
         public void UnresolvedProjectDoesNotThrow(DnxSdk sdk)
         {
             const string solutionName = "BootstrapperSolution";

--- a/test/Microsoft.Dnx.Host.Tests/RuntimeEnvironmentTests.cs
+++ b/test/Microsoft.Dnx.Host.Tests/RuntimeEnvironmentTests.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Linq;
 using Microsoft.AspNet.Testing.xunit;
-using Microsoft.Dnx.Host;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Extensions.PlatformAbstractions;
 using Xunit;
 
-namespace dnx.hostTests
+namespace Microsoft.Dnx.Host.Tests
 {
     public class RuntimeEnvironmentTests
     {
@@ -36,6 +35,8 @@ namespace dnx.hostTests
 
         // Test RID generation
         [Theory]
+
+        // Windows
         [InlineData("Windows", "6.1", "x86", "win7-x86")]
         [InlineData("Windows", "6.1", "x64", "win7-x64")]
         [InlineData("Windows", "6.2", "x86", "win8-x86")]
@@ -45,18 +46,27 @@ namespace dnx.hostTests
         [InlineData("Windows", "10.0", "x86", "win10-x86")]
         [InlineData("Windows", "10.0", "x64", "win10-x64")]
         [InlineData("Windows", "10.0", "arm", "win10-arm")]
-        [InlineData("Linux", null, "x86", "ubuntu.14.04-x86")]
-        [InlineData("Linux", null, "x64", "ubuntu.14.04-x64")]
-        [InlineData("Linux", null, "arm", "ubuntu.14.04-arm")]
-        [InlineData("Linux", "", "x86", "ubuntu.14.04-x86")]
-        [InlineData("Linux", "", "x64", "ubuntu.14.04-x64")]
-        [InlineData("Linux", "", "arm", "ubuntu.14.04-arm")]
+
+        // Generic Linux
+        [InlineData("Linux", null, "x86", "linux-x86")]
+        [InlineData("Linux", null, "x64", "linux-x64")]
+        [InlineData("Linux", null, "arm", "linux-arm")]
+        [InlineData("Linux", "", "x86", "linux-x86")]
+        [InlineData("Linux", "", "x64", "linux-x64")]
+        [InlineData("Linux", "", "arm", "linux-arm")]
+
+        // Linux Distros
         [InlineData("Linux", "Ubuntu 14.04", "x86", "ubuntu.14.04-x86")]
         [InlineData("Linux", "Ubuntu 14.04", "x64", "ubuntu.14.04-x64")]
         [InlineData("Linux", "Ubuntu 14.04", "arm", "ubuntu.14.04-arm")]
-        [InlineData("Linux", "LinuxMint 17.2", "x86", "ubuntu.14.04-x86")]
-        [InlineData("Linux", "LinuxMint 17.2", "x64", "ubuntu.14.04-x64")]
-        [InlineData("Linux", "LinuxMint 17.2", "arm", "ubuntu.14.04-arm")]
+        [InlineData("Linux", "LinuxMint 17.2", "x86", "linuxmint.17.2-x86")]
+        [InlineData("Linux", "LinuxMint 17.2", "x64", "linuxmint.17.2-x64")]
+        [InlineData("Linux", "LinuxMint 17.2", "arm", "linuxmint.17.2-arm")]
+        [InlineData("Linux", "CentOS 7", "x86", "centos.7-x86")]
+        [InlineData("Linux", "CentOS 7", "x64", "centos.7-x64")]
+        [InlineData("Linux", "CentOS 7", "arm", "centos.7-arm")]
+
+        // Mac OS X
         [InlineData("Darwin", null, "x86", "osx-x86")]
         [InlineData("Darwin", null, "x64", "osx-x64")]
         [InlineData("Darwin", null, "arm", "osx-arm")]
@@ -74,10 +84,12 @@ namespace dnx.hostTests
                 OperatingSystemVersion = version,
                 RuntimeArchitecture = architecture
             };
-            Assert.Equal(expectedRid, runtimeEnv.GetRuntimeIdentifier());
+            Assert.Equal(expectedRid, RuntimeEnvironmentExtensions.GetRuntimeIdentifierWithoutOverride(runtimeEnv));
         }
 
         [Theory]
+
+        // Windows
         [InlineData("Windows", "6.1", "x86", "win7-x86")]
         [InlineData("Windows", "6.1", "x64", "win7-x64")]
         [InlineData("Windows", "6.2", "x86", "win8-x86,win7-x86")]
@@ -86,21 +98,30 @@ namespace dnx.hostTests
         [InlineData("Windows", "6.3", "x64", "win81-x64,win8-x64,win7-x64")]
         [InlineData("Windows", "10.0", "x86", "win10-x86,win81-x86,win8-x86,win7-x86")]
         [InlineData("Windows", "10.0", "x64", "win10-x64,win81-x64,win8-x64,win7-x64")]
-        [InlineData("Linux", "", "x86", "ubuntu.14.04-x86")]
-        [InlineData("Linux", "", "x64", "ubuntu.14.04-x64")]
-        [InlineData("Linux", "", "arm", "ubuntu.14.04-arm")]
+
+        // Generic Linux
+        [InlineData("Linux", null, "x86", "linux-x86")]
+        [InlineData("Linux", null, "x64", "linux-x64")]
+        [InlineData("Linux", null, "arm", "linux-arm")]
+        [InlineData("Linux", "", "x86", "linux-x86")]
+        [InlineData("Linux", "", "x64", "linux-x64")]
+        [InlineData("Linux", "", "arm", "linux-arm")]
+
+        // Linux Distros
         [InlineData("Linux", "Ubuntu 14.04", "x86", "ubuntu.14.04-x86")]
         [InlineData("Linux", "Ubuntu 14.04", "x64", "ubuntu.14.04-x64")]
         [InlineData("Linux", "Ubuntu 14.04", "arm", "ubuntu.14.04-arm")]
-        [InlineData("Linux", "LinuxMint 17.2", "x86", "ubuntu.14.04-x86")]
-        [InlineData("Linux", "LinuxMint 17.2", "x64", "ubuntu.14.04-x64")]
-        [InlineData("Linux", "LinuxMint 17.2", "arm", "ubuntu.14.04-arm")]
+        [InlineData("Linux", "LinuxMint 17.2", "x86", "linuxmint.17.2-x86")]
+        [InlineData("Linux", "LinuxMint 17.2", "x64", "linuxmint.17.2-x64")]
+        [InlineData("Linux", "LinuxMint 17.2", "arm", "linuxmint.17.2-arm")]
+        [InlineData("Linux", "CentOS 7", "x86", "centos.7-x86")]
+        [InlineData("Linux", "CentOS 7", "x64", "centos.7-x64")]
+        [InlineData("Linux", "CentOS 7", "arm", "centos.7-arm")]
+
+        // Mac OS X
         [InlineData("Darwin", "", "x86", "osx-x86")]
         [InlineData("Darwin", "", "x64", "osx-x64")]
         [InlineData("Darwin", "", "arm", "osx-arm")]
-
-        // Our Darwin RIDs are in flux a bit, but this is just testing that whatever we decide on, we can render the right RID from the right input data :)
-        // See: https://github.com/aspnet/dnx/issues/2792
         [InlineData("Darwin", "10.10", "x86", "osx.10.10-x86")]
         [InlineData("Darwin", "10.10", "x64", "osx.10.10-x64")]
         [InlineData("Darwin", "10.10", "arm", "osx.10.10-arm")]
@@ -115,7 +136,7 @@ namespace dnx.hostTests
                 OperatingSystemVersion = version,
                 RuntimeArchitecture = architecture
             };
-            Assert.Equal(expectedRids.Split(','), runtimeEnv.GetAllRuntimeIdentifiers().ToArray());
+            Assert.Equal(expectedRids.Split(','), RuntimeEnvironmentExtensions.GetAllRuntimeIdentifiersWithoutOverride(runtimeEnv).ToArray());
         }
 
         // Test live runtime ids
@@ -147,14 +168,7 @@ namespace dnx.hostTests
             Assert.Equal(expectedArch, arch);
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR | RuntimeFrameworks.CoreCLR)] // We don't have an OS skip condition for all Windows yet
-        public void LinuxRuntimeIdIsCorrect()
-        {
-            var arch = RuntimeEnvironmentHelper.RuntimeEnvironment.RuntimeArchitecture.ToLowerInvariant();
-            Assert.Equal($"ubuntu.14.04-{arch}", RuntimeEnvironmentHelper.RuntimeEnvironment.GetRuntimeIdentifier());
-        }
+        // Linux RIDs are much more volatile and based on Distro.
 
         private class DummyRuntimeEnvironment : IRuntimeEnvironment
         {

--- a/test/Microsoft.Dnx.Testing.Framework/DnxSdk/Dnx.cs
+++ b/test/Microsoft.Dnx.Testing.Framework/DnxSdk/Dnx.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Extensions.PlatformAbstractions;
@@ -21,7 +23,7 @@ namespace Microsoft.Dnx.Testing.Framework
             return Execute($"-p \"{project.ProjectDirectory}\" {commandLine ?? "run"}", dnxTraceOn);
         }
 
-        public ExecResult Execute(string commandLine, bool dnxTraceOn = false)
+        public ExecResult Execute(string commandLine, bool dnxTraceOn = false, Action<Dictionary<string, string>> envSetup = null)
         {
             string command;
             if (RuntimeEnvironmentHelper.IsWindows)
@@ -36,7 +38,11 @@ namespace Microsoft.Dnx.Testing.Framework
             return Exec.Run(
                 command,
                 commandLine,
-                env => env[EnvironmentNames.Trace] = dnxTraceOn ? "1" : null);
+                env =>
+                {
+                    env[EnvironmentNames.Trace] = dnxTraceOn ? "1" : null;
+                    envSetup?.Invoke(env);
+                });
         }
     }
 }

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuRuntimeRestoreTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuRuntimeRestoreTests.cs
@@ -34,14 +34,10 @@ namespace Microsoft.Dnx.Tooling.FunctionalTests
         {
             // TODO(anurse): Maybe this could be a condition? This is the only place we need it right now so it
             // didn't seem worth the refactor.
-            if (RuntimeEnvironmentHelper.RuntimeEnvironment.OperatingSystem.Equals("Darwin"))
+            // Travis has old versions of OSes and our test package doesn't work there
+            if(Environment.GetEnvironmentVariable("TRAVIS").Equals("true"))
             {
-                var ver = Version.Parse(RuntimeEnvironmentHelper.RuntimeEnvironment.OperatingSystemVersion);
-                if (ver < new Version(10, 10))
-                {
-                    // Not supported on this!
-                    return;
-                }
+                return;
             }
 
             var runtimeHomeDir = TestUtils.GetRuntimeHomeDir(flavor, os, architecture);


### PR DESCRIPTION
Fixes #2881 

We need to sync up our RID fallback with `Microsoft.NETCore.Platforms` (cc @ericstj). This PR also adds an override environment variable `DNX_RUNTIME_ID` that can be used to override the RID we use if we don't support the distro you're running on but you want to try anyway :)