### PR TITLE
Resolve full path to key file.

### DIFF
--- a/src/Microsoft.Dnx.Compilation.CSharp/RoslynCompiler.cs
+++ b/src/Microsoft.Dnx.Compilation.CSharp/RoslynCompiler.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Dnx.Compilation.CSharp
             var sw = Stopwatch.StartNew();
 
             var compilationSettings = projectContext.CompilerOptions.ToCompilationSettings(
-                projectContext.Target.TargetFramework);
+                projectContext.Target.TargetFramework, projectContext.ProjectDirectory);
 
             var sourceFiles = Enumerable.Empty<string>();
             if (isMainAspect)

--- a/src/Microsoft.Dnx.DesignTimeHost/ProjectStateResolver.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/ProjectStateResolver.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Dnx.DesignTimeHost
                     FrameworkName = frameworkName,
                     // TODO: This shouldn't be Roslyn specific compilation options
                     CompilationSettings = project.GetCompilerOptions(frameworkName, configuration)
-                                                 .ToCompilationSettings(frameworkName),
+                                                 .ToCompilationSettings(frameworkName, project.ProjectDirectory),
                     SourceFiles = dependencySources,
                     DependencyInfo = dependencyInfo
                 };

--- a/test/Microsoft.Dnx.Compilation.CSharp.Common.Tests/CompilerOptionsExtensionsFacts.cs
+++ b/test/Microsoft.Dnx.Compilation.CSharp.Common.Tests/CompilerOptionsExtensionsFacts.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using Microsoft.Dnx.Runtime;
+using Xunit;
+
+namespace Microsoft.Dnx.Compilation.CSharp.Common.Tests
+{
+    public class CompilerOptionsExtensionsFacts
+    {
+        [Fact(Skip = "Can only enable after changes are checked in.")]
+        public void ResolvesFullPathToKeyFile()
+        {
+            var compilerOptions = new CompilerOptions { KeyFile = "../../tools/Key.snk" };
+            var projectDirectory = Path.GetFullPath("/solution/src/project/");
+            var compilationSettings = compilerOptions.ToCompilationSettings(
+                new System.Runtime.Versioning.FrameworkName("A Framework, Version=v1.0"),
+                projectDirectory);
+
+            Assert.Equal(Path.GetFullPath("/solution/tools/Key.snk"), compilationSettings.CompilationOptions.CryptoKeyFile);
+        }
+    }
+}

--- a/test/Microsoft.Dnx.Compilation.CSharp.Common.Tests/Microsoft.Dnx.Compilation.CSharp.Common.Tests.xproj
+++ b/test/Microsoft.Dnx.Compilation.CSharp.Common.Tests/Microsoft.Dnx.Compilation.CSharp.Common.Tests.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>7464544b-dda0-48a6-a83a-875957e47b21</ProjectGuid>
+    <RootNamespace>Microsoft.Dnx.Compilation.CSharp.Common.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.Dnx.Compilation.CSharp.Common.Tests/project.json
+++ b/test/Microsoft.Dnx.Compilation.CSharp.Common.Tests/project.json
@@ -1,0 +1,14 @@
+﻿{
+  "dependencies": {
+    "Microsoft.Dnx.Compilation.CSharp.Common": "1.0.0-*",
+    "Microsoft.Dnx.Runtime": "1.0.0-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet"
+  }
+}

--- a/test/Microsoft.Dnx.Compilation.CSharp.Tests/ProjectExtensionsFacts.cs
+++ b/test/Microsoft.Dnx.Compilation.CSharp.Tests/ProjectExtensionsFacts.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Dnx.Compilation.CSharp.Tests
         {
             var framework = FrameworkNameHelper.ParseFrameworkName(frameworkName);
             return project.GetCompilerOptions(framework, "Debug")
-                          .ToCompilationSettings(framework);
+                          .ToCompilationSettings(framework, project.ProjectDirectory);
         }
     }
 }

--- a/test/Microsoft.Dnx.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Dnx.Runtime.Tests/ProjectFacts.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Dnx.Runtime.Tests
         {
             var project = ProjectUtilities.GetProject(@"
 {
-    ""dependencies"": {  
+    ""dependencies"": {
         ""A"": """",
         ""B"": ""1.0-alpha-*"",
         ""C"": ""1.0.0"",
@@ -301,7 +301,7 @@ namespace Microsoft.Dnx.Runtime.Tests
 {
     ""frameworks"": {
         ""net45"": {
-            ""dependencies"": {  
+            ""dependencies"": {
                 ""A"": """",
                 ""B"": ""1.0-alpha-*"",
                 ""C"": ""1.0.0"",
@@ -341,7 +341,7 @@ namespace Microsoft.Dnx.Runtime.Tests
 {
     ""frameworks"": {
         ""net45"": {
-            ""frameworkAssemblies"": {  
+            ""frameworkAssemblies"": {
                 ""A"": """",
                 ""B"": ""1.0-alpha-*"",
                 ""C"": ""1.0.0"",
@@ -382,10 +382,10 @@ namespace Microsoft.Dnx.Runtime.Tests
         {
             var project = ProjectUtilities.GetProject(@"
 {
-    ""compilationOptions"": { ""allowUnsafe"": true, ""define"": [""X"", ""y""], ""platform"": ""x86"", ""warningsAsErrors"": true, ""optimize"": true, ""keyFile"" : ""c:\\keyfile.snk"", ""delaySign"" : true, ""useOssSigning"" : true }
+    ""compilationOptions"": { ""allowUnsafe"": true, ""define"": [""X"", ""y""], ""platform"": ""x86"", ""warningsAsErrors"": true, ""optimize"": true, ""keyFile"" : ""keyfile.snk"", ""delaySign"" : true, ""useOssSigning"" : true }
 }",
 "foo",
-@"c:\foo\project.json");
+@"foo/project.json");
 
             var compilerOptions = project.GetCompilerOptions();
             Assert.NotNull(compilerOptions);
@@ -394,7 +394,7 @@ namespace Microsoft.Dnx.Runtime.Tests
             Assert.True(compilerOptions.WarningsAsErrors.Value);
             Assert.Equal("x86", compilerOptions.Platform);
             Assert.True(compilerOptions.Optimize.Value);
-            Assert.Equal(compilerOptions.KeyFile, @"c:\keyfile.snk");
+            Assert.Equal("keyfile.snk", compilerOptions.KeyFile);
             Assert.True(compilerOptions.DelaySign);
             Assert.True(compilerOptions.UseOssSigning);
         }


### PR DESCRIPTION
This is required for signing to work on both desktop CLR and other environments. Having a path relative to a project breaks our builds on non-desktop CLR because we attempt to read from that path relative to the repository root.

/cc @moozzyk @davidfowl @muratg @victorhurdugaci 

This change is required for #2615.