### PR TITLE
Microsoft.Extensions.CommandLineUtils Option switches with '/'

### DIFF
--- a/src/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
@@ -119,6 +119,15 @@ namespace Microsoft.Dnx.Runtime.Common.CommandLine
                     {
                         shortOption = arg.Substring(1).Split(new[] { ':', '=' }, 2);
                     }
+                    else if (arg.StartsWith("/"))
+                    {
+                        var longOrShortoption = arg.Substring(1).Split(new[] { ':', '=' }, 2);
+
+                        if (longOrShortoption.Length > 0 && longOrShortoption[0].Length == 1)
+                            shortOption = longOrShortoption;
+                        else
+                            longOption = longOrShortoption;
+                    }
                     if (longOption != null)
                     {
                         processed = true;

--- a/src/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandOption.cs
+++ b/src/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandOption.cs
@@ -35,6 +35,22 @@ namespace Microsoft.Dnx.Runtime.Common.CommandLine
                         ShortName = optName;
                     }
                 }
+                else if (part.StartsWith("/"))
+                {
+                    var optName = part.Substring(1);
+
+                    if (optName.Length > 1)
+                        LongName = optName;
+                    // If there is only one char and it is not an English letter, it is a symbol option (e.g. "-?")
+                    else if (optName.Length == 1 && !IsEnglishLetter(optName[0]))
+                    {
+                        SymbolName = optName;
+                    }
+                    else
+                    {
+                        ShortName = optName;
+                    }
+                }
                 else if (part.StartsWith("<") && part.EndsWith(">"))
                 {
                     ValueName = part.Substring(1, part.Length - 2);

--- a/test/Microsoft.Extensions.CommandLineUtils.Sources.Tests/CommandLineApplicationTests.cs
+++ b/test/Microsoft.Extensions.CommandLineUtils.Sources.Tests/CommandLineApplicationTests.cs
@@ -426,5 +426,26 @@ namespace Microsoft.Dnx.Runtime.Common.CommandLine
             Assert.IsType<InvalidOperationException>(ex);
             Assert.Equal("this should throw", ex.Message);
         }
+
+        [Fact]
+        public void OptionSwitchWithSlashMayBeProvided()
+        {
+            CommandOption first = null;
+            CommandOption second = null;
+
+            var app = new CommandLineApplication();
+
+            app.Command("test", c =>
+            {
+                first = c.Option("/first <NAME>", "First argument", CommandOptionType.SingleValue);
+                second = c.Option("/second <NAME>", "Second argument", CommandOptionType.SingleValue);
+                c.OnExecute(() => 0);
+            });
+
+            app.Execute("test", "/first", "one", "/second", "two");
+
+            Assert.Equal("one", first.Values[0]);
+            Assert.Equal("two", second.Values[0]);
+        }        
     }
 }

--- a/test/Microsoft.Extensions.CommandLineUtils.Sources.Tests/project.json
+++ b/test/Microsoft.Extensions.CommandLineUtils.Sources.Tests/project.json
@@ -1,7 +1,8 @@
 {
     "dependencies": {
         "Microsoft.Extensions.CommandLineUtils.Sources": "1.0.0-*",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+        "xunit": "2.1.0-*",
+		"xunit.runner.dnx": "2.1.0-*"
     },
 
     "frameworks": {
@@ -9,8 +10,8 @@
         "dnxcore50": { }
     },
 
-    "commands": {
-        "run": "xunit.runner.aspnet",
-        "test": "xunit.runner.aspnet"
-    }
+	"commands": {
+		"run": "xunit.runner.dnx",
+		"test": "xunit.runner.dnx"
+	}
 }


### PR DESCRIPTION
Tests and implementation for options switches that use forward-slash ('/')

Some applications (especially older Windows applications) use forward-slah instead of GNU-typical dashes ('-')

This implementation allows for slashes to be used as well as the original dashes