### PR TITLE
DNU Publish can bundle the output into a NuGet package

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
@@ -13,6 +13,7 @@ using Microsoft.Dnx.Runtime;
 using Microsoft.Extensions.CompilationAbstractions;
 using Microsoft.Extensions.PlatformAbstractions;
 using Microsoft.Dnx.Runtime.Internals;
+using Microsoft.Dnx.Tooling.Building;
 using Microsoft.Dnx.Tooling.Utils;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
@@ -178,8 +179,8 @@ namespace Microsoft.Dnx.Tooling
                 // Create a new builder per configuration
                 packageBuilder = new PackageBuilder();
                 symbolPackageBuilder = new PackageBuilder();
-                InitializeBuilder(_currentProject, packageBuilder);
-                InitializeBuilder(_currentProject, symbolPackageBuilder);
+                packageBuilder.InitializeFromProject(_currentProject);
+                symbolPackageBuilder.InitializeFromProject(_currentProject);
                 installBuilder = new InstallBuilder(_currentProject, packageBuilder, _buildOptions.Reports);
             }
 
@@ -423,52 +424,6 @@ namespace Microsoft.Dnx.Tooling
                 contextVariables.TryGetValue(key, out value);
                 return value;
             };
-        }
-
-        private static void InitializeBuilder(Runtime.Project project, PackageBuilder builder)
-        {
-            builder.Authors.AddRange(project.Authors);
-            builder.Owners.AddRange(project.Owners);
-
-            if (builder.Authors.Count == 0)
-            {
-                // TODO: DNX_AUTHOR is a temporary name
-                var defaultAuthor = Environment.GetEnvironmentVariable("DNX_AUTHOR");
-                if (string.IsNullOrEmpty(defaultAuthor))
-                {
-                    builder.Authors.Add(project.Name);
-                }
-                else
-                {
-                    builder.Authors.Add(defaultAuthor);
-                }
-            }
-
-            builder.Description = project.Description ?? project.Name;
-            builder.Id = project.Name;
-            builder.Version = project.Version;
-            builder.Title = project.Title;
-            builder.Summary = project.Summary;
-            builder.Copyright = project.Copyright;
-            builder.RequireLicenseAcceptance = project.RequireLicenseAcceptance;
-            builder.ReleaseNotes = project.ReleaseNotes;
-            builder.Language = project.Language;
-            builder.Tags.AddRange(project.Tags);
-
-            if (!string.IsNullOrEmpty(project.IconUrl))
-            {
-                builder.IconUrl = new Uri(project.IconUrl);
-            }
-
-            if (!string.IsNullOrEmpty(project.ProjectUrl))
-            {
-                builder.ProjectUrl = new Uri(project.ProjectUrl);
-            }
-
-            if (!string.IsNullOrEmpty(project.LicenseUrl))
-            {
-                builder.LicenseUrl = new Uri(project.LicenseUrl);
-            }
         }
 
         private void WriteSummary(List<DiagnosticMessage> diagnostics)

