### PR TITLE
remove the embedded version of NETCore.Platforms

### DIFF
--- a/src/Microsoft.Dnx.Tooling/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Dnx.Tooling/Restore/RestoreCommand.cs
@@ -12,10 +12,10 @@ using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Dnx.Runtime;
-using Microsoft.Extensions.PlatformAbstractions;
 using Microsoft.Dnx.Tooling.Publish;
 using Microsoft.Dnx.Tooling.Restore.RuntimeModel;
 using Microsoft.Dnx.Tooling.Utils;
+using Microsoft.Extensions.PlatformAbstractions;
 using NuGet;
 
 namespace Microsoft.Dnx.Tooling
@@ -273,9 +273,6 @@ namespace Microsoft.Dnx.Tooling
             localProviders.Add(
                 new LocalWalkProvider(
                     new NuGetDependencyResolver(packageRepository)));
-
-            // Add the embedded package provider at the very end of the local providers
-            localProviders.Add(new ImplicitPackagesWalkProvider());
 
             var tasks = new List<Task<TargetContext>>();
 
@@ -617,6 +614,14 @@ namespace Microsoft.Dnx.Tooling
                     }
                 }
             }
+
+            // Add the embedded runtime data if we didn't find any imports
+            if (imports == null)
+            {
+                // This will return null if there are no embedded imports for this runtime, which is fine.
+                imports = EmbeddedRuntimeData.GetEmbeddedImports(runtimeName);
+            }
+
             if (imports != null)
             {
                 foreach (var import in imports)


### PR DESCRIPTION
instead, we use the data as a fallback and don't do weird tricks around injecting package references

fixes #3193 

I confirmed that with this, the `PublishRuntimeDependency` project has a nearly identical lock file when published as no-source as when published with source. The only difference is attributable to the synthetic "root" project we create. I haven't verified on Mac yet, but am confident this will fix it. I'll try it on Mac, but if I can get sign-off we can optimistically begin the DNX build.

/cc @Eilon @muratg @davidfowl @BrennanConroy 