### PR TITLE
Change message for Entrypoint type name error

### DIFF
--- a/src/Microsoft.Dnx.Runtime.Sources/Impl/EntryPointExecutor.cs
+++ b/src/Microsoft.Dnx.Runtime.Sources/Impl/EntryPointExecutor.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Dnx.Runtime.Common
                 if (programTypeInfo == null)
                 {
                                         
-                    System.Console.WriteLine("'{0}' does not contain a type 'Program' for an entry point", name);
+                    System.Console.WriteLine("'{0}' does not contain a 'Program' type suitable for an entry point", name);
                     return false;
                 }
 

--- a/src/Microsoft.Dnx.Runtime.Sources/Impl/EntryPointExecutor.cs
+++ b/src/Microsoft.Dnx.Runtime.Sources/Impl/EntryPointExecutor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Dnx.Runtime.Common
             {
                 return true;
             }
-
+            
             var programType = assembly.GetType("Program") ?? assembly.GetType(name + ".Program");
 
             if (programType == null)
@@ -90,7 +90,8 @@ namespace Microsoft.Dnx.Runtime.Common
 
                 if (programTypeInfo == null)
                 {
-                    System.Console.WriteLine("'{0}' does not contain a static 'Main' method suitable for an entry point", name);
+                                        
+                    System.Console.WriteLine("'{0}' does not contain a type 'Program' for an entry point", name);
                     return false;
                 }
 

--- a/src/Microsoft.Dnx.Runtime.Sources/Impl/EntryPointExecutor.cs
+++ b/src/Microsoft.Dnx.Runtime.Sources/Impl/EntryPointExecutor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Dnx.Runtime.Common
             {
                 return true;
             }
-            
+
             var programType = assembly.GetType("Program") ?? assembly.GetType(name + ".Program");
 
             if (programType == null)


### PR DESCRIPTION
Guys I change to message when the EnpointEtry has no type called Program, I spent 20 minutes to discover that error in my program was the name of Entrypoint class.
The message that DNX show me was about my Main method but the main method was right and the error was in the name of class. So, i change de error message to be more specific in that case.

What do you think?

