### PR TITLE
Explicitly choose Mono 4.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 dist: trusty
 env:
   - MONO_THREADS_PER_CPU=2000
+mono:
+  - 4.0.5
 os:
   - linux
   - osx


### PR DESCRIPTION
- avoids future problems related to aspnet/External#48
  - e.g. when Travis updates default Mono version in `csharp` bundle