### PR TITLE
update to respect nuget lock file format

### DIFF
--- a/src/Microsoft.Dnx.Runtime/DependencyManagement/LibraryRange.cs
+++ b/src/Microsoft.Dnx.Runtime/DependencyManagement/LibraryRange.cs
@@ -49,6 +49,16 @@ namespace Microsoft.Dnx.Runtime
             return Name + " " + (VersionRange?.ToString());
         }
 
+        public string ToNuGetString()
+        {
+            var name = Name;
+            if(IsGacOrFrameworkReference && Name.StartsWith("fx/"))
+            {
+                name = Name.Substring(3);
+            }
+            return name + " " + (VersionRange?.ToString());
+        }
+
         public bool Equals(LibraryRange other)
         {
             if (ReferenceEquals(null, other)) return false;


### PR DESCRIPTION
Mega hack to ensure `dnx [blah]` doesn't throw errors because the lock file is out of date when you use `dotnet restore` (NuGet3 edition) to generate the lock file.

NuGet a) does not apply the `fx/` prefix to framework references and b) sorts using OrdinalIgnoreCase. It's not as simple as just switching though since we want `dnu restore` to continue working. With this change, both will work fine (I haven't actually tested it yet ;P, but am building to do so now and wanted to start the review while @davidfowl was awake).

/cc @davidfowl 