### PR TITLE
Small change to avert compiler errors when _UNICODE is set to 0

### DIFF
--- a/src/dnx.coreclr/stdafx.h
+++ b/src/dnx.coreclr/stdafx.h
@@ -7,8 +7,6 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <tchar.h>
-
 // Windows Headers
 // Exclude rarely-used stuff from Windows headers
 #define WIN32_LEAN_AND_MEAN

--- a/src/dnx.windows/dnx.cpp
+++ b/src/dnx.windows/dnx.cpp
@@ -9,13 +9,13 @@ HMODULE load_dnx_dll(const wchar_t* dnx_dll_name)
     if (!dnx_dll)
     {
         auto last_error = GetLastError();
-        _tprintf(L"%s could not be loaded. Last error: %d\n", dnx_dll_name, last_error);
+        wprintf(L"%s could not be loaded. Last error: %d\n", dnx_dll_name, last_error);
     }
 
     return dnx_dll;
 }
 
-int _tmain(int argc, _TCHAR* argv[])
+int wmain(int argc, wchar_t* argv[])
 {
     OSVERSIONINFO version_info;
     ZeroMemory(&version_info, sizeof(OSVERSIONINFO));
@@ -38,7 +38,7 @@ int _tmain(int argc, _TCHAR* argv[])
     {
         if (is_oneCore)
         {
-            _tprintf(L"Falling back to loading dnx.win32.dll\n");
+            wprintf(L"Falling back to loading dnx.win32.dll\n");
         }
 
         dnx_dll = load_dnx_dll(L"dnx.win32.dll");
@@ -52,7 +52,7 @@ int _tmain(int argc, _TCHAR* argv[])
     auto entry_point = (int (STDAPICALLTYPE*)(int, wchar_t **))GetProcAddress(dnx_dll, "DnxMain");
     if (!entry_point)
     {
-        _tprintf(L"Getting entry point failed\n");
+        wprintf(L"Getting entry point failed\n");
         return -1;
     }
 

--- a/src/dnx.windows/stdafx.h
+++ b/src/dnx.windows/stdafx.h
@@ -6,7 +6,6 @@
 #include "targetver.h"
 
 #include <stdio.h>
-#include <tchar.h>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/src/dnx/pal.win32.cpp
+++ b/src/dnx/pal.win32.cpp
@@ -16,8 +16,8 @@ std::wstring GetNativeBootstrapperDirectory()
 {
     wchar_t buffer[MAX_PATH];
     DWORD dirLength = GetModuleFileName(NULL, buffer, MAX_PATH);
-    for (dirLength--; dirLength >= 0 && buffer[dirLength] != _T('\\'); dirLength--);
-    buffer[dirLength + 1] = _T('\0');
+    for (dirLength--; dirLength >= 0 && buffer[dirLength] != L'\\'; dirLength--);
+    buffer[dirLength + 1] = L'\0';
     return std::wstring(buffer);
 }
 

--- a/src/dnx/stdafx.h
+++ b/src/dnx/stdafx.h
@@ -8,7 +8,6 @@
 #ifndef PLATFORM_UNIX
 #include "targetver.h"
 
-#include <tchar.h>
 #include <strsafe.h>
 
 #define WIN32_LEAN_AND_MEAN

--- a/test/dnx.tests/dnxtests.cpp
+++ b/test/dnx.tests/dnxtests.cpp
@@ -3,7 +3,7 @@
 
 #include "stdafx.h"
 
-int _tmain(int argc, _TCHAR* argv[])
+int wmain(int argc, wchar_t* argv[])
 {
     ::testing::InitGoogleTest(&argc, argv);
     RUN_ALL_TESTS();

--- a/test/dnx.tests/stdafx.h
+++ b/test/dnx.tests/stdafx.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <tchar.h>
 #include <strsafe.h>
 
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Was just browsing some code the other day when I came across this, so I thought I'd submit a pull request.

TCHAR is may cause compiler errors when mixed with `wchar_t`, since it can change to `char` if the `_UNICODE` macro is set to 0.

This PR replaces all uses of `TCHAR` with `wchar_t` and removes all includes of its header.