### PR TITLE
Migrate to using System.Runtime.Loader.AssemblyLoadContext

### DIFF
--- a/DNX.sln
+++ b/DNX.sln
@@ -120,6 +120,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Dnx", "src\Micros
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Dnx.Host.Mono", "src\Microsoft.Dnx.Host.Mono\Microsoft.Dnx.Host.Mono.xproj", "{D043986D-83EA-4FA8-BBC4-9B3353EEBB82}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.PlatformAbstractions.Dnx", "src\Microsoft.Extensions.PlatformAbstractions.Dnx\Microsoft.Extensions.PlatformAbstractions.Dnx.xproj", "{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1150,6 +1152,30 @@ Global
 		{D043986D-83EA-4FA8-BBC4-9B3353EEBB82}.Release|x64.Build.0 = Release|Any CPU
 		{D043986D-83EA-4FA8-BBC4-9B3353EEBB82}.Release|x86.ActiveCfg = Release|Any CPU
 		{D043986D-83EA-4FA8-BBC4-9B3353EEBB82}.Release|x86.Build.0 = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|Win32.Build.0 = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|x64.Build.0 = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Debug|x86.Build.0 = Debug|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|ARM.Build.0 = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|Win32.ActiveCfg = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|Win32.Build.0 = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|x64.ActiveCfg = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|x64.Build.0 = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|x86.ActiveCfg = Release|Any CPU
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1205,5 +1231,6 @@ Global
 		{88FF8911-526C-4FBE-B4E2-707CDAF1DEC0} = {C43EE429-DE10-4906-BB09-54E6A080948A}
 		{EC03F0B1-CA30-418D-AE88-D6BFBA59D6CB} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 		{D043986D-83EA-4FA8-BBC4-9B3353EEBB82} = {13ED5001-B871-4BC3-8499-29607F596C7C}
+		{3E583C7E-D7A4-467C-9D4C-4E3C33BCDC9D} = {AF391791-F4B7-41AC-8F08-9485DAC543C5}
 	EndGlobalSection
 EndGlobal

--- a/makefile.shade
+++ b/makefile.shade
@@ -85,7 +85,7 @@ var MANAGED_PROJECTS = '${FindAllProjects(
     "Microsoft.Dnx.DesignTimeHost.Abstractions",
     "Microsoft.Dnx.Loader",
     "Microsoft.Dnx.Runtime",
-    "Microsoft.Extensions.PlatformAbstractions",
+    "Microsoft.Extensions.PlatformAbstractions.Dnx",
     "Microsoft.Dnx.Runtime.CommandParsing.Sources",
     "Microsoft.Dnx.Runtime.Internals",
     "Microsoft.Extensions.JsonParser.Sources",

--- a/src/Microsoft.Dnx.ApplicationHost/ApplicationHostPlatformServices.cs
+++ b/src/Microsoft.Dnx.ApplicationHost/ApplicationHostPlatformServices.cs
@@ -8,23 +8,33 @@ namespace Microsoft.Dnx.ApplicationHost
     {
         private readonly PlatformServices _previous;
 
-        public ApplicationHostPlatformServices(PlatformServices previous, 
-                                               ApplicationEnvironment applicationEnvironment, 
-                                               RuntimeLibraryManager runtimeLibraryManager)
+        public ApplicationHostPlatformServices(PlatformServices previous,
+                                               ApplicationEnvironment applicationEnvironment)
         {
             _previous = previous;
-            LibraryManager = runtimeLibraryManager;
             Application = applicationEnvironment;
         }
 
         public override IApplicationEnvironment Application { get; }
+
+        public override IRuntimeEnvironment Runtime => _previous.Runtime;
+    }
+
+    internal class ApplicationHostDnxPlatformServices : DnxPlatformServices
+    {
+        private readonly DnxPlatformServices _previous;
+
+        public ApplicationHostDnxPlatformServices(DnxPlatformServices previous,
+                                               RuntimeLibraryManager runtimeLibraryManager)
+        {
+            _previous = previous;
+            LibraryManager = runtimeLibraryManager;
+        }
 
         public override ILibraryManager LibraryManager { get; }
 
         public override IAssemblyLoadContextAccessor AssemblyLoadContextAccessor => _previous.AssemblyLoadContextAccessor;
 
         public override IAssemblyLoaderContainer AssemblyLoaderContainer => _previous.AssemblyLoaderContainer;
-
-        public override IRuntimeEnvironment Runtime => _previous.Runtime;
     }
 }

