### PR TITLE
Added CodeBase=. to AppDomainManagerAssemblyName

### DIFF
--- a/src/dnx.clr/HostAssemblyStore.cpp
+++ b/src/dnx.clr/HostAssemblyStore.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include "utils.h"
 
-const wchar_t* AppDomainManagerAssemblyName = L"Microsoft.Dnx.Host.Clr, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, ProcessorArchitecture=MSIL";
+const wchar_t* AppDomainManagerAssemblyName = L"Microsoft.Dnx.Host.Clr, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, ProcessorArchitecture=MSIL, CodeBase=.";
 
 // IHostAssemblyStore
 HRESULT STDMETHODCALLTYPE HostAssemblyStore::ProvideAssembly(AssemblyBindInfo *pBindInfo, UINT64* pAssemblyId, UINT64* pContext,


### PR DESCRIPTION
Adding CodeBase=. to the AppDomainManagerAssemblyName ensures that the Microsoft.Dnx.Host.Clr.dll assembly is loaded with a CodeBase and EscapedCodeBase property set to the correct runtime directory.
- Fixes a bug when attempting to create an ADODB Connection (and probably some other COM objects), where internal System.dll calls throw the following exception:

The exception and stack trace when instantiating the Connection is:

System.URI.FormatException: {"Invalid URI: The URI is empty."}
Call Stack:
System.dll!System.Uri.CreateThis(string uri, bool dontEscape, System.UriKind uriKind) Unknown
System.dll!System.Uri.Uri(string uriString) Unknown
System.dll!System.ComponentModel.Design.RuntimeLicenseContext.GetLocalPath(string fileName) Unknown
System.dll!System.ComponentModel.Design.RuntimeLicenseContext.GetSavedLicenseKey(System.Type type, System.Reflection.Assembly resourceAssembly) Unknown
System.dll!System.ComponentModel.LicenseManager.LicenseInteropHelper.GetCurrentContextInfo(ref int fDesignTime, ref System.IntPtr bstrKey, System.RuntimeTypeHandle rth) Unknown

Addresses #3337 