--- a/src/Microsoft.Dnx.Tooling/Building/PackageBuilderExtensions.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/PackageBuilderExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet;
+
+namespace Microsoft.Dnx.Tooling.Building
+{
+    public static class PackageBuilderExtensions
+    {
+        public static void InitializeFromProject(this PackageBuilder builder, Runtime.Project project)
+        {
+            builder.Authors.AddRange(project.Authors);
+            builder.Owners.AddRange(project.Owners);
+
+            if (builder.Authors.Count == 0)
+            {
+                // TODO: DNX_AUTHOR is a temporary name
+                var defaultAuthor = Environment.GetEnvironmentVariable("DNX_AUTHOR");
+                if (string.IsNullOrEmpty(defaultAuthor))
+                {
+                    builder.Authors.Add(project.Name);
+                }
+                else
+                {
+                    builder.Authors.Add(defaultAuthor);
+                }
+            }
+
+            builder.Description = project.Description ?? project.Name;
+            builder.Id = project.Name;
+            builder.Version = project.Version;
+            builder.Title = project.Title;
+            builder.Summary = project.Summary;
+            builder.Copyright = project.Copyright;
+            builder.RequireLicenseAcceptance = project.RequireLicenseAcceptance;
+            builder.ReleaseNotes = project.ReleaseNotes;
+            builder.Language = project.Language;
+            builder.Tags.AddRange(project.Tags);
+
+            if (!string.IsNullOrEmpty(project.IconUrl))
+            {
+                builder.IconUrl = new Uri(project.IconUrl);
+            }
+
+            if (!string.IsNullOrEmpty(project.ProjectUrl))
+            {
+                builder.ProjectUrl = new Uri(project.ProjectUrl);
+            }
+
+            if (!string.IsNullOrEmpty(project.LicenseUrl))
+            {
+                builder.LicenseUrl = new Uri(project.LicenseUrl);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Dnx.Tooling/ConsoleCommands/PublishConsoleCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/ConsoleCommands/PublishConsoleCommand.cs
@@ -37,12 +37,12 @@ namespace Microsoft.Dnx.Tooling
                     CommandOptionType.NoValue);
                 var optionWwwRoot = c.Option("--wwwroot <NAME>", "Name of public folder in the project directory",
                     CommandOptionType.SingleValue);
+                var optionWwwRootOut = c.Option("--wwwroot-out <NAME>",
+                    "Name of public folder in the output, can be used only when the '--wwwroot' option or 'webroot' in project.json is specified",
+                    CommandOptionType.SingleValue);
                 var optionBundleFormat = c.Option("--bundle <FORMAT>", $"After publishing, output files can be bundled together into a single artifact, using the specified format. Supported formats: {string.Join(", ", BundlerFactory.SupportedFormats)}",
                     CommandOptionType.SingleValue);
                 var optionBundleOutput = c.Option("--bundle-out <PATH>", "Where does the bundle go",
-                    CommandOptionType.SingleValue);
-                var optionWwwRootOut = c.Option("--wwwroot-out <NAME>",
-                    "Name of public folder in the output, can be used only when the '--wwwroot' option or 'webroot' in project.json is specified",
                     CommandOptionType.SingleValue);
                 var optionQuiet = c.Option("--quiet", "Do not show output such as source/destination of published files",
                     CommandOptionType.NoValue);

--- a/src/Microsoft.Dnx.Tooling/NuGet/Authoring/PackageBuilder.cs
+++ b/src/Microsoft.Dnx.Tooling/NuGet/Authoring/PackageBuilder.cs
@@ -518,7 +518,8 @@ namespace NuGet
 
         private static void CreatePart(ZipArchive package, string path, Stream sourceStream)
         {
-            if (PackageHelper.IsManifest(path))
+            var isRoot = string.IsNullOrWhiteSpace(Path.GetDirectoryName(path));
+            if (isRoot && PackageHelper.IsManifest(path))
             {
                 return;
             }

--- a/src/Microsoft.Dnx.Tooling/Publish/Bundling/BundlerFactory.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/Bundling/BundlerFactory.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Dnx.Tooling.Publish.Bundling
+{
+    public static class BundlerFactory
+    {
+        static readonly IDictionary<string, Func<string, IPublishBundler>> Bundlers = new Dictionary<string, Func<string, IPublishBundler>>(StringComparer.OrdinalIgnoreCase);
+
+        static BundlerFactory()
+        {
+            Bundlers["nupkg"] = CreateNuGetPackage;
+        }
+
+        public static string[] SupportedFormats => Bundlers.Keys.ToArray();
+
+        public static bool IsSupportedFormat(string format)
+        {
+            return Bundlers.ContainsKey(format);
+        }
+
+        public static IPublishBundler CreateNuGetPackage(string outputDirectory)
+        {
+            return new NuGetPublishBundler(outputDirectory);
+        }
+
+        public static IPublishBundler Create(string format, string outputDirectory)
+        {
+            Func<string, IPublishBundler> bundler;
+            if (!Bundlers.TryGetValue(format, out bundler))
+            {
+                throw new ArgumentException($"Unknown bundler format: \"{format}\". Supported formats: {string.Join(", ", SupportedFormats)}");
+            }
+            return bundler(outputDirectory);
+        }
+    }
+}

--- a/src/Microsoft.Dnx.Tooling/Publish/Bundling/IPublishBundler.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/Bundling/IPublishBundler.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Dnx.Tooling.Publish.Bundling
+{
+    public interface IPublishBundler
+    {
+        bool Bundle(Runtime.Project project, PublishRoot publishRoot, Reports reports);
+    }
+}

--- a/src/Microsoft.Dnx.Tooling/Publish/Bundling/NuGetPublishBundler.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/Bundling/NuGetPublishBundler.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using Microsoft.Dnx.Tooling.Building;
+using NuGet;
+
+namespace Microsoft.Dnx.Tooling.Publish.Bundling
+{
+    public class NuGetPublishBundler : IPublishBundler
+    {
+        private readonly string _outputDirectory;
+
+        public NuGetPublishBundler(string outputDirectory)
+        {
+            _outputDirectory = outputDirectory;
+        }
+
+        public bool Bundle(Runtime.Project project, PublishRoot publishRoot, Reports reports)
+        {
+            var builder = new PackageBuilder();
+            builder.InitializeFromProject(project);
+
+            AddPublishedFiles(publishRoot, builder);
+
+            var outputFile = SavePackage(builder);
+            reports.Quiet.WriteLine("{0} -> {1}", publishRoot.OutputPath, outputFile);
+
+            return true;
+        }
+
+        private static void AddPublishedFiles(PublishRoot publishRoot, PackageBuilder builder)
+        {
+            foreach (var file in Directory.EnumerateFiles(publishRoot.OutputPath, "*", SearchOption.AllDirectories))
+            {
+                builder.Files.Add(new PhysicalPackageFile
+                {
+                    SourcePath = file,
+                    TargetPath = file.Replace(publishRoot.OutputPath, "").Trim('\\', '/')
+                });
+            }
+        }
+
+        private string SavePackage(PackageBuilder builder)
+        {
+            var outputFile = Path.GetFullPath(Path.Combine(_outputDirectory, $"{builder.Id}.{builder.Version}.nupkg"));
+            using (var fs = File.Create(outputFile))
+            {
+                builder.Save(fs);
+            }
+            return outputFile;
+        }
+    }
+}

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishManager.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishManager.cs
@@ -10,6 +10,7 @@ using System.Runtime.Versioning;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Extensions.PlatformAbstractions;
 using Microsoft.Dnx.Runtime.Helpers;
+using Microsoft.Dnx.Tooling.Publish.Bundling;
 using Microsoft.Dnx.Tooling.Utils;
 using Newtonsoft.Json.Linq;
 
@@ -326,6 +327,12 @@ namespace Microsoft.Dnx.Tooling.Publish
             if (_options.Native && !nativeImageGenerator.BuildNativeImages(root))
             {
                 _options.Reports.Error.WriteLine("Native image generation failed.");
+                return false;
+            }
+            
+            if (_options.Bundler != null && !_options.Bundler.Bundle(project, root, _options.Reports))
+            {
+                _options.Reports.Error.WriteLine("Bundle failed.");
                 return false;
             }
 

--- a/src/Microsoft.Dnx.Tooling/Publish/PublishOptions.cs
+++ b/src/Microsoft.Dnx.Tooling/Publish/PublishOptions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
 using Microsoft.Dnx.Runtime.Helpers;
+using Microsoft.Dnx.Tooling.Publish.Bundling;
 
 namespace Microsoft.Dnx.Tooling.Publish
 {
@@ -35,6 +36,8 @@ namespace Microsoft.Dnx.Tooling.Publish
         public Reports Reports { get; set; }
 
         public string IISCommand { get; set; }
+
+        public IPublishBundler Bundler { get; set; }
 
         public void AddFrameworkMonikers(IEnumerable<string> monikers)
         {

--- a/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
+++ b/test/Microsoft.Dnx.Tooling.FunctionalTests/DnuPublishTests.cs
@@ -215,6 +215,25 @@ namespace Microsoft.Dnx.Tooling.FunctionalTests
 
         [Theory, TraceTest]
         [MemberData(nameof(DnxSdks))]
+        public void PublishedAppCanBeBundled(DnxSdk sdk)
+        {
+            // Arrange
+            var solution = TestUtils.GetSolution<DnuPublishTests>(sdk, "HelloWorld");
+            var outputPath = Path.Combine(solution.RootPath, "Output");
+            var project = solution.GetProject("HelloWorld");
+
+            // Act
+            sdk.Dnu.Restore(project).EnsureSuccess();
+            sdk.Dnu.Publish(project.ProjectDirectory, outputPath, $"--no-source --bundle nupkg --bundle-out \"{outputPath}\"").EnsureSuccess();
+
+            // Assert
+            Assert.True(File.Exists(Path.Combine(outputPath, "HelloWorld.1.0.0.nupkg")));
+
+            TestUtils.CleanUpTestDir<DnuPublishTests>(sdk);
+        }
+
+        [Theory, TraceTest]
+        [MemberData(nameof(DnxSdks))]
         public void IISCommandInvalid(DnxSdk sdk)
         {
             // Arrange


### PR DESCRIPTION
This was discussed last year in some detail in #766 and there seemed to be a lot of positivity around it. There was also a subsequent chat on Jabbr where we agreed to give it a go, but wait until things settled down (KPM->DNU changes) before trying to implement it. 

When using `dnu publish`, you can now tell the command to bundle the outputs into a NuGet package. For example:

```
dnu publish .... --bundle nupkg --bundle-out ../artifacts
```

In #766 there was discussion of potentially other package formats (the ZIP format used by the web gallery for example), so the value passed to `--bundle` is the format to use (currently just nupkg). Here's the help output:

```
Usage: dnu publish [arguments] [options]

Arguments:
  [project]  Path to project, default is current directory

Options:
  -o|--out <PATH>                  Where does it go
  --configuration <CONFIGURATION>  The configuration to use for deployment (Debug|Release|{Custom})
  --no-source                      Compiles the source files into NuGet packages
  --framework                      Name of the frameworks to include.
  --iis-command                    Overrides the command name to use in the web.config for the httpPlatformHandler. The default is web.
  --runtime <RUNTIME>              Name or full path of the runtime folder to include, or "active" for current runtime on PATH
  --native                         Build and include native images. User must provide targeted CoreCLR runtime versions along with this option.
  --include-symbols                Include symbols in output bundle
  --wwwroot <NAME>                 Name of public folder in the project directory
  --wwwroot-out <NAME>             Name of public folder in the output, can be used only when the '--wwwroot' option or 'webroot' in project.json is specified
  --bundle <FORMAT>                After publishing, output files can be bundled together into a single artifact, using the specified format. Supported formats: nupkg
  --bundle-out <PATH>              Where does the bundle go
  --quiet                          Do not show output such as source/destination of published files
  -?|-h|--help                     Show help information
```

This support isn't just useful for Octopus and similar tools, but for Chocolatey and tools that are distributed via NuGet. 