### PR TITLE
Improve cross platform support for environment variables

### DIFF
--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Dnx.Runtime
                 return Enumerable.Empty<IPackagePathResolver>();
             }
 
-            return packageCachePathValue.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+            return packageCachePathValue.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries)
                                         .Select(path => new DefaultPackagePathResolver(path));
         }
 

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishManager.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishManager.cs
@@ -142,14 +142,15 @@ namespace Microsoft.Dnx.Tooling.Publish
                     runtimeProbePaths = new List<string>();
                     runtimeProbePaths.Add(runtime);
                     var runtimeHome = Environment.GetEnvironmentVariable(EnvironmentNames.Home);
+                    var pathSeparator = Path.PathSeparator;
                     if (string.IsNullOrEmpty(runtimeHome))
                     {
                         var runtimeGlobalPath = DnuEnvironment.GetFolderPath(DnuFolderPath.DnxGlobalPath);
                         var defaultRuntimeHome = DnuEnvironment.GetFolderPath(DnuFolderPath.DefaultDnxHome);
-                        runtimeHome = $"{defaultRuntimeHome};{runtimeGlobalPath}";
+                        runtimeHome = $"{defaultRuntimeHome}{pathSeparator}{runtimeGlobalPath}";
                     }
 
-                    foreach (var portion in runtimeHome.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                    foreach (var portion in runtimeHome.Split(new[] { pathSeparator }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         var packagesPath = Path.Combine(
                             Environment.ExpandEnvironmentVariables(portion),

--- a/src/Microsoft.Dnx.Tooling/Utils/PathUtilities.cs
+++ b/src/Microsoft.Dnx.Tooling/Utils/PathUtilities.cs
@@ -36,15 +36,16 @@ namespace Microsoft.Dnx.Tooling
         private static string FindRuntimeHome()
         {
             var runtimeHome = Environment.GetEnvironmentVariable(EnvironmentNames.Home);
+            var pathSeparator = Path.PathSeparator;
             if (string.IsNullOrEmpty(runtimeHome))
             {
                 var runtimeGlobalPath = DnuEnvironment.GetFolderPath(DnuFolderPath.DnxGlobalPath);
                 var userRuntimeFolder = DnuEnvironment.GetFolderPath(DnuFolderPath.DefaultDnxHome);
 
-                runtimeHome = $"{userRuntimeFolder};{runtimeGlobalPath}";
+                runtimeHome = $"{userRuntimeFolder}{pathSeparator}{runtimeGlobalPath}";
             }
 
-            foreach (var probePath in runtimeHome.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var probePath in runtimeHome.Split(new[] { pathSeparator }, StringSplitOptions.RemoveEmptyEntries))
             {
                 string fullPath = Environment.ExpandEnvironmentVariables(probePath);
 


### PR DESCRIPTION
DNX allows environment variables `DNX_HOME` and `DNX_PACKAGES_CACHE` to be set with multiple paths:
**Windows** `%USERPROFILE%\.dnx;C:\Program Files\Dnx`
**Linux/Mac** `~/.dnx:/usr/local/lib/dnx`

The path separator for both environments are different (`;` for windows and `:` for linux/mac) although the code splits the string always using a semi column. Because of this DNX looses the ability to supply multiple paths for these environment variables.