--- a/src/Microsoft.Dnx.ApplicationHost/DefaultHost.cs
+++ b/src/Microsoft.Dnx.ApplicationHost/DefaultHost.cs
@@ -151,10 +151,12 @@ Please make sure the runtime matches a framework specified in {Project.ProjectFi
             _serviceProvider.Add(typeof(IApplicationEnvironment), applicationEnvironment);
             _serviceProvider.Add(typeof(IRuntimeEnvironment), PlatformServices.Default.Runtime);
             _serviceProvider.Add(typeof(ILibraryManager), runtimeLibraryManager);
-            _serviceProvider.Add(typeof(IAssemblyLoadContextAccessor), PlatformServices.Default.AssemblyLoadContextAccessor);
-            _serviceProvider.Add(typeof(IAssemblyLoaderContainer), PlatformServices.Default.AssemblyLoaderContainer);
-            
-            PlatformServices.SetDefault(new ApplicationHostPlatformServices(PlatformServices.Default, applicationEnvironment, runtimeLibraryManager));
+            _serviceProvider.Add(typeof(IAssemblyLoadContextAccessor), DnxPlatformServices.Default.AssemblyLoadContextAccessor);
+            _serviceProvider.Add(typeof(IAssemblyLoaderContainer), DnxPlatformServices.Default.AssemblyLoaderContainer);
+
+            PlatformServices.SetDefault(new ApplicationHostPlatformServices(PlatformServices.Default, applicationEnvironment));
+
+            DnxPlatformServices.SetDefault(new ApplicationHostDnxPlatformServices(DnxPlatformServices.Default, runtimeLibraryManager));
 
             if (options.CompilationServerPort.HasValue)
             {

--- a/src/Microsoft.Dnx.ApplicationHost/Program.cs
+++ b/src/Microsoft.Dnx.ApplicationHost/Program.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Dnx.ApplicationHost
                     return exitCode;
                 }
 
-                host = new DefaultHost(options, PlatformServices.Default.AssemblyLoadContextAccessor);
+                host = new DefaultHost(options, DnxPlatformServices.Default.AssemblyLoadContextAccessor);
 
                 if (host.Project == null)
                 {
@@ -69,7 +69,7 @@ namespace Microsoft.Dnx.ApplicationHost
 
             try
             {
-                disposable = host.AddLoaders(PlatformServices.Default.AssemblyLoaderContainer);
+                disposable = host.AddLoaders(DnxPlatformServices.Default.AssemblyLoaderContainer);
 
                 return ExecuteMain(host, options.ApplicationName, programArgs)
                         .ContinueWith((t, state) =>

--- a/src/Microsoft.Dnx.ApplicationHost/project.json
+++ b/src/Microsoft.Dnx.ApplicationHost/project.json
@@ -10,6 +10,7 @@
         "Microsoft.Dnx.Runtime": "1.0.0-*",
         "Microsoft.Dnx.Compilation": "1.0.0-*",
         "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+        "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*",
         "Microsoft.Dnx.Runtime.CommandParsing.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },

--- a/src/Microsoft.Dnx.Compilation/project.json
+++ b/src/Microsoft.Dnx.Compilation/project.json
@@ -14,7 +14,8 @@
             "type": "build"
         },
       "Microsoft.Dnx.Runtime": "1.0.0-*",
-      "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*"
+      "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+      "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": {

--- a/src/Microsoft.Dnx.DesignTimeHost.Abstractions/project.json
+++ b/src/Microsoft.Dnx.DesignTimeHost.Abstractions/project.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+    "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*",
     "Newtonsoft.Json": "6.0.6"
   },
   "frameworks": {

--- a/src/Microsoft.Dnx.DesignTimeHost/Program.cs
+++ b/src/Microsoft.Dnx.DesignTimeHost/Program.cs
@@ -59,16 +59,16 @@ namespace Microsoft.Dnx.DesignTimeHost
             // REVIEW: Should these be on a shared context object that flows?
             var applicationEnvironment = PlatformServices.Default.Application;
             var runtimeEnvironment = PlatformServices.Default.Runtime;
-            var loadContextAccessor = PlatformServices.Default.AssemblyLoadContextAccessor;
+            var loadContextAccessor = DnxPlatformServices.Default.AssemblyLoadContextAccessor;
             var compilationEngine = new CompilationEngine(new CompilationEngineContext(applicationEnvironment, runtimeEnvironment, loadContextAccessor.Default, new CompilationCache()));
             var frameworkResolver = new FrameworkReferenceResolver();
 
             var services = new ServiceProvider();
             services.Add(typeof(IApplicationEnvironment), PlatformServices.Default.Application);
             services.Add(typeof(IRuntimeEnvironment), PlatformServices.Default.Runtime);
-            services.Add(typeof(IAssemblyLoadContextAccessor), PlatformServices.Default.AssemblyLoadContextAccessor);
-            services.Add(typeof(IAssemblyLoaderContainer), PlatformServices.Default.AssemblyLoaderContainer);
-            services.Add(typeof(ILibraryManager), PlatformServices.Default.LibraryManager);
+            services.Add(typeof(IAssemblyLoadContextAccessor), DnxPlatformServices.Default.AssemblyLoadContextAccessor);
+            services.Add(typeof(IAssemblyLoaderContainer), DnxPlatformServices.Default.AssemblyLoaderContainer);
+            services.Add(typeof(ILibraryManager), DnxPlatformServices.Default.LibraryManager);
 
             // This fixes the mono incompatibility but ties it to ipv4 connections
             var listenSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);

--- a/src/Microsoft.Dnx.DesignTimeHost/project.json
+++ b/src/Microsoft.Dnx.DesignTimeHost/project.json
@@ -6,6 +6,7 @@
         "Microsoft.Dnx.DesignTimeHost.Abstractions": "1.0.0-*",
         "Microsoft.Dnx.Runtime": "1.0.0-*",
         "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+        "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*",
         "Microsoft.Dnx.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Newtonsoft.Json": "6.0.6"

--- a/src/Microsoft.Dnx.Host/Bootstrapper.cs
+++ b/src/Microsoft.Dnx.Host/Bootstrapper.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Dnx.Host
                 serviceProvider.Add(typeof(IApplicationEnvironment), applicationEnvironment);
                 serviceProvider.Add(typeof(IRuntimeEnvironment), env);
 
-                PlatformServices.SetDefault(new DnxHostPlatformServices(applicationEnvironment, env, container, accessor));
+                PlatformServices.SetDefault(new DnxHostPlatformServices(applicationEnvironment, env));
+                DnxPlatformServices.SetDefault(new DnxHostDnxPlatformServices(container, accessor));
 
 #if DNX451
                 if (RuntimeEnvironmentHelper.IsMono)

--- a/src/Microsoft.Dnx.Host/DnxHostDnxPlatformServices.cs
+++ b/src/Microsoft.Dnx.Host/DnxHostDnxPlatformServices.cs
@@ -1,0 +1,21 @@
+using Microsoft.Dnx.Runtime.Loader;
+using Microsoft.Extensions.PlatformAbstractions;
+
+namespace Microsoft.Dnx.Host
+{
+    internal class DnxHostDnxPlatformServices : DnxPlatformServices
+    {
+        public DnxHostDnxPlatformServices(LoaderContainer container,
+            LoadContextAccessor accessor)
+        {
+            AssemblyLoaderContainer = container;
+            AssemblyLoadContextAccessor = accessor;
+        }
+
+        public override IAssemblyLoadContextAccessor AssemblyLoadContextAccessor { get; }
+
+        public override IAssemblyLoaderContainer AssemblyLoaderContainer { get; }
+
+        public override ILibraryManager LibraryManager { get; }
+    }
+}

--- a/src/Microsoft.Dnx.Host/DnxHostPlatformServices.cs
+++ b/src/Microsoft.Dnx.Host/DnxHostPlatformServices.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Dnx.Runtime.Loader;
 using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.Dnx.Host
@@ -7,23 +6,13 @@ namespace Microsoft.Dnx.Host
     internal class DnxHostPlatformServices : PlatformServices
     {
         public DnxHostPlatformServices(HostApplicationEnvironment applicationEnvironment, 
-                                       IRuntimeEnvironment runtimeEnvironment, 
-                                       LoaderContainer container, 
-                                       LoadContextAccessor accessor)
+                                       IRuntimeEnvironment runtimeEnvironment)
         {
             Application = applicationEnvironment;
             Runtime = runtimeEnvironment;
-            AssemblyLoaderContainer = container;
-            AssemblyLoadContextAccessor = accessor;
         }
 
         public override IApplicationEnvironment Application { get; }
-
-        public override IAssemblyLoadContextAccessor AssemblyLoadContextAccessor { get; }
-
-        public override IAssemblyLoaderContainer AssemblyLoaderContainer { get; }
-
-        public override ILibraryManager LibraryManager { get; }
 
         public override IRuntimeEnvironment Runtime { get; }
     }

--- a/src/Microsoft.Dnx.Host/project.json
+++ b/src/Microsoft.Dnx.Host/project.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-*",
+        "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*",
         "Microsoft.Extensions.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Runtime.Internals": { "version": "1.0.0-*", "type": "build" },
         "Microsoft.Dnx.Runtime.Sources": { "version": "1.0.0-*", "type": "build" },

--- a/src/Microsoft.Dnx.Loader/project.json
+++ b/src/Microsoft.Dnx.Loader/project.json
@@ -5,7 +5,8 @@
     },
     "description": "ASP.NET 5 runtime infrastructure for assembly load contexts.",
     "dependencies": {
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*"
+        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+        "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": {

--- a/src/Microsoft.Dnx.Runtime/project.json
+++ b/src/Microsoft.Dnx.Runtime/project.json
@@ -16,6 +16,7 @@
     "dependencies": {
         "Microsoft.Dnx.Loader": "1.0.0-*",
         "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+        "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*",
         "Microsoft.Extensions.JsonParser.Sources": {
             "version": "1.0.0-*",
             "type": "build"

--- a/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
+++ b/src/Microsoft.Dnx.Tooling/Building/BuildManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Dnx.Tooling
 
             _applicationEnvironment = PlatformServices.Default.Application;
             var runtimeEnvironment = PlatformServices.Default.Runtime;
-            var loadContextAccessor = PlatformServices.Default.AssemblyLoadContextAccessor;
+            var loadContextAccessor = DnxPlatformServices.Default.AssemblyLoadContextAccessor;
 
             _compilationEngine = new CompilationEngine(new CompilationEngineContext(
                 _applicationEnvironment,

--- a/src/Microsoft.Extensions.CompilationAbstractions/project.json
+++ b/src/Microsoft.Extensions.CompilationAbstractions/project.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+    "Microsoft.Extensions.PlatformAbstractions.Dnx": "1.0.0-*",
     "Microsoft.Extensions.HashCodeCombiner.Sources": {
       "type": "build",
       "version": "1.0.0-*"

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/AssemblyLoadContextExtensions.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/AssemblyLoadContextExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    public static class AssemblyLoadContextExtensions
+    {
+        public static Assembly Load(this IAssemblyLoadContext loadContext, string name)
+        {
+            return loadContext.Load(new AssemblyName(name));
+        }
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/DefaultPlatformServices.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/DefaultPlatformServices.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    internal class DefaultDnxPlatformServices : DnxPlatformServices
+    {
+        public override IAssemblyLoaderContainer AssemblyLoaderContainer { get; }
+
+        public override IAssemblyLoadContextAccessor AssemblyLoadContextAccessor { get; }
+
+        public override ILibraryManager LibraryManager { get; }
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoadContext.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoadContext.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    /// <summary>
+    /// A context in which assemblies can be loaded.
+    /// </summary>
+    public interface IAssemblyLoadContext : IDisposable
+    {
+        /// <summary>
+        /// Load an assembly by name.
+        /// </summary>
+        /// <param name="assemblyName">The name of the assembly.</param>
+        /// <returns>The loaded assembly.</returns>
+        Assembly Load(AssemblyName assemblyName);
+
+        /// <summary>
+        /// Loads the assembly located at the provided file system path.
+        /// </summary>
+        /// <param name="path">The fully qualified path of the file to load.</param>
+        /// <returns>The loaded assembly.</returns>
+        Assembly LoadFile(string path);
+
+        /// <summary>
+        /// Loads the assembly with a common object file format (COFF)-based image containing an emitted assembly, optionally including symbols for the assembly.
+        /// </summary>
+        /// <param name="assemblyStream">The stream representing the assembly.</param>
+        /// <param name="assemblySymbols">The stream representing the symbols.</param>
+        /// <returns>The loaded assembly.</returns>
+        Assembly LoadStream(Stream assemblyStream, Stream assemblySymbols);
+
+        /// <summary>
+        /// Loads an unmanaged library by name.
+        /// </summary>
+        /// <param name="path">The name of the unmanaged library to load.</param>
+        /// <returns>A handle to the unmanaged library or <c>IntPtr.Zero</c> if the library cannot be loaded.</returns>
+        IntPtr LoadUnmanagedLibrary(string name);
+
+        /// <summary>
+        /// Loads an unmanaged library from the provided path.
+        /// </summary>
+        /// <param name="path">The path to load the unmanaged library from.</param>
+        /// <returns>A handle to the unmanaged library or <c>IntPtr.Zero</c> if the library cannot be loaded.</returns>
+        IntPtr LoadUnmanagedLibraryFromPath(string path);
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoadContextAccessor.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoadContextAccessor.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    /// <summary>
+    /// Provides access to created <see cref="IAssemblyLoadContext"/>
+    /// </summary>
+    public interface IAssemblyLoadContextAccessor
+    {
+        /// <summary>
+        /// Gets the default <see cref="IAssemblyLoadContext"/>.
+        /// </summary>
+        IAssemblyLoadContext Default { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IAssemblyLoadContext"/> associated with the specified <see cref="Assembly"/>.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <returns></returns>
+        IAssemblyLoadContext GetLoadContext(Assembly assembly);
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoader.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoader.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    /// <summary>
+    /// Defines a contract for an assembly loader. This is an extension point that can be used to implement custom assembly loading logic.
+    /// </summary>
+    public interface IAssemblyLoader
+    {
+        /// <summary>
+        /// Load an assembly by name.
+        /// </summary>
+        /// <param name="assemblyName">The name of the assembly.</param>
+        /// <returns>The loaded assembly.</returns>
+        Assembly Load(AssemblyName assemblyName);
+
+        /// <summary>
+        /// Loads an unmanaged library by name.
+        /// </summary>
+        /// <param name="name">The name of the library to load.</param>
+        /// <returns>A handle to the unmanaged library or <c>IntPtr.Zero</c> if the library cannot be loaded.</returns>
+        IntPtr LoadUnmanagedLibrary(string name);
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoaderContainer.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/IAssemblyLoaderContainer.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+using System;
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    /// <summary>
+    /// Provides access to assembly loaders used for runtime assembly resolution.
+    /// </summary>
+    public interface IAssemblyLoaderContainer
+    {
+        /// <summary>
+        /// Adds an <see cref="IAssemblyLoader"/> to the runtime.
+        /// </summary>
+        /// <param name="loader">The loader to add.</param>
+        /// <returns>A disposable object representing the registration of the loader. Disposing it removes the loader from the runtime.</returns>
+        IDisposable AddLoader(IAssemblyLoader loader);
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/ILibraryManager.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/ILibraryManager.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    /// <summary>
+    /// Provides access to the complete graph of dependencies for the application.
+    /// </summary>
+    public interface ILibraryManager
+    {
+        IEnumerable<Library> GetReferencingLibraries(string name);
+
+        Library GetLibrary(string name);
+
+        IEnumerable<Library> GetLibraries();
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/Library.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/Library.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    /// <summary>
+    /// Exposes information about a library which can be an assembly, project, or a package.
+    /// </summary>
+    public class Library
+    {
+        public Library(string name)
+            : this(name, string.Empty, string.Empty, string.Empty, Enumerable.Empty<string>(), Enumerable.Empty<AssemblyName>())
+        {
+        }
+
+        public Library(string name, IEnumerable<string> dependencies)
+            : this(name, string.Empty, string.Empty, string.Empty, dependencies, Enumerable.Empty<AssemblyName>())
+        {
+        }
+
+        public Library(string name, string version, string path, string type, IEnumerable<string> dependencies, IEnumerable<AssemblyName> assemblies)
+        {
+            Name = name;
+            Version = version;
+            Path = path;
+            Type = type;
+            Dependencies = dependencies;
+            Assemblies = assemblies;
+        }
+
+        /// <summary>
+        /// Gets the name of the library.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        ///  Gets the version of the library.
+        /// </summary>
+        public string Version { get; }
+
+        /// <summary>
+        /// Gets the path to the library. For projects, this is a path to the project.json file.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Gets the type of library. Common values include Project, Package, and Assembly.
+        /// </summary>
+        public string Type { get; }
+
+        /// <summary>
+        /// Gets a list of dependencies for the library. The dependencies are names of other <see cref="Library"/> objects.
+        /// </summary>
+        public IEnumerable<string> Dependencies { get; }
+
+        /// <summary>
+        /// Gets a list of assembly names from the library that can be loaded. Packages can contain multiple assemblies.
+        /// </summary>
+        public IEnumerable<AssemblyName> Assemblies { get; }
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/Microsoft.Extensions.PlatformAbstractions.Dnx.xproj
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/Microsoft.Extensions.PlatformAbstractions.Dnx.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>3e583c7e-d7a4-467c-9d4c-4e3c33bcdc9d</ProjectGuid>
+    <RootNamespace>Microsoft.Extensions.PlatformAbstractions.Dnx</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/PlatformServices.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/PlatformServices.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.PlatformAbstractions
+{
+    public abstract class DnxPlatformServices
+    {
+        private static DnxPlatformServices _defaultPlatformServices = new DefaultDnxPlatformServices();
+
+        public static DnxPlatformServices Default
+        {
+            get
+            {
+                return _defaultPlatformServices;
+            }
+        }
+
+        public abstract IAssemblyLoaderContainer AssemblyLoaderContainer { get; }
+
+        public abstract IAssemblyLoadContextAccessor AssemblyLoadContextAccessor { get; }
+
+        public abstract ILibraryManager LibraryManager { get; }
+
+        public static void SetDefault(DnxPlatformServices defaultPlatformServices)
+        {
+            _defaultPlatformServices = defaultPlatformServices;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Resources;
+
+[assembly: AssemblyMetadata("Serviceable", "True")]
+[assembly: NeutralResourcesLanguage("en-US")]

--- a/src/Microsoft.Extensions.PlatformAbstractions.Dnx/project.json
+++ b/src/Microsoft.Extensions.PlatformAbstractions.Dnx/project.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.0.0-*",
+    "description": "Abstractions that unify behavior and API across .NET Framework, .NET Core and Mono",
+    "compilationOptions": {
+        "warningsAsErrors": true,
+        "allowUnsafe": true,
+        "keyFile": "../../tools/Key.snk"
+    },
+    "dependencies": { },
+    "frameworks": {
+        "net451": {
+        },
+        "dotnet5.4": {
+            "dependencies": {
+                "System.AppContext": "4.0.1-*",
+                "System.IO.FileSystem": "4.0.1-*",
+                "System.Linq": "4.0.1-*",
+                "System.Reflection": "4.1.0-*",
+                "System.Reflection.Extensions": "4.0.1-*",
+                "System.Reflection.TypeExtensions": "4.1.0-*",
+                "System.Runtime": "4.0.21-*",
+                "System.Runtime.InteropServices": "4.0.21-*",
+                "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-*",
+                "System.Threading.Tasks": "4.0.11-*"
+            }
+        }
+    }
+}


### PR DESCRIPTION
aspnet/dnx#3227
Move IAssembly* and ILibraryManager classes back to dnx :laughing: 
Uses https://github.com/aspnet/PlatformAbstractions/pull/19
@davidfowl @anurse 