### PR TITLE
Keep dotnet restore working with latest dnx tooling

### DIFF
--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/PackageDependencyProvider.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Dnx.Runtime
                 profileDirectory = Environment.GetEnvironmentVariable("HOME");
             }
 
-            return Path.Combine(profileDirectory, Constants.DefaultLocalRuntimeHomeDir, "packages");
+            return Path.Combine(profileDirectory, ".nuget", "packages");
         }
 
 #if DNX451


### PR DESCRIPTION
Change the default package location to $Home/.nuget/packages

/cc @anurse 