### PR TITLE
Move Travis to supported Linux distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
-sudo: false
+sudo: required
+dist: trusty
 env:
   - MONO_THREADS_PER_CPU=2000
 os:
@@ -7,9 +8,15 @@ os:
   - osx
 addons:
   apt:
-    sources:
-    - debian-sid
     packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
     - libunwind8
+    - zlib1g
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; fi
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew install icu4c; fi
 script:
   - ./build.sh --quiet verify

--- a/makefile.shade
+++ b/makefile.shade
@@ -142,7 +142,7 @@ var CAN_BUILD_ONECORE = '${Directory.Exists(VS_ONECORE_ROOT) && Directory.GetFil
 #repo-initialize target='initialize'
     git gitCommand="submodule update --init"
     @{
-        DoRestore();
+        DoRestore("default -runtime coreclr");
     }
 
 - // k-standard-goal overrides
@@ -720,22 +720,14 @@ var CI_DARWIN_DROP_PATH = '${Environment.GetEnvironmentVariable("CI_DARWIN_DROP_
             }
         }
 
-        // We need to run restore with the new runtime (just one of them)
-        // On windows, grab a random windows target, otherwise use mono
-        string path = null;
-
-        if (CanBuildForWindows)
-        {
-            path = binPaths[RUNTIME_CLR_WIN_x86_NAME];
-        }
-        else
-        {
-            path = binPaths[RUNTIME_MONO_NAME];
-        }
+        // We need to run restore with the new runtime (just one of them).
+        // Avoid Mono since it can be unreliable; use first DNX Core target.
+        var coreTarget = RUNTIME_TARGETS.First(target => target.Flavor == "coreclr");
+        var path = binPaths[coreTarget.Name];
 
         ExecuteWithPath(path, () =>
         {
-            DoRestore();
+            DoRestore(dnvmUse: null);
         });
 
         // Group by operation system since we only want to run unit tests on a single bitness
@@ -824,8 +816,8 @@ var CI_DARWIN_DROP_PATH = '${Environment.GetEnvironmentVariable("CI_DARWIN_DROP_
     }
 
 - // ===================== SHARED UTILITIES =====================
-macro name='DoRestore'
-    dnu command='restore ${ E("KOREBUILD_DNU_RESTORE_OPTIONS") } ${ IsLinux ? string.Empty : "--parallel" } src test samples'
+macro name='DoRestore' dnvmUse='string'
+    dnu command='restore ${ E("KOREBUILD_DNU_RESTORE_OPTIONS") } --parallel src test samples'
 
 #update-tpa
     @{


### PR DESCRIPTION
- use Ubuntu 14.04 (Trusty) without experimental source
  - Travis support for Trusty is in Beta and currently requires `sudo`
- run `dnu restore` with DNX Core since aspnet/External#49 is not fixed in Beta 4.0.4 (Beta)
  - use `--parallel` everywhere since Mono threading bugs are not an issue
- add required dependencies for DNX Core to `.travis.yml`
- addresses part of aspnet/Universe#290 and avoids DNX regressions like #3077

This in part reverts commit 82ee48c04a76decfb9818859dfbb0893fbfb397b
- "Go back to running `dnu restore` with Mono"